### PR TITLE
Fix for one of the issues running the client build on Ubuntu

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -55,6 +55,7 @@ task installHostAngularCli(type: Exec) {
 task buildHostWebApp(type: Exec) {
     group = BasePlugin.BUILD_GROUP
     description = "Builds the client webapp using the host Angular CLI installation"
+    dependsOn npmInstall
     workingDir "$projectDir"
     inputs.dir "$projectDir"
     if (System.getProperty("os.name").toUpperCase().contains("WINDOWS")) {


### PR DESCRIPTION
The local build variant that automatically installs node does not work on Ubuntu.

In the meantime, this PR fixes an issue with using the node version that is installed on the host build machine.

From a clean Ubuntu 16.04 image, I installed the following: 

1. Docker
https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04

2. JDK 8 (Make sure to install the JDK, not JRE)
https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-get-on-ubuntu-16-04

3. Node global install -follow the section "How To Install Using a PPA"
https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-16-04

4. Angular cli global install
sudo npm install -g @ angular/cli

Then run:
./gradlew -PcloudType=local -PnodeType=host clean check shadowJar :distributions:demo-server:dockerize
