### PR TITLE
Flickr auth and wireup through the binaries 

### DIFF
--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -47,12 +47,15 @@ dependencies {
 
     compile project(':portability-gateway')
     compile project(':portability-worker')
+
     // TODO: depend on these based on list in flag values.
     compile project(':extensions:auth:portability-auth-microsoft')
     compile project(':extensions:auth:portability-auth-google')
+    compile project(':extensions:auth:portability-auth-flickr')
 
     compile project(':extensions:data-transfer:portability-data-transfer-google')
     compile project(':extensions:data-transfer:portability-data-transfer-microsoft')
+    compile project(':extensions:data-transfer:portability-data-transfer-flickr')
 
 }
 

--- a/distributions/worker-default/build.gradle
+++ b/distributions/worker-default/build.gradle
@@ -28,6 +28,7 @@ repositories {
 dependencies {
     compile project(':portability-worker')
 
+    compile project(':extensions:data-transfer:portability-data-transfer-flickr')
     compile project(':extensions:data-transfer:portability-data-transfer-google')
     compile project(':extensions:data-transfer:portability-data-transfer-microsoft')
 }

--- a/extensions/auth/portability-auth-flickr/build.gradle
+++ b/extensions/auth/portability-auth-flickr/build.gradle
@@ -14,32 +14,16 @@
  * limitations under the License.
  */
 
-plugins {
-    id 'com.github.johnrengelman.shadow' version '2.0.2'
-    id 'java'
-    id 'application'
-}
-
-
-repositories {
-    jcenter()
-}
-
 dependencies {
-    compile project(':portability-gateway')
-    // TODO: depend on these based on list in flag values.
-    compile project(':extensions:auth:portability-auth-google')
-    compile project(':extensions:auth:portability-auth-microsoft')
-    compile project(':extensions:auth:portability-auth-flickr')
+    compile project(':portability-spi-cloud')
+    compile project(':portability-spi-gateway')
+
+    compile("org.slf4j:slf4j-api:${slf4jVersion}")
+    compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
+
+    compile("com.flickr4java:flickr4java:${flickrVersion}")
+
+    testCompile("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
+    testCompile("org.mockito:mockito-core:${mockitoVersion}")
+    testCompile project(":extensions:cloud:portability-cloud-local")
 }
-
-addCloudExtensionDependency(project)
-
-mainClassName = 'org.dataportabilityproject.gateway.ApiMain'
-
-shadowJar {
-    mergeServiceFiles()
-    exclude '**/pom.properties'
-    exclude '**/pom.xml'
-}
-

--- a/extensions/auth/portability-auth-flickr/src/main/java/org/dataportabilityproject/auth/flickr/FlickrAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-flickr/src/main/java/org/dataportabilityproject/auth/flickr/FlickrAuthDataGenerator.java
@@ -57,7 +57,7 @@ public class FlickrAuthDataGenerator implements AuthDataGenerator {
   public AuthData generateAuthData(
       String callbackBaseUrl, String authCode, String id, AuthData initialAuthData, String extra) {
     Preconditions.checkArgument(Strings.isNullOrEmpty(extra), "Extra data not expected");
-    Preconditions.checkNotNull(initialAuthData, "Earlier auth data not expected for Google flow");
+    Preconditions.checkNotNull(initialAuthData, "Earlier auth data not expected for Flickr flow");
     AuthInterface authInterface = flickr.getAuthInterface();
     Token token = fromAuthData(initialAuthData);
     Token requestToken = authInterface.getAccessToken(token, new Verifier(authCode));

--- a/extensions/auth/portability-auth-flickr/src/main/java/org/dataportabilityproject/auth/flickr/FlickrAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-flickr/src/main/java/org/dataportabilityproject/auth/flickr/FlickrAuthDataGenerator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataportabilityproject.auth.flickr;
+
+import com.flickr4java.flickr.Flickr;
+import com.flickr4java.flickr.FlickrException;
+import com.flickr4java.flickr.REST;
+import com.flickr4java.flickr.auth.AuthInterface;
+import com.flickr4java.flickr.auth.Permission;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.dataportabilityproject.spi.gateway.auth.AuthDataGenerator;
+import org.dataportabilityproject.spi.gateway.types.AuthFlowConfiguration;
+import org.dataportabilityproject.types.transfer.auth.AppCredentials;
+import org.dataportabilityproject.types.transfer.auth.AuthData;
+import org.dataportabilityproject.types.transfer.auth.TokenSecretAuthData;
+import org.scribe.model.Token;
+import org.scribe.model.Verifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FlickrAuthDataGenerator implements AuthDataGenerator {
+  private final Flickr flickr;
+  private final Logger logger = LoggerFactory.getLogger(FlickrAuthDataGenerator.class);
+
+  FlickrAuthDataGenerator(AppCredentials appCredentials){
+    flickr = new Flickr(appCredentials.getKey(), appCredentials.getSecret(), new REST());
+  }
+
+  @Override
+  public AuthFlowConfiguration generateConfiguration(String callbackBaseUrl, String id) {
+    logger.debug("Generating FlickrAuthConfiguration");
+    // TODO: wire up stuffs
+    AuthInterface authInterface = flickr.getAuthInterface();
+    Token token = authInterface.getRequestToken(callbackBaseUrl + "/callback1/flickr");
+    String url =
+            authInterface.getAuthorizationUrl(
+                    token, Permission.WRITE);
+    return new AuthFlowConfiguration(url, toAuthData(token));
+  }
+
+  @Override
+  public AuthData generateAuthData(
+      String callbackBaseUrl, String authCode, String id, AuthData initialAuthData, String extra) {
+    Preconditions.checkArgument(Strings.isNullOrEmpty(extra), "Extra data not expected");
+    Preconditions.checkNotNull(initialAuthData, "Earlier auth data not expected for Google flow");
+    AuthInterface authInterface = flickr.getAuthInterface();
+    Token token = fromAuthData(initialAuthData);
+    Token requestToken = authInterface.getAccessToken(token, new Verifier(authCode));
+
+    try {
+      authInterface.checkToken(requestToken);
+    } catch (FlickrException e) {
+      logger.warn("Problem verifying auth token {}", e);
+      return null;
+    }
+    return new TokenSecretAuthData(requestToken.getToken(), requestToken.getSecret());
+  }
+
+  private static Token fromAuthData(AuthData authData) {
+    TokenSecretAuthData data = (TokenSecretAuthData) authData;
+    return new Token(data.getToken(), data.getSecret());
+  }
+
+  private static TokenSecretAuthData toAuthData(Token token){
+    return new TokenSecretAuthData(token.getToken(), token.getSecret());
+  }
+}

--- a/extensions/auth/portability-auth-flickr/src/main/java/org/dataportabilityproject/auth/flickr/FlickrAuthServiceExtension.java
+++ b/extensions/auth/portability-auth-flickr/src/main/java/org/dataportabilityproject/auth/flickr/FlickrAuthServiceExtension.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataportabilityproject.auth.flickr;
+
+import com.google.common.collect.ImmutableList;
+import org.dataportabilityproject.api.launcher.ExtensionContext;
+import org.dataportabilityproject.spi.gateway.auth.AuthDataGenerator;
+import org.dataportabilityproject.spi.gateway.auth.AuthServiceProviderRegistry;
+import org.dataportabilityproject.spi.gateway.auth.extension.AuthServiceExtension;
+
+import java.util.List;
+
+public class FlickrAuthServiceExtension implements AuthServiceExtension {
+  private final static String SERVICE_ID = "flickr";
+  private final List<String> supportedServices = ImmutableList.of("photos");
+  private FlickrAuthDataGenerator flickrAuthDataGenerator;
+
+  @Override
+  public String getServiceId() {
+    return SERVICE_ID;
+  }
+
+  @Override
+  public AuthDataGenerator getAuthDataGenerator(String transferDataType, AuthServiceProviderRegistry.AuthMode mode) {
+    return flickrAuthDataGenerator;
+  }
+
+  @Override
+  public List<String> getImportTypes() {
+    return supportedServices;
+  }
+
+  @Override
+  public List<String> getExportTypes() {
+    return supportedServices;
+  }
+
+  @Override
+  public void initialize(ExtensionContext context) {
+
+
+  }
+}

--- a/extensions/auth/portability-auth-flickr/src/main/resources/META-INF/services/org.dataportabilityproject.spi.gateway.auth.extension.AuthServiceExtension
+++ b/extensions/auth/portability-auth-flickr/src/main/resources/META-INF/services/org.dataportabilityproject.spi.gateway.auth.extension.AuthServiceExtension
@@ -1,0 +1,1 @@
+org.dataportabilityproject.auth.flickr.FlickrAuthServiceExtension

--- a/extensions/auth/portability-auth-flickr/src/test/java/org/dataportabilityproject/auth/flickr/FlickrAuthDataGeneratorTest.java
+++ b/extensions/auth/portability-auth-flickr/src/test/java/org/dataportabilityproject/auth/flickr/FlickrAuthDataGeneratorTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataportabilityproject.auth.flickr;
+
+class FlickrAuthDataGeneratorTest {
+
+}

--- a/portability-api-launcher/src/main/java/org/dataportabilityproject/api/launcher/TypeManager.java
+++ b/portability-api-launcher/src/main/java/org/dataportabilityproject/api/launcher/TypeManager.java
@@ -33,4 +33,12 @@ public interface TypeManager {
    * @param type the type to register.
    */
   void registerType(Class<?> type);
+
+  /**
+   * Registers a model type. Extensions that introduce new model subtypes must registered them here
+   * so they can be databound properly.
+   *
+   * @param type the type to register.
+   */
+  void registerTypes(Class<?>... types);
 }

--- a/portability-api-launcher/src/main/java/org/dataportabilityproject/launcher/impl/TypeManagerImpl.java
+++ b/portability-api-launcher/src/main/java/org/dataportabilityproject/launcher/impl/TypeManagerImpl.java
@@ -36,4 +36,10 @@ public class TypeManagerImpl implements TypeManager {
   public void registerType(Class<?> type) {
     objectMapper.registerSubtypes(type);
   }
+
+  public void registerTypes(Class<?>... types) {
+    for (Class<?> t : types) {
+      objectMapper.registerSubtypes(t);
+    }
+  }
 }

--- a/portability-gateway/src/main/java/org/dataportabilityproject/gateway/ApiMain.java
+++ b/portability-gateway/src/main/java/org/dataportabilityproject/gateway/ApiMain.java
@@ -46,6 +46,9 @@ import org.dataportabilityproject.spi.cloud.storage.JobStore;
 import org.dataportabilityproject.spi.gateway.auth.AuthServiceProviderRegistry;
 import org.dataportabilityproject.spi.gateway.auth.extension.AuthServiceExtension;
 import org.dataportabilityproject.spi.service.extension.ServiceExtension;
+import org.dataportabilityproject.types.transfer.auth.TokenAuthData;
+import org.dataportabilityproject.types.transfer.auth.TokenSecretAuthData;
+import org.dataportabilityproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +80,10 @@ public class ApiMain {
 
   public void initializeHttps(
       TrustManagerFactory trustManagerFactory, KeyManagerFactory keyManagerFactory) {
+    // TODO init with types
     TypeManager typeManager = new TypeManagerImpl();
+    typeManager.registerTypes(
+        TokenAuthData.class, TokensAndUrlAuthData.class, TokenSecretAuthData.class);
 
     // TODO implement
     Map<String, Object> configuration = new HashMap<>();

--- a/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/DataTransferHandler.java
+++ b/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/DataTransferHandler.java
@@ -81,6 +81,8 @@ final class DataTransferHandler implements HttpHandler {
     this.store = store;
     this.symmetricKeyGenerator = symmetricKeyGenerator;
     this.objectMapper = typeManager.getMapper();
+
+    logger.debug("Using jobstore: {} in DataTransferHandler", store);
   }
 
   /** Services the {@link CreateJobAction} via the {@link HttpExchange}. */
@@ -130,6 +132,7 @@ final class DataTransferHandler implements HttpHandler {
         request.getSource());
 
     PortabilityJob job = store.findJob(actionResponse.getId());
+    logger.debug("Found job: {} in DTH", job);
 
     // If present, store initial auth data for export services, e.g. used for oauth1
     if (authFlowConfiguration.getInitialAuthData() != null) {
@@ -159,6 +162,11 @@ final class DataTransferHandler implements HttpHandler {
           job.toBuilder().setAndValidateJobAuthorization(updatedJobAuthorization).build();
 
       store.updateJob(actionResponse.getId(), updatedPortabilityJob);
+
+      logger.debug("Updated job is: {}", updatedPortabilityJob);
+
+      PortabilityJob storejob = store.findJob(actionResponse.getId());
+      logger.debug("Job looked up in jobstore is: {} -> {}", actionResponse.getId(), storejob);
     }
 
     dataTransferResponse =

--- a/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/OauthCallbackHandler.java
+++ b/portability-gateway/src/main/java/org/dataportabilityproject/gateway/reference/OauthCallbackHandler.java
@@ -72,6 +72,9 @@ final class OauthCallbackHandler implements HttpHandler {
     this.symmetricKeyGenerator = symmetricKeyGenerator;
     this.objectMapper = typeManager.getMapper();
     this.apiSettings = apiSettings;
+
+    logger.debug("Using jobstore: {} in DataTransferHandler", store);
+
   }
 
   @Override
@@ -119,6 +122,8 @@ final class OauthCallbackHandler implements HttpHandler {
       UUID jobId = ReferenceApiUtils.decodeJobId(encodedIdCookie);
 
       PortabilityJob job = store.findJob(jobId);
+      logger.debug("Found job: {}->{} in OCH", jobId, job);
+
       Preconditions.checkNotNull(job, "existing job not found for jobId: %s", jobId);
 
       // TODO: Determine service from job or from authUrl path?

--- a/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/dataportabilityproject/spi/cloud/types/PortabilityJob.java
@@ -7,7 +7,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-
 import java.time.LocalDateTime;
 import java.util.Map;
 
@@ -29,6 +28,10 @@ public abstract class PortabilityJob {
   private static final String ENCRYPTED_SESSION_KEY = "ENCRYPTED_SESSION_KEY";
   private static final String ENCRYPTED_AUTH_KEY = "ENCRYPTED_AUTH_KEY";
   private static final String WORKER_INSTANCE_PUBLIC_KEY = "WORKER_INSTANCE_PUBLIC_KEY";
+  private static final String IMPORT_ENCRYPTED_INITIAL_AUTH_DATA =
+      "IMPORT_ENCRYPTED_INITIAL_AUTH_DATA";
+  private static final String EXPORT_ENCRYPTED_INITIAL_AUTH_DATA =
+      "EXPORT_ENCRYPTED_INITIAL_AUTH_DATA";
 
   public static PortabilityJob.Builder builder() {
     LocalDateTime now = LocalDateTime.now();
@@ -56,6 +59,16 @@ public abstract class PortabilityJob {
             ? (String) properties.get(WORKER_INSTANCE_PUBLIC_KEY)
             : null;
 
+    String encryptedExportInitialAuthData =
+        properties.containsKey(EXPORT_ENCRYPTED_INITIAL_AUTH_DATA)
+            ? (String) properties.get(EXPORT_ENCRYPTED_INITIAL_AUTH_DATA)
+            : null;
+
+    String encryptedImportInitialAuthData =
+        properties.containsKey(IMPORT_ENCRYPTED_INITIAL_AUTH_DATA)
+            ? (String) properties.get(IMPORT_ENCRYPTED_INITIAL_AUTH_DATA)
+            : null;
+
     return PortabilityJob.builder()
         .setState(State.NEW)
         .setExportService((String) properties.get(EXPORT_SERVICE_KEY))
@@ -72,6 +85,8 @@ public abstract class PortabilityJob {
                 .setSessionSecretKey((String) properties.get(ENCRYPTED_SESSION_KEY))
                 .setAuthSecretKey((String) properties.get(ENCRYPTED_AUTH_KEY))
                 .setAuthPublicKey(encodedPublicKey)
+                .setEncryptedInitialExportAuthData(encryptedExportInitialAuthData)
+                .setEncryptedInitialImportAuthData(encryptedImportInitialAuthData)
                 .build())
         .build();
   }
@@ -133,6 +148,16 @@ public abstract class PortabilityJob {
     }
     if (null != jobAuthorization().authPublicKey()) {
       builder.put(WORKER_INSTANCE_PUBLIC_KEY, jobAuthorization().authPublicKey());
+    }
+
+    if (null != jobAuthorization().encryptedInitialExportAuthData()) {
+      builder.put(
+          EXPORT_ENCRYPTED_INITIAL_AUTH_DATA, jobAuthorization().encryptedInitialExportAuthData());
+    }
+
+    if (null != jobAuthorization().encryptedInitialImportAuthData()) {
+      builder.put(
+          IMPORT_ENCRYPTED_INITIAL_AUTH_DATA, jobAuthorization().encryptedInitialImportAuthData());
     }
     return builder.build();
   }

--- a/portability-worker/src/main/java/org/dataportabilityproject/worker/PortabilityInMemoryDataCopier.java
+++ b/portability-worker/src/main/java/org/dataportabilityproject/worker/PortabilityInMemoryDataCopier.java
@@ -59,7 +59,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
     // Initial copy, starts off the process with no previous paginationData or containerResource
     // information
     ExportInformation emptyExportInfo = new ExportInformation(null, null);
-    copyHelper(exportAuthData, importAuthData, emptyExportInfo);
+    copyHelper(jobId, exportAuthData, importAuthData, emptyExportInfo);
   }
 
   /**
@@ -73,7 +73,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
    * @param exportInformation Any pagination or resource information to use for subsequent calls.
    */
   private void copyHelper(
-      AuthData exportAuthData, AuthData importAuthData, ExportInformation exportInformation)
+      UUID jobId, AuthData exportAuthData, AuthData importAuthData, ExportInformation exportInformation)
       throws IOException {
 
     logger.debug("copy iteration: {}", COPY_ITERATION_COUNTER.incrementAndGet());
@@ -87,7 +87,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
 
     logger.debug("Starting import");
     // TODO, use job Id?
-    importer.get().importItem("1", importAuthData, exportResult.getExportedData());
+    importer.get().importItem(jobId.toString(), importAuthData, exportResult.getExportedData());
     logger.debug("Finished import");
 
     ContinuationData continuationData = (ContinuationData) exportResult.getContinuationData();
@@ -97,6 +97,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
       if (null != continuationData.getPaginationData()) {
         logger.debug("start off a new copy iteration with pagination info");
         copyHelper(
+            jobId,
             exportAuthData,
             importAuthData,
             new ExportInformation(
@@ -107,7 +108,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
       if (continuationData.getContainerResources() != null
           && !continuationData.getContainerResources().isEmpty()) {
         for (ContainerResource resource : continuationData.getContainerResources()) {
-          copyHelper(exportAuthData, importAuthData, new ExportInformation(null, resource));
+          copyHelper(jobId, exportAuthData, importAuthData, new ExportInformation(null, resource));
         }
       }
     }

--- a/portability-worker/src/main/java/org/dataportabilityproject/worker/WorkerExtensionContext.java
+++ b/portability-worker/src/main/java/org/dataportabilityproject/worker/WorkerExtensionContext.java
@@ -29,11 +29,10 @@ import org.dataportabilityproject.api.launcher.TypeManager;
 import org.dataportabilityproject.config.ConfigUtils;
 import org.dataportabilityproject.launcher.impl.TypeManagerImpl;
 import org.dataportabilityproject.types.transfer.auth.TokenAuthData;
+import org.dataportabilityproject.types.transfer.auth.TokenSecretAuthData;
 import org.dataportabilityproject.types.transfer.auth.TokensAndUrlAuthData;
 
-/**
- * {@link ExtensionContext} used by the worker.
- */
+/** {@link ExtensionContext} used by the worker. */
 final class WorkerExtensionContext implements ExtensionContext {
   private static final String WORKER_SETTINGS_PATH = "config/worker.yaml";
   private static final String ENV_WORKER_SETTINGS_PATH = "config/env/worker.yaml";
@@ -47,13 +46,15 @@ final class WorkerExtensionContext implements ExtensionContext {
   WorkerExtensionContext() {
     // TODO init with types
     this.typeManager = new TypeManagerImpl();
-    typeManager.registerType(TokenAuthData.class);
-    typeManager.registerType(TokensAndUrlAuthData.class);
+    typeManager.registerTypes(
+        TokenAuthData.class, TokensAndUrlAuthData.class, TokenSecretAuthData.class);
     registered.put(TypeManager.class, typeManager);
 
     try {
-      // TODO: read settings from files in jar once they are built in - Jim: I think this should be done by the class creating this one
-      ImmutableList<String> settingsFiles = ImmutableList.<String>builder()
+      // TODO: read settings from files in jar once they are built in - Jim: I think this should be
+      // done by the class creating this one
+      ImmutableList<String> settingsFiles =
+          ImmutableList.<String>builder()
               .add(WORKER_SETTINGS_PATH)
               .add(ENV_WORKER_SETTINGS_PATH)
               .add(COMMON_SETTINGS_PATH)

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,4 +26,5 @@ include ':portability-core', ':portability-worker', ':portability-bootstrap-vm'
 
 include ':distributions:worker-default', ':distributions:gateway-default', ':distributions:demo-server'
 
+include ':extensions:auth:portability-auth-flickr'
 include ':extensions:data-transfer:portability-data-transfer-flickr'


### PR DESCRIPTION
#213 

This also adds InitialAuthData to the JobMap since its required for oauth1 
Also fix PortabilityCopier to use JobId instead of hardcoded number (needed for any importer/exporters that use the job store). 