### PR TITLE
split up listServices into listImportServices and listExportServices, to allow for services that want to provide export only.

### DIFF
--- a/portability-api/src/main/java/org/dataportabilityproject/api/action/listservices/ListServicesAction.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/api/action/listservices/ListServicesAction.java
@@ -17,7 +17,6 @@ package org.dataportabilityproject.api.action.listservices;
 
 import com.google.inject.Inject;
 import java.util.Set;
-
 import org.dataportabilityproject.api.action.Action;
 import org.dataportabilityproject.api.action.ActionUtils;
 import org.dataportabilityproject.spi.api.auth.AuthServiceProviderRegistry;
@@ -30,8 +29,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class ListServicesAction
     implements Action<ListServicesActionRequest, ListServicesActionResponse> {
-
-  private static final Logger logger = LoggerFactory.getLogger(ListServicesAction.class);
 
   private final AuthServiceProviderRegistry registry;
 
@@ -49,10 +46,14 @@ public final class ListServicesAction
       return ListServicesActionResponse.createWithError(
           "Invalid transferDataType: " + transferDataType);
     }
-    Set<String> services = registry.getServices(transferDataType);
-    if (services.isEmpty()) {
-      logger.warn("Empty service list found");
+
+    Set<String> importServices = registry.getImportServices(transferDataType);
+    Set<String> exportServices = registry.getExportServices(transferDataType);
+
+    if (importServices.isEmpty() || exportServices.isEmpty()) {
+      return ListServicesActionResponse.createWithError(
+          "[" + transferDataType + "] does not have an import and export service");
     }
-    return ListServicesActionResponse.create(services);
+    return ListServicesActionResponse.create(importServices, exportServices);
   }
 }

--- a/portability-api/src/main/java/org/dataportabilityproject/api/action/listservices/ListServicesActionResponse.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/api/action/listservices/ListServicesActionResponse.java
@@ -17,30 +17,38 @@ package org.dataportabilityproject.api.action.listservices;
 
 import java.util.Set;
 
-/** The result of a request to list services available for export and import. */
+/** The result of a request to list importServices available for export and import. */
 public class ListServicesActionResponse {
 
-  private final Set<String> services;
+  private final Set<String> importServices;
+  private final Set<String> exportServices;
   private final String errorMsg;
 
-  private ListServicesActionResponse(Set<String> services, String errorMsg) {
-    this.services = services;
+  private ListServicesActionResponse(
+      Set<String> importServices, Set<String> exportServices, String errorMsg) {
+    this.importServices = importServices;
+    this.exportServices = exportServices;
     this.errorMsg = errorMsg;
   }
 
-  public static final ListServicesActionResponse create(Set<String> services) {
-    return new ListServicesActionResponse(services, null);
+  public static final ListServicesActionResponse create(
+      Set<String> importServices, Set<String> exportServices) {
+    return new ListServicesActionResponse(importServices, exportServices, null);
   }
 
   public static final ListServicesActionResponse createWithError(String errorMsg) {
-    return new ListServicesActionResponse(null, errorMsg);
+    return new ListServicesActionResponse(null, null, errorMsg);
   }
 
-  public Set<String> getServices() {
-    return services;
+  public Set<String> getImportServices() {
+    return importServices;
   }
 
   public String getErrorMsg() {
     return errorMsg;
+  }
+
+  public Set<String> getExportServices() {
+    return exportServices;
   }
 }

--- a/portability-api/src/main/java/org/dataportabilityproject/api/reference/ListServicesHandler.java
+++ b/portability-api/src/main/java/org/dataportabilityproject/api/reference/ListServicesHandler.java
@@ -29,8 +29,8 @@ import java.nio.charset.StandardCharsets;
 import org.dataportabilityproject.api.action.listservices.ListServicesAction;
 import org.dataportabilityproject.api.action.listservices.ListServicesActionRequest;
 import org.dataportabilityproject.api.action.listservices.ListServicesActionResponse;
-import org.dataportabilityproject.api.reference.ReferenceApiUtils.HttpMethods;
 import org.dataportabilityproject.api.launcher.TypeManager;
+import org.dataportabilityproject.api.reference.ReferenceApiUtils.HttpMethods;
 import org.dataportabilityproject.types.client.transfer.ListServicesResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,9 +67,10 @@ final class ListServicesHandler implements HttpHandler {
       return;
     }
 
-    // TODO: Determine if export and import services should remain separate in the response
-    String[] services = actionResponse.getServices().toArray(new String[0]);
-    ListServicesResponse response = new ListServicesResponse(transferDataType, services, services);
+    String[] importServices = actionResponse.getImportServices().toArray(new String[0]);
+    String[] exportServices = actionResponse.getExportServices().toArray(new String[0]);
+    ListServicesResponse response =
+        new ListServicesResponse(transferDataType, exportServices, importServices);
 
     // Set response as type json
     Headers headers = exchange.getResponseHeaders();

--- a/portability-spi-api/src/main/java/org/dataportabilityproject/spi/api/auth/AuthServiceProviderRegistry.java
+++ b/portability-spi-api/src/main/java/org/dataportabilityproject/spi/api/auth/AuthServiceProviderRegistry.java
@@ -22,7 +22,8 @@ public interface AuthServiceProviderRegistry {
    *
    * @param transferDataType the transfer data type
    */
-  Set<String> getServices(String transferDataType);
+  Set<String> getImportServices(String transferDataType);
+  Set<String> getExportServices(String transferDataType);
 
   /** Returns the set of data types that support both import and export. */
   Set<String> getTransferDataTypes();

--- a/portability-spi-api/src/main/java/org/dataportabilityproject/spi/api/auth/AuthServiceProviderRegistry.java
+++ b/portability-spi-api/src/main/java/org/dataportabilityproject/spi/api/auth/AuthServiceProviderRegistry.java
@@ -18,11 +18,17 @@ public interface AuthServiceProviderRegistry {
   AuthDataGenerator getAuthDataGenerator(String serviceId, String transferDataType, AuthMode mode);
 
   /**
-   * Returns the set of service ids that can transfered for the given {@code transferDataType}.
+   * Returns the set of service ids that can import the given {@code transferDataType}.
    *
    * @param transferDataType the transfer data type
    */
   Set<String> getImportServices(String transferDataType);
+
+  /**
+   * Returns the set of service ids that can export the given {@code transferDataType}.
+   *
+   * @param transferDataType the transfer data type
+   */
   Set<String> getExportServices(String transferDataType);
 
   /** Returns the set of data types that support both import and export. */


### PR DESCRIPTION
Import only is NOT supported, and is checked for on creation of the AuthProviderRegistry

#337 