### PR TITLE
Removed redundant script docker_push.sh

### DIFF
--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-#Script used by Travis to push new docker images to docker hub on PR merge to master.
-
-./gradlew -PcloudType=local :distributions:demo-server:dockerize
-# These environment variables are set via the Travis UI/CLI
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker push datatransferproject/demo


### PR DESCRIPTION
docker_push.sh is already in scripts directory (https://github.com/google/data-transfer-project/tree/master/scripts) 