### PR TITLE
 re-enable xsrf protection

### DIFF
--- a/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/JWTTokenManager.java
+++ b/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/JWTTokenManager.java
@@ -67,60 +67,56 @@ public class JWTTokenManager implements TokenManager {
 
   @Override
   public boolean verifyToken(String token) {
-    return true;
-
     /*
-     TODO(#258): XSRF prevention temporarily disabled to get local demo working. Issue is:
-     ERROR org.dataportabilityproject.gateway.reference.SetupHandler - Error handling request
-     java.lang.IllegalArgumentException: Empty key
-      at javax.crypto.spec.SecretKeySpec.<init>(SecretKeySpec.java:96)
-      at com.auth0.jwt.algorithms.CryptoHelper.createSignatureFor(CryptoHelper.java:15)
-      at com.auth0.jwt.algorithms.HMACAlgorithm.sign(HMACAlgorithm.java:63)
-      at com.auth0.jwt.JWTCreator.sign(JWTCreator.java:334)
-      at com.auth0.jwt.JWTCreator.access$100(JWTCreator.java:24)
-      at com.auth0.jwt.JWTCreator$Builder.sign(JWTCreator.java:311)
-      at org.dataportabilityproject.gateway.reference.JWTTokenManager.createNewToken(JWTTokenManager.java:103)
-      */
-    // try {
-    //   DecodedJWT jwt = verifier.verify(token);
-    //   return true;
-    // } catch (JWTVerificationException exception) {
-    //   logger.debug("Error verifying token: {}", exception);
-    //   logger.debug("Token: {}", token);
-    //   return false;
-    // }
+    TODO(#258): XSRF prevention temporarily disabled to get local demo working. Issue is:
+    ERROR org.dataportabilityproject.gateway.reference.SetupHandler - Error handling request
+    java.lang.IllegalArgumentException: Empty key
+     at javax.crypto.spec.SecretKeySpec.<init>(SecretKeySpec.java:96)
+     at com.auth0.jwt.algorithms.CryptoHelper.createSignatureFor(CryptoHelper.java:15)
+     at com.auth0.jwt.algorithms.HMACAlgorithm.sign(HMACAlgorithm.java:63)
+     at com.auth0.jwt.JWTCreator.sign(JWTCreator.java:334)
+     at com.auth0.jwt.JWTCreator.access$100(JWTCreator.java:24)
+     at com.auth0.jwt.JWTCreator$Builder.sign(JWTCreator.java:311)
+     at org.dataportabilityproject.gateway.reference.JWTTokenManager.createNewToken(JWTTokenManager.java:103)
+     */
+    try {
+      DecodedJWT jwt = verifier.verify(token);
+      return true;
+    } catch (JWTVerificationException exception) {
+      logger.debug("Error verifying token: {}", exception);
+      logger.debug("Token: {}", token);
+      return false;
+    }
   }
 
   @Override
   public UUID getJobIdFromToken(String token) {
-    return UUID.fromString(token);
     // TODO(#258): XSRF prevention temporarily disabled to get local demo working.
-    // try {
-    //   DecodedJWT jwt = verifier.verify(token);
-    //   // Token is verified, get claim
-    //   Claim claim = jwt.getClaim(JWTTokenManager.ID_CLAIM_KEY);
-    //   if (claim.isNull()) {
-    //     return null;
-    //   }
-    //   return claim.isNull() ? null : UUID.fromString(claim.asString());
-    // } catch (JWTVerificationException exception) {
-    //
-    //   throw new RuntimeException("Error verifying token: " + token);
-    // }
+    try {
+      DecodedJWT jwt = verifier.verify(token);
+      // Token is verified, get claim
+      Claim claim = jwt.getClaim(JWTTokenManager.ID_CLAIM_KEY);
+      if (claim.isNull()) {
+        return null;
+      }
+      return claim.isNull() ? null : UUID.fromString(claim.asString());
+    } catch (JWTVerificationException exception) {
+      logger.debug("Error verifying token: {}", exception);
+      throw new RuntimeException("Error verifying token: " + token);
+    }
   }
 
   @Override
   public String createNewToken(UUID jobId) {
-    return jobId.toString();
     // TODO(#258): XSRF prevention temporarily disabled to get local demo working.
-    // try {
-    //   return JWT.create()
-    //       .withIssuer(JWTTokenManager.ISSUER)
-    //       .withClaim(JWTTokenManager.ID_CLAIM_KEY, jobId.toString())
-    //       .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME_MILLIS))
-    //       .sign(algorithm);
-    // } catch (JWTCreationException e) {
-    //   throw new RuntimeException("Error creating token for: " + jobId);
-    // }
+    try {
+      return JWT.create()
+          .withIssuer(JWTTokenManager.ISSUER)
+          .withClaim(JWTTokenManager.ID_CLAIM_KEY, jobId.toString())
+          .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME_MILLIS))
+          .sign(algorithm);
+    } catch (JWTCreationException e) {
+      throw new RuntimeException("Error creating token for: " + jobId);
+    }
   }
 }

--- a/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/JWTTokenManager.java
+++ b/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/JWTTokenManager.java
@@ -67,20 +67,8 @@ public class JWTTokenManager implements TokenManager {
 
   @Override
   public boolean verifyToken(String token) {
-    /*
-    TODO(#258): XSRF prevention temporarily disabled to get local demo working. Issue is:
-    ERROR org.dataportabilityproject.gateway.reference.SetupHandler - Error handling request
-    java.lang.IllegalArgumentException: Empty key
-     at javax.crypto.spec.SecretKeySpec.<init>(SecretKeySpec.java:96)
-     at com.auth0.jwt.algorithms.CryptoHelper.createSignatureFor(CryptoHelper.java:15)
-     at com.auth0.jwt.algorithms.HMACAlgorithm.sign(HMACAlgorithm.java:63)
-     at com.auth0.jwt.JWTCreator.sign(JWTCreator.java:334)
-     at com.auth0.jwt.JWTCreator.access$100(JWTCreator.java:24)
-     at com.auth0.jwt.JWTCreator$Builder.sign(JWTCreator.java:311)
-     at org.dataportabilityproject.gateway.reference.JWTTokenManager.createNewToken(JWTTokenManager.java:103)
-     */
     try {
-      DecodedJWT jwt = verifier.verify(token);
+      verifier.verify(token);
       return true;
     } catch (JWTVerificationException exception) {
       logger.debug("Error verifying token: {}", exception);
@@ -91,7 +79,6 @@ public class JWTTokenManager implements TokenManager {
 
   @Override
   public UUID getJobIdFromToken(String token) {
-    // TODO(#258): XSRF prevention temporarily disabled to get local demo working.
     try {
       DecodedJWT jwt = verifier.verify(token);
       // Token is verified, get claim
@@ -108,7 +95,6 @@ public class JWTTokenManager implements TokenManager {
 
   @Override
   public String createNewToken(UUID jobId) {
-    // TODO(#258): XSRF prevention temporarily disabled to get local demo working.
     try {
       return JWT.create()
           .withIssuer(JWTTokenManager.ISSUER)

--- a/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/ReferenceApiModule.java
+++ b/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/ReferenceApiModule.java
@@ -48,16 +48,6 @@ public class ReferenceApiModule extends AbstractModule {
   private static final String API_SETTINGS_PATH = "config/api.yaml";
   private static final String ENV_API_SETTINGS_PATH = "config/env/api.yaml";
 
-  static ApiSettings getApiSettings(ImmutableList<String> settingsFiles) throws IOException {
-    InputStream combinedInputStream = ConfigUtils.getSettingsCombinedInputStream(settingsFiles);
-    return getApiSettings(combinedInputStream);
-  }
-
-  static ApiSettings getApiSettings(InputStream inputStream) throws IOException {
-    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    return mapper.readValue(inputStream, ApiSettings.class);
-  }
-
   @Provides
   @Named("httpPort")
   public int httpPort() {
@@ -130,5 +120,15 @@ public class ReferenceApiModule extends AbstractModule {
     } catch (IOException e) {
       throw new IllegalArgumentException("Problem parsing api settings", e);
     }
+  }
+
+  static ApiSettings getApiSettings(ImmutableList<String> settingsFiles) throws IOException {
+    InputStream combinedInputStream = ConfigUtils.getSettingsCombinedInputStream(settingsFiles);
+    return getApiSettings(combinedInputStream);
+  }
+
+  static ApiSettings getApiSettings(InputStream inputStream) throws IOException {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    return mapper.readValue(inputStream, ApiSettings.class);
   }
 }


### PR DESCRIPTION
#258 (reverts  #266) 

this requires that a JWT_SECRET and JWT_KEY  be provided from the AppCredentialStore.

For local deployment add the following into your ~/.gradle/gradle.properties
```
data.portability.key.jwt=foo
data.portability.secret.jwt=bar
```
For cloud deployment, make sure a file/blob for JWT_KEY and JWT_SECRET exist where the key can contain foo, and the secret should be generated via ssh_keygen or something similar.