### PR TITLE
Fix bug where worker would die after failing to claim a job

### DIFF
--- a/portability-transfer/src/main/java/org/dataportabilityproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/dataportabilityproject/transfer/JobPollingService.java
@@ -86,9 +86,8 @@ class JobPollingService extends AbstractScheduledService {
     // encrypt and store the private key on the client.
     // Note: tryToClaimJob may fail if another transfer worker beat us to it. That's ok -- this transfer
     // worker will keep polling until it can claim a job.
-    boolean claim = tryToClaimJob(jobId, keyPair);
-    logger.debug("Claim: " + claim);
-    if (claim) {
+    boolean claimed = tryToClaimJob(jobId, keyPair);
+    if (claimed) {
       logger.debug(
           "Updated job {} to CREDS_ENCRYPTION_KEY_GENERATED, publicKey length: {}",
           jobId,
@@ -96,7 +95,8 @@ class JobPollingService extends AbstractScheduledService {
     }
   }
 
-  /** Claims {@link PortabilityJob} {@code jobId} and updates it with our public key in storage. */
+  /** Claims {@link PortabilityJob} {@code jobId} and updates it with our public key in storage.
+   * Returns true if the claim was successful; otherwise it returns false. */
   private boolean tryToClaimJob(UUID jobId, KeyPair keyPair) {
     // Lookup the job so we can append to its existing properties.
     PortabilityJob existingJob = store.findJob(jobId);

--- a/portability-transfer/src/main/java/org/dataportabilityproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/dataportabilityproject/transfer/JobPollingService.java
@@ -60,9 +60,10 @@ class JobPollingService extends AbstractScheduledService {
     }
   }
 
+  // TODO: the delay should be more easily configurable
   @Override
   protected Scheduler scheduler() {
-    return AbstractScheduledService.Scheduler.newFixedDelaySchedule(0, 2, TimeUnit.SECONDS);
+    return AbstractScheduledService.Scheduler.newFixedDelaySchedule(0, 20, TimeUnit.SECONDS);
   }
 
   /**

--- a/portability-transfer/src/main/java/org/dataportabilityproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/dataportabilityproject/transfer/JobPollingService.java
@@ -61,6 +61,7 @@ class JobPollingService extends AbstractScheduledService {
   }
 
   // TODO: the delay should be more easily configurable
+  // https://github.com/google/data-transfer-project/issues/400
   @Override
   protected Scheduler scheduler() {
     return AbstractScheduledService.Scheduler.newFixedDelaySchedule(0, 20, TimeUnit.SECONDS);


### PR DESCRIPTION
When a worker failed to claim a job, it would throw and exception and die.  This fix updates it so that claiming a job is a matter of success/failure, instead of success/exception, and if a worker fails to claim a job, it can continue to poll.