### PR TITLE
Switch to new UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ testem.log
 /e2e/*.js
 /e2e/*.map
 
+client-rest/dist/
+
 # System Files
 .DS_Store
 Thumbs.db

--- a/client-rest/build.gradle
+++ b/client-rest/build.gradle
@@ -29,7 +29,7 @@ task buildLocalWebApp(type: NodeTask) {
     group = BasePlugin.BUILD_GROUP
     description = "Builds the client webapp using the local Angular CLI installation"
     script = file("node_modules/.bin/ng")
-    args = ["build", "--env", "localhttps"]
+    args = ["build"]
 }
 
 

--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -1,8 +1,5 @@
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile
-
-import java.nio.file.Paths
-
 /*
  * Copyright 2018 The Data Transfer Project Authors.
  *
@@ -149,20 +146,20 @@ task createDockerfile(type: Dockerfile) {
 }
 
 task copyWebApp {
-    dependsOn ":client:buildWebApp"
+    dependsOn ":client-rest:buildWebApp"
     doLast {
         group = 'docker'
         // The static webapp must be copied since Docker requires included files to be in a subdirectory relative to where Docker is executed
         copy {
-            from '../../client/build/resources'
+            from '../../client-rest/dist/portability-demo'
             into 'build/webapp/html'
         }
         copy {
-            from '../../client/src/test-keys/server.crt'
+            from '../../client-rest/src/test-keys/server.crt'
             into 'build/webapp/test-keys'
         }
         copy {
-            from '../../client/src/test-keys/server.key'
+            from '../../client-rest/src/test-keys/server.key'
             into 'build/webapp/test-keys'
         }
     }
@@ -179,7 +176,7 @@ task dockerize(type: DockerBuildImage) {
 task installToolsAndDockerize {
     description = 'Installs required build tools and builds the demo Docker image'
     group = 'docker'
-    dependsOn ":client:installTools", dockerize
+    dependsOn ":client-rest:installTools", dockerize
 }
 
 

--- a/distributions/demo-server/src/config/client/nginx.conf
+++ b/distributions/demo-server/src/config/client/nginx.conf
@@ -60,7 +60,7 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
-        location /_/ {
+        location /api/ {
 
            proxy_pass https://localhost:8080;
            add_header  Access-Control-Allow-Origin  *;

--- a/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrAuthDataGenerator.java
@@ -44,7 +44,7 @@ public class FlickrAuthDataGenerator implements AuthDataGenerator {
   @Override
   public AuthFlowConfiguration generateConfiguration(String callbackBaseUrl, String id) {
     AuthInterface authInterface = flickr.getAuthInterface();
-    Token token = authInterface.getRequestToken(callbackBaseUrl + "/callback1/flickr");
+    Token token = authInterface.getRequestToken(callbackBaseUrl + "/callback/flickr");
     String url =
             authInterface.getAuthorizationUrl(
                     token, Permission.WRITE);

--- a/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugAuthDataGenerator.java
@@ -48,7 +48,7 @@ public class SmugMugAuthDataGenerator implements AuthDataGenerator {
     // Generate a request token and include that as initial auth data
     TokenSecretAuthData authData = null;
     try {
-      authData = smugMugOauthInterface.getRequestToken(callbackBaseUrl + "/callback1/smugmug");
+      authData = smugMugOauthInterface.getRequestToken(callbackBaseUrl + "/callback/smugmug");
     } catch (IOException e) {
       logger.warn("Couldnt get authData {}", e.getMessage());
       return null;

--- a/extensions/auth/portability-auth-twitter/src/main/java/org/datatransferproject/auth/twitter/TwitterAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-twitter/src/main/java/org/datatransferproject/auth/twitter/TwitterAuthDataGenerator.java
@@ -55,7 +55,7 @@ final class TwitterAuthDataGenerator implements AuthDataGenerator {
     RequestToken requestToken;
     try {
        requestToken =
-          twitterApi.getOAuthRequestToken(callbackBaseUrl + "/callback1/twitter", perms);
+          twitterApi.getOAuthRequestToken(callbackBaseUrl + "/callback/twitter", perms);
     } catch (TwitterException e) {
       logger.warn("Couldn't get authData", e);
       return null;

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/GetTransferServicesAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/GetTransferServicesAction.java
@@ -56,6 +56,6 @@ public final class GetTransferServicesAction
       throw new IllegalArgumentException(
           "[" + transferDataType + "] does not have an import and export service");
     }
-    return new TransferServices(transferDataType, importServices, exportServices);
+    return new TransferServices(transferDataType, exportServices,importServices);
   }
 }


### PR DESCRIPTION
This PR supersedes the previous one. It switches the build to default to the new UI; adds support for OAuth1 and Legacy Auth in new UI; and fixes a bug where export and import services were transposed.

Note that multiple callback protocols are handled by the same Angular auth component on the client so all extensions may use the same "/callback" base URL. If an extension uses a completely custom auth protocol, the UI can be extended with a custom URL.  