### PR TITLE
Fix a MS build/dependency problem

### DIFF
--- a/extensions/cloud/portability-cloud-microsoft/build.gradle
+++ b/extensions/cloud/portability-cloud-microsoft/build.gradle
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+// TODO: remove this.
+// MS pushed some dependencies out to 1.5.4 but not https://jcenter.bintray.com/com/microsoft/rest/client-runtime/
+// So to make things continue to build we need to swap in the 1.5.3 version of
+// com.microsoft.rest:client-runtime until they publish v 1.5.4
+configurations.all {
+    resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'com.microsoft.rest' && details.requested.name == 'client-runtime') {
+                details.useVersion "1.5.3"
+            }
+        }
+    }
+}
+
 dependencies {
     
     compile project(':portability-spi-cloud')


### PR DESCRIPTION
https://mvnrepository.com/artifact/com.microsoft.azure/azure-client-runtime/1.5.4 got pushed out which relies on 1.5.4 of https://mvnrepository.com/artifact/com.microsoft.rest/client-runtime but the 1.5.4 version of that has not been pushed yet, so forcing it to use 1.5.3