### PR TITLE
Document setting for annotation processor sources dir

### DIFF
--- a/Documentation/Developer.md
+++ b/Documentation/Developer.md
@@ -31,6 +31,7 @@ The following instructions work for IntelliJ IDEA version 2017.2.6.
     * Go to File -> Settings -> Build, Execution, Deployment -> Compiler -> Annotation Processors
     * Check 'Enable annotation processing'
     * Store generated sources relative to: 'Module content root' (not the default)
+    * Production sources directory: 'build/classes/java/'
 
 ## Environment-specific settings
 Environment-specific settings (values for PortabilityFlags) are stored


### PR DESCRIPTION
This is apparently not the default all the time - my latest install of
IntelliJ on my new remote machine needed this to be specified.