### PR TITLE
Fix copy creds in api gradle file for running locally against GCP 

### DIFF
--- a/distributions/demo-google-deployment/api/build.gradle
+++ b/distributions/demo-google-deployment/api/build.gradle
@@ -139,11 +139,9 @@ task dockerize(type: DockerBuildImage) {
 // Note: This service acct creds file should be used for local developmemt only. In production, we
 // use GOOGLE_APPLICATION_CREDENTIALS which is stored as a Kubernetes secret. Hence this is only
 // called from createApiServerDockerfileLocal and NOT the production createApiServerDockerfile.
-task copyApiServerDepsLocal {
-    copy {
-        from '../bin/service_acct_creds.json'
-        into 'build'
-    }
+task copyApiServerDepsLocal(type: Copy) {
+    from '/tmp/service_acct_creds.json'
+    into 'build/libs/'
 }
 
 task createApiServerDockerfileLocal(type: Dockerfile) {
@@ -154,6 +152,7 @@ task createApiServerDockerfileLocal(type: Dockerfile) {
     from "gcr.io/google-appengine/openjdk:8"
     exposePort 8080 // Port the API server is accessed from
     copyFile("build/libs/api-all.jar", "/app/api.jar")
+    copyFile("build/libs/service_acct_creds.json", '/service_acct_creds.json')
 
     // Note: Debug port, project ID, and service_acct_creds.json set in the image are for local
     // only. This is not secure for an image deployed to production. In production,
@@ -163,10 +162,9 @@ task createApiServerDockerfileLocal(type: Dockerfile) {
     exposePort 5005 // Port to open up for the debugger
     defaultCommand("java",
             "-Xdebug",
-            "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005",
+            "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005",
             "-jar",
             "/app/api.jar")
-    copyFile("build/service_acct_creds.json", '/service_acct_creds.json')
     ext.gcpProject = project.hasProperty('gcpProject') ? gcpProject : 'missing-project-please-specify-one'
     environmentVariable('GOOGLE_PROJECT_ID', ext.gcpProject)
     environmentVariable('GOOGLE_APPLICATION_CREDENTIALS', '/service_acct_creds.json')


### PR DESCRIPTION
Fix copy creds in api gradle file for running locally against GCP test project #392 