### PR TITLE
Small fix & documentation to get Instagram export working

### DIFF
--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     compile project(':extensions:auth:portability-auth-instagram')
 
     compile project(':extensions:data-transfer:portability-data-transfer-google')
+    compile project(':extensions:data-transfer:portability-data-transfer-instagram')
     compile project(':extensions:data-transfer:portability-data-transfer-microsoft')
     compile project(':extensions:data-transfer:portability-data-transfer-flickr')
     compile project(':extensions:data-transfer:portability-data-transfer-rememberthemilk')

--- a/extensions/data-transfer/portability-data-transfer-instagram/src/main/java/org/dataportabilityproject/transfer/instagram/InstagramTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-instagram/src/main/java/org/dataportabilityproject/transfer/instagram/InstagramTransferExtension.java
@@ -70,7 +70,7 @@ public class InstagramTransferExtension implements TransferExtension {
   @Override
   public void initialize(ExtensionContext context) {
     if (initialized) {
-      logger.warn("InstagramTransferExtension already initalized");
+      logger.warn("InstagramTransferExtension already initialized");
       return;
     }
 

--- a/extensions/data-transfer/portability-data-transfer-instagram/src/main/java/org/dataportabilityproject/transfer/instagram/photos/InstagramPhotoExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-instagram/src/main/java/org/dataportabilityproject/transfer/instagram/photos/InstagramPhotoExporter.java
@@ -15,9 +15,7 @@
  */
 package org.dataportabilityproject.transfer.instagram.photos;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
@@ -28,7 +26,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -66,7 +63,7 @@ public class InstagramPhotoExporter implements
   @Override
   public ExportResult<PhotosContainerResource> export(UUID jobId, TokensAndUrlAuthData authData,
       ExportInformation exportInformation) {
-    return exportPhotos(authData, Optional.of(exportInformation.getPaginationData()));
+    return exportPhotos(authData, Optional.ofNullable(exportInformation.getPaginationData()));
   }
 
   private ExportResult<PhotosContainerResource> exportPhotos(TokensAndUrlAuthData authData,

--- a/extensions/data-transfer/portability-data-transfer-instagram/src/main/java/org/dataportabilityproject/transfer/instagram/photos/InstagramPhotoImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-instagram/src/main/java/org/dataportabilityproject/transfer/instagram/photos/InstagramPhotoImporter.java
@@ -31,6 +31,7 @@ public class InstagramPhotoImporter implements
   @Override
   public ImportResult importItem(UUID jobId, TokensAndUrlAuthData authData,
       PhotosContainerResource data) {
-    return null; // TODO: implement
+    // TODO(#337): Import is not supported for Instagram since their API does not support upload
+    return null;
   }
 }


### PR DESCRIPTION
Small fix & documentation to get Instagram export working in the demo server.

Successfully exported photos from Instagram to Google.

Fixes #285 