### PR TITLE
Implementation of GoogleCloudExtensions

### DIFF
--- a/extensions/cloud/portability-cloud-google/build.gradle
+++ b/extensions/cloud/portability-cloud-google/build.gradle
@@ -27,4 +27,9 @@ dependencies {
     testCompile("junit:junit:${junitVersion}")
     testCompile("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
     testCompile("org.mockito:mockito-all:${mockitoVersion}")
+
+    // Logging
+    compile("org.slf4j:slf4j-api:${slf4jVersion}")
+    compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
+
 }

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Data-Portability Project Authors.
+ * Copyright 2018 The Data Transfer Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
@@ -1,13 +1,11 @@
 package org.dataportabilityproject.cloud.google;
 
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.DatastoreOptions;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import org.dataportabilityproject.api.launcher.ExtensionContext;
 import org.dataportabilityproject.spi.cloud.extension.CloudExtension;
 import org.dataportabilityproject.spi.cloud.storage.BucketStore;
@@ -15,9 +13,6 @@ import org.dataportabilityproject.spi.cloud.storage.CryptoKeyStore;
 import org.dataportabilityproject.spi.cloud.storage.JobStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 
 public class GoogleCloudExtension implements CloudExtension {
   private static final Logger logger = LoggerFactory.getLogger(GoogleCloudExtension.class);
@@ -50,28 +45,29 @@ public class GoogleCloudExtension implements CloudExtension {
     return cryptoKeyManagementSystem;
   }
 
+  /*
+   * Initializes the GoogleCloudExtension based on the ExtensionContext.
+   *
+   * The ExtensionContext should provide the following:
+   * <li> Google Project Id
+   * <li> GoogleCredentials
+   * <li> DataStore
+   * <li> HttpTransport
+   * <li> JsonFactory
+   */
   @Override
   public void initialize(ExtensionContext context) {
+    Preconditions.checkArgument(
+        !initialized, "Attempting to initialize GoogleCloudExtension more than once");
+    validateContext(context);
+
     try {
-      projectId = context.getConfiguration("GOOGLE_PROJECT_ID", "");
-      Preconditions.checkArgument(!projectId.isEmpty(), "Google project id not found");
-      googleCredentials = GoogleCredentials.getApplicationDefault();
-      datastore =
-          DatastoreOptions.newBuilder()
-              .setProjectId(projectId)
-              .setCredentials(googleCredentials)
-              .build()
-              .getService();
       jobstore = new GoogleJobStore(datastore);
       bucketStore = new GoogleBucketStore(googleCredentials, projectId);
-
-      // TODO: Hook these up with the global instances
-      transport =  GoogleNetHttpTransport.newTrustedTransport();
-      jsonFactory = new JacksonFactory();
       cryptoKeyManagementSystem = new GoogleCryptoKeyStore(transport, jsonFactory, projectId);
 
       initialized = true;
-    } catch (IOException | GoogleCredentialException | GeneralSecurityException e) {
+    } catch (GoogleCredentialException e) {
       // TODO: the method doesn't throw an exception, how do we pass this onto the user?
       logger.warn("Error initializing extension: " + this.getClass().getName(), e);
       initialized = false;
@@ -81,5 +77,25 @@ public class GoogleCloudExtension implements CloudExtension {
   @Override
   public void shutdown() {
     this.initialized = false;
+  }
+
+  /* validates the provided context and initializes services needed. */
+  private void validateContext(ExtensionContext context) {
+    projectId = context.getConfiguration("GOOGLE_PROJECT_ID", "");
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(projectId), "Google Project Id not found in ExtensionContext");
+
+    googleCredentials = context.getService(GoogleCredentials.class);
+    Preconditions.checkArgument(
+        googleCredentials != null, "GoogleCredentials not found in ExtensionContext");
+
+    datastore = context.getService(Datastore.class);
+    Preconditions.checkArgument(datastore != null, "DataStore not found in ExtensionContext");
+
+    transport = context.getService(HttpTransport.class);
+    Preconditions.checkArgument(transport != null, "HttpTransport not found in ExtensionContext");
+
+    jsonFactory = context.getService(JsonFactory.class);
+    Preconditions.checkArgument(jsonFactory != null, "JsonFactory not found in ExtensionContext");
   }
 }

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
@@ -53,7 +53,8 @@ public class GoogleCloudExtension implements CloudExtension {
   @Override
   public void initialize(ExtensionContext context) {
     try {
-      projectId = context.getConfiguration("", "");
+      projectId = context.getConfiguration("GOOGLE_PROJECT_ID", "");
+      Preconditions.checkArgument(!projectId.isEmpty(), "Google project id not found");
       googleCredentials = GoogleCredentials.getApplicationDefault();
       datastore =
           DatastoreOptions.newBuilder()

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
@@ -73,7 +73,7 @@ public class GoogleCloudExtension implements CloudExtension {
       initialized = true;
     } catch (IOException | GoogleCredentialException | GeneralSecurityException e) {
       // TODO: the method doesn't throw an exception, how do we pass this onto the user?
-      logger.debug("Error initializing extension: " + this.getClass().getName(), e);
+      logger.warn("Error initializing extension: " + this.getClass().getName(), e);
       initialized = false;
     }
   }

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
@@ -1,0 +1,89 @@
+package org.dataportabilityproject.cloud.google;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import org.dataportabilityproject.api.launcher.ExtensionContext;
+import org.dataportabilityproject.spi.cloud.extension.CloudExtension;
+import org.dataportabilityproject.spi.cloud.storage.BucketStore;
+import org.dataportabilityproject.spi.cloud.storage.CryptoKeyStore;
+import org.dataportabilityproject.spi.cloud.storage.JobStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GoogleCloudExtension implements CloudExtension {
+  // TODO: Should these be initialized from the ExtensionContext and not injected?
+  // If injected, this requires that we install the GoogleCloudModule before using which might not
+  // make sense depending on where it would happen
+  private final GoogleCredentials googleCredentials;
+  private final String projectId;
+  private final HttpTransport transport;
+  private final JsonFactory jsonFactory;
+  private static final Logger logger = LoggerFactory.getLogger(GoogleCloudExtension.class);
+
+  private boolean initialized = false;
+  private Datastore datastore;
+  private JobStore jobstore;
+  private BucketStore bucketStore;
+  private GoogleCryptoKeyStore cryptoKeyManagementSystem;
+
+  @Inject
+  GoogleCloudExtension(
+      @GoogleCloudModule.ProjectId String projectId,
+      GoogleCredentials googleCredentials,
+      HttpTransport transport,
+      JsonFactory jsonFactory) {
+    this.projectId = projectId;
+    this.googleCredentials = googleCredentials;
+    this.transport = transport;
+    this.jsonFactory = jsonFactory;
+  }
+
+  @Override
+  public JobStore getJobStore() {
+    Preconditions.checkArgument(initialized, "Attempting to getJobStore() before initializing");
+    return jobstore;
+  }
+
+  @Override
+  public BucketStore getBucketStore() {
+    Preconditions.checkArgument(initialized, "Attempting to getBucketStore() before initializing");
+    return bucketStore;
+  }
+
+  @Override
+  public CryptoKeyStore getCryptoKeyStore() {
+    Preconditions.checkArgument(initialized, "Attempting to getCryptoKeyStore() before initializing");
+    return cryptoKeyManagementSystem;
+  }
+
+  @Override
+  public void initialize(ExtensionContext context) {
+    this.datastore =
+        DatastoreOptions.newBuilder()
+            .setProjectId(projectId)
+            .setCredentials(googleCredentials)
+            .build()
+            .getService();
+    this.jobstore = new GoogleJobStore(datastore);
+    this.bucketStore = new GoogleBucketStore(googleCredentials,projectId);
+
+    try {
+      this.cryptoKeyManagementSystem = new GoogleCryptoKeyStore(transport, jsonFactory, projectId);
+    } catch (GoogleCredentialException e) {
+      //TODO: the method doesn't throw an exception, how do we pass this onto the user?
+      logger.debug("Error creating GoogleCryptoKeyStore: ", e);
+    }
+    this.initialized = true;
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void shutdown() {}
+}

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCloudExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 The Data-Portability Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dataportabilityproject.cloud.google;
 
 import com.google.api.client.http.HttpTransport;

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCryptoKeyStore.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/dataportabilityproject/cloud/google/GoogleCryptoKeyStore.java
@@ -29,7 +29,7 @@ import org.dataportabilityproject.cloud.google.GoogleCloudModule.ProjectId;
 import org.dataportabilityproject.spi.cloud.storage.CryptoKeyStore;
 
 /** Crypto key management using Google's Cloud KMS. */
-final class GoogleCryptoKeyManagementSystem implements CryptoKeyStore {
+final class GoogleCryptoKeyStore implements CryptoKeyStore {
   // Key for encrypting app secrets.
   private static final String SECRETS_CRYPTO_KEY_FMT_STRING =
       "projects/%s/locations/global/"
@@ -39,7 +39,7 @@ final class GoogleCryptoKeyManagementSystem implements CryptoKeyStore {
   private final String secretsCryptoKey;
 
   @Inject
-  GoogleCryptoKeyManagementSystem(
+  GoogleCryptoKeyStore(
       HttpTransport transport, JsonFactory jsonFactory, @ProjectId String projectId)
       throws GoogleCredentialException {
     GoogleCredential credential;
@@ -54,7 +54,7 @@ final class GoogleCryptoKeyManagementSystem implements CryptoKeyStore {
     }
     this.cloudKMS =
         new CloudKMS.Builder(transport, jsonFactory, credential)
-            .setApplicationName("GoogleCryptoKeyManagementSystem")
+            .setApplicationName("GoogleCryptoKeyStore")
             .build();
     this.secretsCryptoKey = String.format(SECRETS_CRYPTO_KEY_FMT_STRING, projectId);
   }

--- a/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/extension/CloudExtension.java
+++ b/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/extension/CloudExtension.java
@@ -16,10 +16,16 @@
 package org.dataportabilityproject.spi.cloud.extension;
 
 import org.dataportabilityproject.api.launcher.AbstractExtension;
+import org.dataportabilityproject.spi.cloud.storage.BucketStore;
+import org.dataportabilityproject.spi.cloud.storage.CryptoKeyStore;
 import org.dataportabilityproject.spi.cloud.storage.JobStore;
 
 /** Cloud extensions implement this interface to be loaded in either a gateway or worker process. */
 public interface CloudExtension extends AbstractExtension {
   /** Returns the {@link JobStore} provided by the extension. */
   JobStore getJobStore();
+
+  BucketStore getBucketStore();
+
+  CryptoKeyStore getCryptoKeyStore();
 }


### PR DESCRIPTION
I added getCryptoKeyStore and getBucketStore to the CloudExtension since I suspect they might be needed (the CloudFactory had these). 

I'm not sure of where the initialization of the constructor params should go. My initial thought was to pull them in from the ExtensionContext, but its not clear to me what that looks like for things like creds or the json factories. 

#192 