### PR TITLE
Set default transport for our demo to jettyrest

### DIFF
--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -49,7 +49,7 @@ repositories {
     jcenter()
 }
 
-def transportType = project.hasProperty('transportType') ? transportType : "jdk"
+def transportType = project.hasProperty('transportType') ? transportType : "jettyrest"
 def offlineData = project.hasProperty('offlineData') ? offlineData : "false"
 def demoDomain = project.hasProperty('appDomain') ? appDomain : "localhost"
 def appPort = project.hasProperty('appPort') ? appPort : "3000"


### PR DESCRIPTION
since jdk is currently incompatible with new UI, @jimmarino is looking into a fix for that