### PR TITLE
Propagate jobid

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/dataportabilityproject/datatransfer/flickr/photos/FlickrPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/dataportabilityproject/datatransfer/flickr/photos/FlickrPhotosExporter.java
@@ -35,20 +35,23 @@ import com.google.common.collect.ImmutableSet;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult.ResultType;
 import org.dataportabilityproject.spi.transfer.provider.Exporter;
-import org.dataportabilityproject.spi.transfer.types.*;
+import org.dataportabilityproject.spi.transfer.types.ContinuationData;
+import org.dataportabilityproject.spi.transfer.types.ExportInformation;
+import org.dataportabilityproject.spi.transfer.types.IdOnlyContainerResource;
+import org.dataportabilityproject.spi.transfer.types.IntPaginationToken;
+import org.dataportabilityproject.spi.transfer.types.PaginationData;
 import org.dataportabilityproject.types.transfer.auth.AppCredentials;
 import org.dataportabilityproject.types.transfer.auth.AuthData;
-import org.dataportabilityproject.types.transfer.auth.TokenSecretAuthData;
 import org.dataportabilityproject.types.transfer.models.photos.PhotoAlbum;
 import org.dataportabilityproject.types.transfer.models.photos.PhotoModel;
 import org.dataportabilityproject.types.transfer.models.photos.PhotosContainerResource;
-import org.scribe.model.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class FlickrPhotosExporter implements Exporter<AuthData, PhotosContainerResource> {
@@ -103,13 +106,13 @@ public class FlickrPhotosExporter implements Exporter<AuthData, PhotosContainerR
   }
 
   @Override
-  public ExportResult<PhotosContainerResource> export(AuthData authData) {
-    return export(authData, new ExportInformation(null, null));
+  public ExportResult<PhotosContainerResource> export(UUID jobId, AuthData authData) {
+    return export(jobId, authData, new ExportInformation(null, null));
   }
 
   @Override
   public ExportResult<PhotosContainerResource> export(
-      AuthData authData, ExportInformation exportInformation) {
+      UUID jobId, AuthData authData, ExportInformation exportInformation) {
     Auth auth;
     try {
       auth = FlickrUtils.getAuth(authData, flickr);

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/dataportabilityproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/dataportabilityproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -84,7 +84,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
     // photo in it, so we have to wait for the first photo to create the album
     TempPhotosData tempPhotosData = jobStore.findData(TempPhotosData.class, jobId);
     if (tempPhotosData == null) {
-      tempPhotosData = new TempPhotosData(jobId.toString());
+      tempPhotosData = new TempPhotosData(jobId);
       jobStore.create(jobId, tempPhotosData);
     }
 

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/dataportabilityproject/datatransfer/flickr/photos/FlickrPhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/dataportabilityproject/datatransfer/flickr/photos/FlickrPhotosExporterTest.java
@@ -16,15 +16,6 @@
 
 package org.dataportabilityproject.datatransfer.flickr.photos;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anySet;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.flickr4java.flickr.Flickr;
 import com.flickr4java.flickr.FlickrException;
 import com.flickr4java.flickr.auth.Auth;
@@ -34,12 +25,9 @@ import com.flickr4java.flickr.people.User;
 import com.flickr4java.flickr.photos.Photo;
 import com.flickr4java.flickr.photos.PhotoList;
 import com.flickr4java.flickr.photos.PhotosInterface;
-import com.flickr4java.flickr.photos.Size;
 import com.flickr4java.flickr.photosets.Photoset;
 import com.flickr4java.flickr.photosets.Photosets;
 import com.flickr4java.flickr.photosets.PhotosetsInterface;
-import java.util.Collection;
-import java.util.Collections;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
 import org.dataportabilityproject.spi.transfer.types.ContinuationData;
 import org.dataportabilityproject.spi.transfer.types.ExportInformation;
@@ -53,8 +41,19 @@ import org.dataportabilityproject.types.transfer.models.photos.PhotoModel;
 import org.dataportabilityproject.types.transfer.models.photos.PhotosContainerResource;
 import org.junit.Test;
 import org.scribe.model.Token;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FlickrPhotosExporterTest {
   private static final String PHOTO_TITLE = "Title";
@@ -73,7 +72,8 @@ public class FlickrPhotosExporterTest {
 
   @Test
   public void toCommonPhoto() {
-    Photo photo = FlickrTestUtils.initializePhoto(PHOTO_TITLE, FETCHABLE_URL, PHOTO_DESCRIPTION, MEDIA_TYPE);
+    Photo photo =
+        FlickrTestUtils.initializePhoto(PHOTO_TITLE, FETCHABLE_URL, PHOTO_DESCRIPTION, MEDIA_TYPE);
     PhotoModel photoModel = FlickrPhotosExporter.toCommonPhoto(photo, ALBUM_ID);
 
     assertThat(photoModel.getAlbumId()).isEqualTo(ALBUM_ID);
@@ -113,7 +113,7 @@ public class FlickrPhotosExporterTest {
     // run test
     FlickrPhotosExporter exporter = new FlickrPhotosExporter(flickr);
     AuthData authData = new TokenSecretAuthData("token", "secret");
-    ExportResult<PhotosContainerResource> result = exporter.export(authData);
+    ExportResult<PhotosContainerResource> result = exporter.export(UUID.randomUUID(), authData);
 
     // make sure album and photo information is correct
     assertThat(result.getExportedData().getPhotos()).isEmpty();
@@ -151,7 +151,8 @@ public class FlickrPhotosExporterTest {
     int numPhotos = 4;
     PhotoList<Photo> photosList = new PhotoList<>();
     for (int i = 0; i < numPhotos; i++) {
-      photosList.add(FlickrTestUtils.initializePhoto("title" + 1, "url" + i, "description" + i, MEDIA_TYPE));
+      photosList.add(
+          FlickrTestUtils.initializePhoto("title" + 1, "url" + i, "description" + i, MEDIA_TYPE));
     }
     photosList.setPage(page);
     photosList.setPages(page + 1);
@@ -162,7 +163,8 @@ public class FlickrPhotosExporterTest {
     // run test
     FlickrPhotosExporter exporter = new FlickrPhotosExporter(flickr);
     ExportResult<PhotosContainerResource> result =
-        exporter.export(new TokenSecretAuthData("token", "secret"), exportInformation);
+        exporter.export(
+            UUID.randomUUID(), new TokenSecretAuthData("token", "secret"), exportInformation);
     assertThat(result.getExportedData().getPhotos().size()).isEqualTo(numPhotos);
     assertThat(result.getExportedData().getAlbums()).isEmpty();
 

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/dataportabilityproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/dataportabilityproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
@@ -106,7 +106,7 @@ public class FlickrPhotosImporterTest {
     // Run test
     FlickrPhotosImporter importer = new FlickrPhotosImporter(flickr, jobStore, imageStreamProvider);
     ImportResult result = importer.importItem(
-        jobId.toString(), new TokenSecretAuthData("token", "secret"), photosContainerResource);
+        jobId, new TokenSecretAuthData("token", "secret"), photosContainerResource);
 
     // Verify that the image stream provider got the correct URL and that the correct info was uploaded
     verify(imageStreamProvider).get(FETCHABLE_URL);

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarExporter.java
@@ -1,8 +1,5 @@
 package org.dataportabilityproject.datatransfer.google.calendar;
 
-import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.CALENDAR_TOKEN_PREFIX;
-import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.EVENT_TOKEN_PREFIX;
-
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.model.CalendarList;
@@ -13,14 +10,6 @@ import com.google.api.services.calendar.model.EventDateTime;
 import com.google.api.services.calendar.model.Events;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult.ResultType;
@@ -35,6 +24,19 @@ import org.dataportabilityproject.types.transfer.models.calendar.CalendarAttende
 import org.dataportabilityproject.types.transfer.models.calendar.CalendarContainerResource;
 import org.dataportabilityproject.types.transfer.models.calendar.CalendarEventModel;
 import org.dataportabilityproject.types.transfer.models.calendar.CalendarModel;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.CALENDAR_TOKEN_PREFIX;
+import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.EVENT_TOKEN_PREFIX;
 
 public class GoogleCalendarExporter implements Exporter<AuthData, CalendarContainerResource> {
 
@@ -97,13 +99,13 @@ public class GoogleCalendarExporter implements Exporter<AuthData, CalendarContai
   }
 
   @Override
-  public ExportResult<CalendarContainerResource> export(AuthData authData) {
+  public ExportResult<CalendarContainerResource> export(UUID jobId, AuthData authData) {
     return exportCalendars(authData, Optional.empty());
   }
 
   @Override
   public ExportResult<CalendarContainerResource> export(
-      AuthData authData, ExportInformation exportInformation) {
+      UUID jobId, AuthData authData, ExportInformation exportInformation) {
     StringPaginationToken paginationToken =
         (StringPaginationToken) exportInformation.getPaginationData();
     if (paginationToken != null && paginationToken.getToken().startsWith(CALENDAR_TOKEN_PREFIX)) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarImporter.java
@@ -115,7 +115,7 @@ public class GoogleCalendarImporter implements Importer<AuthData, CalendarContai
 
     TempCalendarData calendarMappings = jobStore.findData(TempCalendarData.class, jobId);
     if (calendarMappings == null) {
-      calendarMappings = new TempCalendarData(jobId.toString());
+      calendarMappings = new TempCalendarData(jobId);
       jobStore.create(jobId, calendarMappings);
     }
     calendarMappings.addIdMapping(calendarModel.getId(), calendarResult.getId());

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarImporter.java
@@ -7,9 +7,6 @@ import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.EventAttendee;
 import com.google.api.services.calendar.model.EventDateTime;
 import com.google.common.annotations.VisibleForTesting;
-import java.io.IOException;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects;
 import org.dataportabilityproject.spi.cloud.storage.JobStore;
 import org.dataportabilityproject.spi.transfer.provider.ImportResult;
@@ -21,6 +18,10 @@ import org.dataportabilityproject.types.transfer.models.calendar.CalendarAttende
 import org.dataportabilityproject.types.transfer.models.calendar.CalendarContainerResource;
 import org.dataportabilityproject.types.transfer.models.calendar.CalendarEventModel;
 import org.dataportabilityproject.types.transfer.models.calendar.CalendarModel;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class GoogleCalendarImporter implements Importer<AuthData, CalendarContainerResource> {
 
@@ -89,7 +90,7 @@ public class GoogleCalendarImporter implements Importer<AuthData, CalendarContai
   }
 
   @Override
-  public ImportResult importItem(String jobId, AuthData authData, CalendarContainerResource data) {
+  public ImportResult importItem(UUID jobId, AuthData authData, CalendarContainerResource data) {
     try {
       for (CalendarModel calendarModel : data.getCalendars()) {
         importSingleCalendar(jobId, authData, calendarModel);
@@ -105,30 +106,28 @@ public class GoogleCalendarImporter implements Importer<AuthData, CalendarContai
   }
 
   @VisibleForTesting
-  void importSingleCalendar(String jobId, AuthData authData, CalendarModel calendarModel)
+  void importSingleCalendar(UUID jobId, AuthData authData, CalendarModel calendarModel)
       throws IOException {
     com.google.api.services.calendar.model.Calendar toInsert = convertToGoogleCalendar(
         calendarModel);
     com.google.api.services.calendar.model.Calendar calendarResult =
         getOrCreateCalendarInterface(authData).calendars().insert(toInsert).execute();
 
-    UUID id = UUID.fromString(jobId);
-    TempCalendarData calendarMappings = jobStore.findData(TempCalendarData.class, id);
+    TempCalendarData calendarMappings = jobStore.findData(TempCalendarData.class, jobId);
     if (calendarMappings == null) {
-      calendarMappings = new TempCalendarData(jobId);
-      jobStore.create(id, calendarMappings);
+      calendarMappings = new TempCalendarData(jobId.toString());
+      jobStore.create(jobId, calendarMappings);
     }
     calendarMappings.addIdMapping(calendarModel.getId(), calendarResult.getId());
-    jobStore.update(id, calendarMappings);
+    jobStore.update(jobId, calendarMappings);
   }
 
   @VisibleForTesting
-  void importSingleEvent(String jobId, AuthData authData, CalendarEventModel eventModel)
+  void importSingleEvent(UUID jobId, AuthData authData, CalendarEventModel eventModel)
       throws IOException {
     Event event = convertToGoogleCalendarEvent(eventModel);
-    UUID id = UUID.fromString(jobId);
     // calendarMappings better not be null!
-    TempCalendarData calendarMappings = jobStore.findData(TempCalendarData.class, id);
+    TempCalendarData calendarMappings = jobStore.findData(TempCalendarData.class, jobId);
     String newCalendarId = calendarMappings.getImportedId(eventModel.getCalendarId());
     getOrCreateCalendarInterface(authData)
         .events()

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/contacts/GoogleContactsExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/contacts/GoogleContactsExporter.java
@@ -53,6 +53,7 @@ import java.io.StringWriter;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.PERSON_FIELDS;
@@ -76,13 +77,13 @@ public class GoogleContactsExporter
   }
 
   @Override
-  public ExportResult<ContactsModelWrapper> export(TokensAndUrlAuthData authData) {
+  public ExportResult<ContactsModelWrapper> export(UUID jobId, TokensAndUrlAuthData authData) {
     return exportContacts(authData, Optional.empty());
   }
 
   @Override
   public ExportResult<ContactsModelWrapper> export(
-      TokensAndUrlAuthData authData, ExportInformation exportInformation) {
+      UUID jobId, TokensAndUrlAuthData authData, ExportInformation exportInformation) {
     StringPaginationToken stringPaginationToken =
         (StringPaginationToken) exportInformation.getPaginationData();
     Optional<PaginationData> paginationData = Optional.ofNullable(stringPaginationToken);

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/contacts/GoogleContactsImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/contacts/GoogleContactsImporter.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.CONTACT_SOURCE_TYPE;
@@ -199,7 +200,7 @@ public class GoogleContactsImporter implements Importer<TokensAndUrlAuthData, Co
   }
 
   @Override
-  public ImportResult importItem(String jobId, TokensAndUrlAuthData authData, ContactsModelWrapper data) {
+  public ImportResult importItem(UUID jobId, TokensAndUrlAuthData authData, ContactsModelWrapper data) {
     JCardReader reader = new JCardReader(data.getVCards());
     try {
       // TODO(olsona): address any other problems that might arise in conversion

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/photos/GooglePhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/photos/GooglePhotosExporter.java
@@ -25,11 +25,6 @@ import com.google.gdata.data.photos.AlbumFeed;
 import com.google.gdata.data.photos.GphotoEntry;
 import com.google.gdata.data.photos.UserFeed;
 import com.google.gdata.util.ServiceException;
-import java.io.IOException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult.ResultType;
@@ -44,7 +39,15 @@ import org.dataportabilityproject.types.transfer.models.photos.PhotoAlbum;
 import org.dataportabilityproject.types.transfer.models.photos.PhotoModel;
 import org.dataportabilityproject.types.transfer.models.photos.PhotosContainerResource;
 
-public class GooglePhotosExporter implements Exporter<TokensAndUrlAuthData, PhotosContainerResource> {
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class GooglePhotosExporter
+    implements Exporter<TokensAndUrlAuthData, PhotosContainerResource> {
 
   static final String ALBUM_TOKEN_PREFIX = "album:";
   static final String PHOTO_TOKEN_PREFIX = "photo:";
@@ -52,9 +55,12 @@ public class GooglePhotosExporter implements Exporter<TokensAndUrlAuthData, Phot
   // TODO(olsona): figure out optimal value here
   static final int MAX_RESULTS = 100;
 
-  static final String URL_ALBUM_FEED_FORMAT = "https://picasaweb.google.com/data/feed/api/user/default?kind=album&start-index=%d&max-results=%d";
-  // imgmax=d gets the original image as per https://developers.google.com/picasa-web/docs/3.0/reference
-  static final String URL_PHOTO_FEED_FORMAT = "https://picasaweb.google.com/data/feed/api/user/default/albumid/%s?imgmax=d&start-index=%s&max-results=%d";
+  static final String URL_ALBUM_FEED_FORMAT =
+      "https://picasaweb.google.com/data/feed/api/user/default?kind=album&start-index=%d&max-results=%d";
+  // imgmax=d gets the original image as per
+  // https://developers.google.com/picasa-web/docs/3.0/reference
+  static final String URL_PHOTO_FEED_FORMAT =
+      "https://picasaweb.google.com/data/feed/api/user/default/albumid/%s?imgmax=d&start-index=%s&max-results=%d";
 
   private volatile PicasawebService photosService;
 
@@ -68,15 +74,15 @@ public class GooglePhotosExporter implements Exporter<TokensAndUrlAuthData, Phot
   }
 
   @Override
-  public ExportResult<PhotosContainerResource> export(TokensAndUrlAuthData authData) {
+  public ExportResult<PhotosContainerResource> export(UUID jobId, TokensAndUrlAuthData authData) {
     return exportAlbums(authData, Optional.empty());
   }
 
   @Override
-  public ExportResult<PhotosContainerResource> export(TokensAndUrlAuthData authData,
-      ExportInformation exportInformation) {
-    StringPaginationToken paginationToken = (StringPaginationToken) exportInformation
-        .getPaginationData();
+  public ExportResult<PhotosContainerResource> export(
+      UUID jobId, TokensAndUrlAuthData authData, ExportInformation exportInformation) {
+    StringPaginationToken paginationToken =
+        (StringPaginationToken) exportInformation.getPaginationData();
     if (paginationToken != null && paginationToken.getToken().startsWith(ALBUM_TOKEN_PREFIX)) {
       // Next thing to export is more albums
       return exportAlbums(authData, Optional.of(paginationToken));
@@ -90,14 +96,14 @@ public class GooglePhotosExporter implements Exporter<TokensAndUrlAuthData, Phot
     }
   }
 
-  private ExportResult<PhotosContainerResource> exportAlbums(TokensAndUrlAuthData authData,
-      Optional<PaginationData> paginationData) {
+  private ExportResult<PhotosContainerResource> exportAlbums(
+      TokensAndUrlAuthData authData, Optional<PaginationData> paginationData) {
     try {
       int startItem = 1;
       if (paginationData.isPresent()) {
         String token = ((StringPaginationToken) paginationData.get()).getToken();
-        Preconditions.checkArgument(token.startsWith(ALBUM_TOKEN_PREFIX),
-            "Invalid pagination token " + token);
+        Preconditions.checkArgument(
+            token.startsWith(ALBUM_TOKEN_PREFIX), "Invalid pagination token " + token);
         startItem = Integer.parseInt(token.substring(ALBUM_TOKEN_PREFIX.length()));
       }
       URL albumUrl = new URL(String.format(URL_ALBUM_FEED_FORMAT, startItem, MAX_RESULTS));
@@ -113,12 +119,15 @@ public class GooglePhotosExporter implements Exporter<TokensAndUrlAuthData, Phot
       List<PhotoAlbum> albums = new ArrayList<>(albumFeed.getAlbumEntries().size());
       for (GphotoEntry googleAlbum : albumFeed.getAlbumEntries()) {
         // Add album info to list so album can be recreated later
-        albums.add(new PhotoAlbum(googleAlbum.getGphotoId(), googleAlbum.getTitle().getPlainText(),
-            googleAlbum.getDescription().getPlainText()));
+        albums.add(
+            new PhotoAlbum(
+                googleAlbum.getGphotoId(),
+                googleAlbum.getTitle().getPlainText(),
+                googleAlbum.getDescription().getPlainText()));
 
         // Add album id to continuation data
-        continuationData
-            .addContainerResource(new IdOnlyContainerResource(googleAlbum.getGphotoId()));
+        continuationData.addContainerResource(
+            new IdOnlyContainerResource(googleAlbum.getGphotoId()));
       }
 
       ResultType resultType = ResultType.CONTINUE;
@@ -132,18 +141,18 @@ public class GooglePhotosExporter implements Exporter<TokensAndUrlAuthData, Phot
     }
   }
 
-  private ExportResult<PhotosContainerResource> exportPhotos(TokensAndUrlAuthData authData, String albumId,
-      Optional<PaginationData> paginationData) {
+  private ExportResult<PhotosContainerResource> exportPhotos(
+      TokensAndUrlAuthData authData, String albumId, Optional<PaginationData> paginationData) {
     try {
       int startItem = 1;
       if (paginationData.isPresent()) {
         String token = ((StringPaginationToken) paginationData.get()).getToken();
-        Preconditions.checkArgument(token.startsWith(PHOTO_TOKEN_PREFIX),
-            "Invalid pagination token " + token);
+        Preconditions.checkArgument(
+            token.startsWith(PHOTO_TOKEN_PREFIX), "Invalid pagination token " + token);
         startItem = Integer.parseInt(token.substring(PHOTO_TOKEN_PREFIX.length()));
       }
-      URL photosUrl = new URL(
-          String.format(URL_PHOTO_FEED_FORMAT, albumId, startItem, MAX_RESULTS));
+      URL photosUrl =
+          new URL(String.format(URL_PHOTO_FEED_FORMAT, albumId, startItem, MAX_RESULTS));
       AlbumFeed photoFeed = getOrCreatePhotosService(authData).getFeed(photosUrl, AlbumFeed.class);
 
       PaginationData nextPageData = null;
@@ -156,9 +165,13 @@ public class GooglePhotosExporter implements Exporter<TokensAndUrlAuthData, Phot
       List<PhotoModel> photos = new ArrayList<>(photoFeed.getEntries().size());
       for (GphotoEntry photo : photoFeed.getEntries()) {
         MediaContent mediaContent = (MediaContent) photo.getContent();
-        photos.add(new PhotoModel(photo.getTitle().getPlainText(), mediaContent.getUri(), photo
-            .getDescription().getPlainText(), mediaContent.getMimeType().getMediaType(),
-            albumId));
+        photos.add(
+            new PhotoModel(
+                photo.getTitle().getPlainText(),
+                mediaContent.getUri(),
+                photo.getDescription().getPlainText(),
+                mediaContent.getMimeType().getMediaType(),
+                albumId));
       }
 
       PhotosContainerResource containerResource = new PhotosContainerResource(null, photos);

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -100,7 +100,7 @@ public class GooglePhotosImporter implements Importer<TokensAndUrlAuthData, Phot
     // Put new album ID in job store so photos can be assigned to the correct album
     TempPhotosData photoMappings = jobStore.findData(TempPhotosData.class, jobId);
     if (photoMappings == null) {
-      photoMappings = new TempPhotosData(jobId.toString());
+      photoMappings = new TempPhotosData(jobId);
       jobStore.create(jobId, photoMappings);
     }
     photoMappings.addAlbumId(inputAlbum.getId(), insertedEntry.getGphotoId());

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/tasks/GoogleTasksExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/dataportabilityproject/datatransfer/google/tasks/GoogleTasksExporter.java
@@ -23,9 +23,6 @@ import com.google.api.services.tasks.model.TaskList;
 import com.google.api.services.tasks.model.TaskLists;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult.ResultType;
@@ -39,6 +36,11 @@ import org.dataportabilityproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.dataportabilityproject.types.transfer.models.tasks.TaskContainerResource;
 import org.dataportabilityproject.types.transfer.models.tasks.TaskListModel;
 import org.dataportabilityproject.types.transfer.models.tasks.TaskModel;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class GoogleTasksExporter implements Exporter<TokensAndUrlAuthData, TaskContainerResource> {
   private static final long PAGE_SIZE = 50;
@@ -54,13 +56,13 @@ public class GoogleTasksExporter implements Exporter<TokensAndUrlAuthData, TaskC
   }
 
   @Override
-  public ExportResult<TaskContainerResource> export(TokensAndUrlAuthData authData) {
-    return export(authData, new ExportInformation(null, null));
+  public ExportResult<TaskContainerResource> export(UUID jobId, TokensAndUrlAuthData authData) {
+    return export(jobId, authData, new ExportInformation(null, null));
   }
 
   @Override
   public ExportResult<TaskContainerResource> export(
-      TokensAndUrlAuthData authData, ExportInformation exportInformation) {
+      UUID jobId, TokensAndUrlAuthData authData, ExportInformation exportInformation) {
     // Create a new tasks service for the authorized user
     Tasks tasksService = getOrCreateTasksService(authData);
 
@@ -108,7 +110,8 @@ public class GoogleTasksExporter implements Exporter<TokensAndUrlAuthData, TaskC
     return new ExportResult<>(resultType, taskContainerResource, new ContinuationData(newPage));
   }
 
-  private ExportResult getTasksList(Tasks tasksSerivce, PaginationData paginationData) throws IOException {
+  private ExportResult getTasksList(Tasks tasksSerivce, PaginationData paginationData)
+      throws IOException {
     Tasks.Tasklists.List query = tasksSerivce.tasklists().list().setMaxResults(PAGE_SIZE);
     if (paginationData != null) {
       query.setPageToken(((StringPaginationToken) paginationData).getToken());
@@ -117,25 +120,30 @@ public class GoogleTasksExporter implements Exporter<TokensAndUrlAuthData, TaskC
     ImmutableList.Builder<TaskListModel> newTaskListsBuilder = ImmutableList.builder();
     ImmutableList.Builder<IdOnlyContainerResource> newResourcesBuilder = ImmutableList.builder();
 
-    for(TaskList taskList : result.getItems()) {
+    for (TaskList taskList : result.getItems()) {
       newTaskListsBuilder.add(new TaskListModel(taskList.getId(), taskList.getTitle()));
       newResourcesBuilder.add(new IdOnlyContainerResource(taskList.getId()));
     }
 
     PaginationData newPage = null;
     ResultType resultType = ResultType.END;
-    if(result.getNextPageToken()!=null) {
+    if (result.getNextPageToken() != null) {
       newPage = new StringPaginationToken(result.getNextPageToken());
       resultType = ResultType.CONTINUE;
     }
 
     List<IdOnlyContainerResource> newResources = newResourcesBuilder.build();
-    if(!newResources.isEmpty()) { resultType = ResultType.CONTINUE; }
+    if (!newResources.isEmpty()) {
+      resultType = ResultType.CONTINUE;
+    }
 
-    TaskContainerResource taskContainerResource = new TaskContainerResource(newTaskListsBuilder.build(), null);
+    TaskContainerResource taskContainerResource =
+        new TaskContainerResource(newTaskListsBuilder.build(), null);
     ContinuationData continuationData = new ContinuationData(newPage);
-    newResourcesBuilder.build().forEach(resource -> continuationData.addContainerResource(resource));
-    return new ExportResult<>(resultType,taskContainerResource, continuationData);
+    newResourcesBuilder
+        .build()
+        .forEach(resource -> continuationData.addContainerResource(resource));
+    return new ExportResult<>(resultType, taskContainerResource, continuationData);
   }
 
   private Tasks getOrCreateTasksService(TokensAndUrlAuthData authData) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarExporterTest.java
@@ -16,24 +16,11 @@
 
 package org.dataportabilityproject.datatransfer.google.calendar;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.CALENDAR_TOKEN_PREFIX;
-import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.EVENT_TOKEN_PREFIX;
-import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.MAX_ATTENDEES;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.model.CalendarList;
 import com.google.api.services.calendar.model.CalendarListEntry;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.Events;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
 import org.dataportabilityproject.spi.transfer.types.ContinuationData;
 import org.dataportabilityproject.spi.transfer.types.ExportInformation;
@@ -48,6 +35,21 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.CALENDAR_TOKEN_PREFIX;
+import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.EVENT_TOKEN_PREFIX;
+import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.MAX_ATTENDEES;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class GoogleCalendarExporterTest {
   private static final String CALENDAR_ID = "calendar_id";
@@ -98,7 +100,8 @@ public class GoogleCalendarExporterTest {
     calendarListResponse.setNextPageToken(NEXT_TOKEN);
 
     // Run test
-    ExportResult<CalendarContainerResource> result = googleCalendarExporter.export(null);
+    ExportResult<CalendarContainerResource> result =
+        googleCalendarExporter.export(UUID.randomUUID(), null);
 
     // Check results
     // Verify correct methods were called
@@ -141,7 +144,7 @@ public class GoogleCalendarExporterTest {
 
     // Run test
     ExportResult<CalendarContainerResource> result =
-        googleCalendarExporter.export(null, exportInformation);
+        googleCalendarExporter.export(UUID.randomUUID(), null, exportInformation);
 
     // Check results
     // Verify correct calls were made
@@ -167,7 +170,7 @@ public class GoogleCalendarExporterTest {
 
     // Run test
     ExportResult<CalendarContainerResource> result =
-        googleCalendarExporter.export(null, exportInformation);
+        googleCalendarExporter.export(UUID.randomUUID(), null, exportInformation);
 
     // Check results
     // Verify correct methods were called
@@ -188,7 +191,8 @@ public class GoogleCalendarExporterTest {
 
     // Check pagination token
     ContinuationData continuationData = (ContinuationData) result.getContinuationData();
-    StringPaginationToken paginationToken = (StringPaginationToken) continuationData.getPaginationData();
+    StringPaginationToken paginationToken =
+        (StringPaginationToken) continuationData.getPaginationData();
     assertThat(paginationToken.getToken()).isEqualTo(EVENT_TOKEN_PREFIX + NEXT_TOKEN);
   }
 
@@ -203,8 +207,8 @@ public class GoogleCalendarExporterTest {
     eventListResponse.setNextPageToken(null);
 
     // Run test
-    ExportResult<CalendarContainerResource> result = googleCalendarExporter
-        .export(null, exportInformation);
+    ExportResult<CalendarContainerResource> result =
+        googleCalendarExporter.export(UUID.randomUUID(), null, exportInformation);
 
     // Check results
     // Verify correct methods were called in order
@@ -214,7 +218,8 @@ public class GoogleCalendarExporterTest {
 
     // Check pagination token
     ContinuationData continuationData = (ContinuationData) result.getContinuationData();
-    StringPaginationToken paginationToken = (StringPaginationToken) continuationData.getPaginationData();
+    StringPaginationToken paginationToken =
+        (StringPaginationToken) continuationData.getPaginationData();
     assertThat(paginationToken).isNull();
   }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarExporterTest.java
@@ -52,6 +52,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class GoogleCalendarExporterTest {
+  private static final UUID JOB_ID = UUID.fromString("9b969983-a09b-4cb0-8017-7daae758126b");
+
   private static final String CALENDAR_ID = "calendar_id";
   private static final CalendarListEntry CALENDAR_LIST_ENTRY =
       new CalendarListEntry().setId(CALENDAR_ID);
@@ -100,8 +102,7 @@ public class GoogleCalendarExporterTest {
     calendarListResponse.setNextPageToken(NEXT_TOKEN);
 
     // Run test
-    ExportResult<CalendarContainerResource> result =
-        googleCalendarExporter.export(UUID.randomUUID(), null);
+    ExportResult<CalendarContainerResource> result = googleCalendarExporter.export(JOB_ID, null);
 
     // Check results
     // Verify correct methods were called

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/calendar/GoogleCalendarImporterTest.java
@@ -96,7 +96,7 @@ public class GoogleCalendarImporterTest {
             Collections.singleton(calendarModel), Collections.singleton(eventModel));
 
     // Run test
-    calendarService.importItem(jobId.toString(), null, calendarContainerResource);
+    calendarService.importItem(jobId, null, calendarContainerResource);
 
     // Check the right methods were called
     verify(calendarCalendars).insert(calendarToInsert);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/contacts/GoogleContactsExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/contacts/GoogleContactsExporterTest.java
@@ -16,13 +16,6 @@
 
 package org.dataportabilityproject.datatransfer.google.contacts;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.PERSON_FIELDS;
-import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.SELF_RESOURCE;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.google.api.services.people.v1.PeopleService;
 import com.google.api.services.people.v1.PeopleService.People;
 import com.google.api.services.people.v1.PeopleService.People.Connections;
@@ -36,9 +29,6 @@ import com.google.api.services.people.v1.model.PersonResponse;
 import com.google.api.services.people.v1.model.Source;
 import ezvcard.VCard;
 import ezvcard.io.json.JCardReader;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
 import org.dataportabilityproject.spi.transfer.types.ContinuationData;
 import org.dataportabilityproject.spi.transfer.types.ExportInformation;
@@ -49,6 +39,18 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.PERSON_FIELDS;
+import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.SELF_RESOURCE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class GoogleContactsExporterTest {
 
@@ -95,7 +97,7 @@ public class GoogleContactsExporterTest {
     // Looking at first page, with at least one page after it
     listConnectionsResponse.setNextPageToken(NEXT_PAGE_TOKEN);
 
-    ExportResult<ContactsModelWrapper> result = contactsService.export(null);
+    ExportResult<ContactsModelWrapper> result = contactsService.export(UUID.randomUUID(), null);
 
     // Check that correct methods were called
     verify(connections).list(SELF_RESOURCE);
@@ -107,8 +109,9 @@ public class GoogleContactsExporterTest {
     // Check continuation data
     ContinuationData continuationData = (ContinuationData) result.getContinuationData();
     assertThat(continuationData.getContainerResources()).isEmpty();
-    StringPaginationToken paginationToken = (StringPaginationToken) ((ContinuationData) result
-        .getContinuationData()).getPaginationData();
+    StringPaginationToken paginationToken =
+        (StringPaginationToken)
+            ((ContinuationData) result.getContinuationData()).getPaginationData();
     assertThat(paginationToken.getToken()).isEqualTo(NEXT_PAGE_TOKEN);
 
     // Check that the right number of VCards was returned
@@ -129,7 +132,8 @@ public class GoogleContactsExporterTest {
     when(listConnectionsRequest.setPageToken(NEXT_PAGE_TOKEN)).thenReturn(listConnectionsRequest);
 
     // Run test
-    ExportResult<ContactsModelWrapper> result = contactsService.export(null, exportInformation);
+    ExportResult<ContactsModelWrapper> result =
+        contactsService.export(UUID.randomUUID(), null, exportInformation);
 
     // Verify correct calls were made - i.e., token was added before execution
     InOrder inOrder = Mockito.inOrder(listConnectionsRequest);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/contacts/GoogleContactsImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/dataportabilityproject/datatransfer/google/contacts/GoogleContactsImporterTest.java
@@ -16,6 +16,21 @@
 
 package org.dataportabilityproject.datatransfer.google.contacts;
 
+import com.google.api.services.people.v1.PeopleService;
+import com.google.api.services.people.v1.PeopleService.People;
+import com.google.api.services.people.v1.PeopleService.People.CreateContact;
+import com.google.api.services.people.v1.model.Person;
+import ezvcard.VCard;
+import ezvcard.property.StructuredName;
+import org.dataportabilityproject.types.transfer.models.contacts.ContactsModelWrapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
 import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.CONTACT_SOURCE_TYPE;
 import static org.dataportabilityproject.datatransfer.google.common.GoogleStaticObjects.SOURCE_PARAM_NAME_TYPE;
 import static org.mockito.Matchers.any;
@@ -23,19 +38,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import com.google.api.services.people.v1.PeopleService;
-import com.google.api.services.people.v1.PeopleService.People;
-import com.google.api.services.people.v1.PeopleService.People.CreateContact;
-import com.google.api.services.people.v1.model.Person;
-import ezvcard.VCard;
-import ezvcard.property.StructuredName;
-import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
-import org.dataportabilityproject.types.transfer.models.contacts.ContactsModelWrapper;
-import org.junit.Before;
-import org.junit.Test;
 
 public class GoogleContactsImporterTest {
 
@@ -73,7 +75,7 @@ public class GoogleContactsImporterTest {
     ContactsModelWrapper wrapper = new ContactsModelWrapper(vCardString);
 
     // Run test
-    contactsService.importItem("jobId", null, wrapper);
+    contactsService.importItem(UUID.randomUUID(), null, wrapper);
 
     // Check that the right methods were called
     verify(people, times(numberOfVCards)).createContact(any(Person.class));

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/calendar/MicrosoftCalendarExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/calendar/MicrosoftCalendarExporter.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.dataportabilityproject.transfer.microsoft.transformer.TransformConstants.CALENDAR_ID;
 
@@ -65,7 +66,7 @@ public class MicrosoftCalendarExporter
   }
 
   @Override
-  public ExportResult<CalendarContainerResource> export(TokenAuthData authData) {
+  public ExportResult<CalendarContainerResource> export(UUID jobId, TokenAuthData authData) {
     Request.Builder calendarsBuilder = getBuilder(baseUrl + CALENDARS_SUBPATH, authData);
 
     List<CalendarModel> calendarModels = new ArrayList<>();
@@ -161,7 +162,7 @@ public class MicrosoftCalendarExporter
 
   @Override
   public ExportResult<CalendarContainerResource> export(
-      TokenAuthData authData, ExportInformation exportInformation) {
+      UUID jobId, TokenAuthData authData, ExportInformation exportInformation) {
     // TODO support pagination
     throw new UnsupportedOperationException();
   }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/calendar/MicrosoftCalendarImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/calendar/MicrosoftCalendarImporter.java
@@ -69,12 +69,11 @@ public class MicrosoftCalendarImporter
   @SuppressWarnings("unchecked")
   @Override
   public ImportResult importItem(
-      String jobId, TokenAuthData authData, CalendarContainerResource data) {
-    UUID id = UUID.fromString(jobId);
-    TempCalendarData calendarMappings = jobStore.findData(TempCalendarData.class, id);
+          UUID jobId, TokenAuthData authData, CalendarContainerResource data) {
+    TempCalendarData calendarMappings = jobStore.findData(TempCalendarData.class, jobId);
     if (calendarMappings == null) {
-      calendarMappings = new TempCalendarData(jobId);
-      jobStore.create(id, calendarMappings);
+      calendarMappings = new TempCalendarData(jobId.toString());
+      jobStore.create(jobId, calendarMappings);
     }
 
     Map<String, String> requestIdToExportedId = new HashMap<>();
@@ -123,7 +122,7 @@ public class MicrosoftCalendarImporter
       calendarMappings.addIdMapping(
           requestIdToExportedId.get(batchRequestId), (String) body.get("id"));
     }
-    jobStore.update(UUID.fromString(jobId), calendarMappings);
+    jobStore.update(jobId, calendarMappings);
 
     List<Map<String, Object>> eventRequests = new ArrayList<>();
     requestId = 1;

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/calendar/MicrosoftCalendarImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/calendar/MicrosoftCalendarImporter.java
@@ -72,7 +72,7 @@ public class MicrosoftCalendarImporter
           UUID jobId, TokenAuthData authData, CalendarContainerResource data) {
     TempCalendarData calendarMappings = jobStore.findData(TempCalendarData.class, jobId);
     if (calendarMappings == null) {
-      calendarMappings = new TempCalendarData(jobId.toString());
+      calendarMappings = new TempCalendarData(jobId);
       jobStore.create(jobId, calendarMappings);
     }
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/contacts/MicrosoftContactsExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/contacts/MicrosoftContactsExporter.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /** Exports Microsoft contacts using the Graph API. */
 public class MicrosoftContactsExporter implements Exporter<TokenAuthData, ContactsModelWrapper> {
@@ -48,7 +49,10 @@ public class MicrosoftContactsExporter implements Exporter<TokenAuthData, Contac
   private final TransformerService transformerService;
 
   public MicrosoftContactsExporter(
-      String baseUrl, OkHttpClient client, ObjectMapper objectMapper, TransformerService transformerService) {
+      String baseUrl,
+      OkHttpClient client,
+      ObjectMapper objectMapper,
+      TransformerService transformerService) {
     this.contactsUrl = baseUrl + CONTACTS_SUBPATH;
     this.client = client;
     this.objectMapper = objectMapper;
@@ -56,17 +60,17 @@ public class MicrosoftContactsExporter implements Exporter<TokenAuthData, Contac
   }
 
   @Override
-  public ExportResult<ContactsModelWrapper> export(TokenAuthData authData) {
+  public ExportResult<ContactsModelWrapper> export(UUID jobId, TokenAuthData authData) {
     return doExport(authData, contactsUrl);
   }
 
   @Override
   public ExportResult<ContactsModelWrapper> export(
-      TokenAuthData authData, ExportInformation continuationData) {
+      UUID jobId, TokenAuthData authData, ExportInformation continuationData) {
     GraphPagination graphPagination = (GraphPagination) continuationData.getPaginationData();
     if (graphPagination != null && graphPagination.getNextLink() != null) {
       return doExport(authData, graphPagination.getNextLink());
-    }else {
+    } else {
       return doExport(authData, contactsUrl);
     }
   }
@@ -105,7 +109,7 @@ public class MicrosoftContactsExporter implements Exporter<TokenAuthData, Contac
 
   private ContactsModelWrapper transform(List<Map<String, Object>> rawContacts) {
     StringWriter stringWriter = new StringWriter();
-    try (JCardWriter writer = new JCardWriter(stringWriter) ) {
+    try (JCardWriter writer = new JCardWriter(stringWriter)) {
       for (Map<String, Object> rawContact : rawContacts) {
         TransformResult<VCard> result = transformerService.transform(VCard.class, rawContact);
         if (result.hasProblems()) {

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/contacts/MicrosoftContactsImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/dataportabilityproject/transfer/microsoft/contacts/MicrosoftContactsImporter.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static java.util.stream.Collectors.toList;
 import static org.dataportabilityproject.transfer.microsoft.common.RequestHelper.batchRequest;
@@ -61,7 +62,7 @@ public class MicrosoftContactsImporter implements Importer<TokenAuthData, Contac
 
   @Override
   public ImportResult importItem(
-      String jobId, TokenAuthData authData, ContactsModelWrapper wrapper) {
+          UUID jobId, TokenAuthData authData, ContactsModelWrapper wrapper) {
     JCardReader reader = new JCardReader(wrapper.getVCards());
     try {
       List<VCard> cards = reader.readAll();

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/integration/LocalExportTestRunner.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/integration/LocalExportTestRunner.java
@@ -7,6 +7,8 @@ import org.dataportabilityproject.transfer.microsoft.MicrosoftTransferExtension;
 import org.dataportabilityproject.types.transfer.auth.TokenAuthData;
 import org.dataportabilityproject.types.transfer.models.contacts.ContactsModelWrapper;
 
+import java.util.UUID;
+
 /** Runs a contacts export using a local setup. */
 @Deprecated
 public class LocalExportTestRunner {
@@ -20,6 +22,6 @@ public class LocalExportTestRunner {
 
     Exporter<TokenAuthData, ContactsModelWrapper> contacts =
         (Exporter<TokenAuthData, ContactsModelWrapper>) serviceProvider.getExporter("contacts");
-    ExportResult<ContactsModelWrapper> wrapper = contacts.export(token);
+    ExportResult<ContactsModelWrapper> wrapper = contacts.export(UUID.randomUUID(), token);
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/integration/LocalImportTestRunner.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/integration/LocalImportTestRunner.java
@@ -18,14 +18,16 @@ package org.dataportabilityproject.transfer.microsoft.integration;
 import ezvcard.VCard;
 import ezvcard.io.json.JCardWriter;
 import ezvcard.property.StructuredName;
-import java.io.IOException;
-import java.io.StringWriter;
 import org.dataportabilityproject.auth.microsoft.harness.AuthTestDriver;
 import org.dataportabilityproject.spi.transfer.provider.ImportResult;
 import org.dataportabilityproject.spi.transfer.provider.Importer;
 import org.dataportabilityproject.transfer.microsoft.MicrosoftTransferExtension;
 import org.dataportabilityproject.types.transfer.auth.TokenAuthData;
 import org.dataportabilityproject.types.transfer.models.contacts.ContactsModelWrapper;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.UUID;
 
 /** */
 public class LocalImportTestRunner {
@@ -40,7 +42,7 @@ public class LocalImportTestRunner {
         (Importer<TokenAuthData, ContactsModelWrapper>) serviceProvider.getImporter("contacts");
 
     ContactsModelWrapper wrapper = new ContactsModelWrapper(createCards());
-    ImportResult result = contacts.importItem("1", token, wrapper);
+    ImportResult result = contacts.importItem(UUID.randomUUID(), token, wrapper);
   }
 
   private static String createCards() throws IOException {

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/integration/MicrosoftCalendarExportTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/integration/MicrosoftCalendarExportTest.java
@@ -30,6 +30,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.UUID;
+
 /**
  * Verifies Calendar export using mock HTTP endpoints that replay responses from the Microsoft Graph
  * API.
@@ -231,7 +233,7 @@ public class MicrosoftCalendarExportTest {
     MicrosoftCalendarExporter exporter =
         new MicrosoftCalendarExporter(baseUrl.toString(), client, mapper, transformerService);
 
-    ExportResult<CalendarContainerResource> resource = exporter.export(token);
+    ExportResult<CalendarContainerResource> resource = exporter.export(UUID.randomUUID(), token);
 
     CalendarContainerResource calendarResource = resource.getExportedData();
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/integration/MicrosoftCalendarImportTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/integration/MicrosoftCalendarImportTest.java
@@ -218,7 +218,7 @@ public class MicrosoftCalendarImportTest {
     CalendarContainerResource resource =
         new CalendarContainerResource(singleton(calendarModel), singleton(eventModel));
 
-    ImportResult result = importer.importItem(JOB_ID.toString(), token, resource);
+    ImportResult result = importer.importItem(JOB_ID, token, resource);
 
     Assert.assertEquals(ImportResult.ResultType.OK, result.getType());
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/types/TempCalendarDataTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/dataportabilityproject/transfer/microsoft/types/TempCalendarDataTest.java
@@ -1,25 +1,28 @@
 package org.dataportabilityproject.transfer.microsoft.types;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Collections;
 import org.dataportabilityproject.spi.transfer.types.TempCalendarData;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.UUID;
+
 /** */
 public class TempCalendarDataTest {
+  private static final UUID JOB_ID = UUID.fromString("9b969983-a09b-4cb0-8017-7daae758126b");
 
   @Test
   public void verifySerializeDeserialize() throws Exception {
     ObjectMapper objectMapper = new ObjectMapper();
 
     TempCalendarData calendarData =
-        new TempCalendarData("job1", Collections.singletonMap("old1", "new1"));
+        new TempCalendarData(JOB_ID, Collections.singletonMap("old1", "new1"));
     String serialized = objectMapper.writeValueAsString(calendarData);
 
     TempCalendarData deserialized = objectMapper.readValue(serialized, TempCalendarData.class);
 
-    Assert.assertEquals("job1", deserialized.getJobId());
+    Assert.assertEquals(JOB_ID, deserialized.getJobId());
     Assert.assertEquals("new1", deserialized.getImportedId("old1"));
   }
 }

--- a/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/provider/Exporter.java
+++ b/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/provider/Exporter.java
@@ -19,21 +19,24 @@ import org.dataportabilityproject.spi.transfer.types.ExportInformation;
 import org.dataportabilityproject.types.transfer.auth.AuthData;
 import org.dataportabilityproject.types.transfer.models.DataModel;
 
+import java.util.UUID;
+
 /** Exports data from a source service. */
 public interface Exporter<A extends AuthData, T extends DataModel> {
   // TODO: reconsider this model - can we avoid sending AuthData with every export call?
 
   /** Performs an export operation. */
-  ExportResult<T> export(A authData);
+  ExportResult<T> export(UUID jobId, A authData);
 
   /**
    * Performs an export operation, starting from the data specified by the continuation.
    *
+   * @param jobId the job id
    * @param authData authentication data for the operation
    * @param exportInformation info about what data to export see {@link ExportInformation} for more
    *     info
    */
   // REVIEW: The original throws IOException. Continue to use checked
   // exceptions or use unchecked?
-  ExportResult<T> export(A authData, ExportInformation exportInformation);
+  ExportResult<T> export(UUID jobId, A authData, ExportInformation exportInformation);
 }

--- a/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/provider/Importer.java
+++ b/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/provider/Importer.java
@@ -18,6 +18,8 @@ package org.dataportabilityproject.spi.transfer.provider;
 import org.dataportabilityproject.types.transfer.auth.AuthData;
 import org.dataportabilityproject.types.transfer.models.DataModel;
 
+import java.util.UUID;
+
 /** Imports data into a destination service. */
 public interface Importer<A extends AuthData, T extends DataModel> {
   /**
@@ -29,5 +31,5 @@ public interface Importer<A extends AuthData, T extends DataModel> {
    * @return the operation result
    */
   // REVIEW: The original throws IOException. Continue to use or return as part of the result?
-  ImportResult importItem(String jobId, A authData, T data);
+  ImportResult importItem(UUID jobId, A authData, T data);
 }

--- a/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/types/TempCalendarData.java
+++ b/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/types/TempCalendarData.java
@@ -18,9 +18,11 @@ package org.dataportabilityproject.spi.transfer.types;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.dataportabilityproject.types.transfer.models.DataModel;
+
 import java.util.HashMap;
 import java.util.Map;
-import org.dataportabilityproject.types.transfer.models.DataModel;
+import java.util.UUID;
 
 /**
  * Temporary data for calendar export/import.
@@ -32,26 +34,26 @@ import org.dataportabilityproject.types.transfer.models.DataModel;
 public class TempCalendarData extends DataModel {
 
   @JsonProperty("jobId")
-  private final String jobId;
+  private final UUID jobId;
 
   @JsonProperty("calendarMappings")
   private final Map<String, String> calendarMappings;
 
   @JsonCreator
   public TempCalendarData(
-      @JsonProperty("jobId") String jobId,
+      @JsonProperty("jobId") UUID jobId,
       @JsonProperty("calendarMappings") Map<String, String> calendarMappings) {
     this.jobId = jobId;
     this.calendarMappings = calendarMappings;
   }
 
-  public TempCalendarData(String jobId) {
+  public TempCalendarData(UUID jobId) {
     this.jobId = jobId;
     calendarMappings = new HashMap<>();
   }
 
   /** Returns the job id this data is associated with. */
-  public String getJobId() {
+  public UUID getJobId() {
     return jobId;
   }
 

--- a/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/types/TempPhotosData.java
+++ b/portability-spi-transfer/src/main/java/org/dataportabilityproject/spi/transfer/types/TempPhotosData.java
@@ -23,6 +23,7 @@ import org.dataportabilityproject.types.transfer.models.photos.PhotoAlbum;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /*
  * TempPhotosData used to store album and photos information before they are ready to be uploaded.
@@ -31,7 +32,7 @@ import java.util.Map;
 public class TempPhotosData extends DataModel {
 
   @JsonProperty("jobId")
-  private final String jobId;
+  private final UUID jobId;
 
   // Map of PhotoAlbums keyed by Album name.
   @JsonProperty("photoAlbums")
@@ -42,7 +43,7 @@ public class TempPhotosData extends DataModel {
   private final Map<String, String> newAlbumIds;
 
   public TempPhotosData(
-      @JsonProperty("jobId") String jobId,
+      @JsonProperty("jobId") UUID jobId,
       @JsonProperty("albums") Map<String, PhotoAlbum> photoAlbums,
       @JsonProperty("newAlbumIds") Map<String, String> newAlbumIds) {
     this.jobId = jobId;
@@ -50,7 +51,7 @@ public class TempPhotosData extends DataModel {
     this.newAlbumIds = newAlbumIds;
   }
 
-  public TempPhotosData(@JsonProperty("jobId") String jobId) {
+  public TempPhotosData(@JsonProperty("jobId") UUID jobId) {
     this.jobId = jobId;
     this.photoAlbums = new HashMap<>();
     this.newAlbumIds = new HashMap<>();

--- a/portability-worker/src/main/java/org/dataportabilityproject/worker/PortabilityInMemoryDataCopier.java
+++ b/portability-worker/src/main/java/org/dataportabilityproject/worker/PortabilityInMemoryDataCopier.java
@@ -86,7 +86,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
     logger.debug("Finished export, results: {}", exportResult);
 
     logger.debug("Starting import");
-    importer.get().importItem(jobId.toString(), importAuthData, exportResult.getExportedData());
+    importer.get().importItem(jobId, importAuthData, exportResult.getExportedData());
     logger.debug("Finished import");
 
     ContinuationData continuationData = (ContinuationData) exportResult.getContinuationData();

--- a/portability-worker/src/main/java/org/dataportabilityproject/worker/PortabilityInMemoryDataCopier.java
+++ b/portability-worker/src/main/java/org/dataportabilityproject/worker/PortabilityInMemoryDataCopier.java
@@ -16,11 +16,6 @@
 package org.dataportabilityproject.worker;
 
 import com.google.inject.Provider;
-import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.inject.Inject;
-
 import org.dataportabilityproject.spi.transfer.InMemoryDataCopier;
 import org.dataportabilityproject.spi.transfer.provider.ExportResult;
 import org.dataportabilityproject.spi.transfer.provider.Exporter;
@@ -32,22 +27,26 @@ import org.dataportabilityproject.types.transfer.models.ContainerResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
 /** Implementation of {@link InMemoryDataCopier}. */
 final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
   private static final AtomicInteger COPY_ITERATION_COUNTER = new AtomicInteger();
   private static final Logger logger = LoggerFactory.getLogger(PortabilityInMemoryDataCopier.class);
 
   /**
-   * Lazy evaluate exporter and importer as their providers depend on the polled
-   * {@code PortabilityJob} which is not available at startup.
+   * Lazy evaluate exporter and importer as their providers depend on the polled {@code
+   * PortabilityJob} which is not available at startup.
    */
   private final Provider<Exporter> exporter;
+
   private final Provider<Importer> importer;
 
   @Inject
-  public PortabilityInMemoryDataCopier(
-      Provider<Exporter> exporter,
-      Provider<Importer> importer) {
+  public PortabilityInMemoryDataCopier(Provider<Exporter> exporter, Provider<Importer> importer) {
     this.exporter = exporter;
     this.importer = importer;
   }
@@ -73,8 +72,10 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
    * @param exportInformation Any pagination or resource information to use for subsequent calls.
    */
   private void copyHelper(
-      UUID jobId, AuthData exportAuthData, AuthData importAuthData, ExportInformation exportInformation)
-      throws IOException {
+      UUID jobId,
+      AuthData exportAuthData,
+      AuthData importAuthData,
+      ExportInformation exportInformation) {
 
     logger.debug("copy iteration: {}", COPY_ITERATION_COUNTER.incrementAndGet());
 
@@ -82,7 +83,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
     // then do sub resources, this ensures all parents are populated before children get
     // processed.
     logger.debug("Starting export, ExportInformation: {}", exportInformation);
-    ExportResult<?> exportResult = exporter.get().export(exportAuthData, exportInformation);
+    ExportResult<?> exportResult = exporter.get().export(jobId, exportAuthData, exportInformation);
     logger.debug("Finished export, results: {}", exportResult);
 
     logger.debug("Starting import");


### PR DESCRIPTION
This PR propagates the Job ID to the exporter which is needed for storing temp data in the JobStore (e.g. for streaming photo content).

This should be applied after #205.

