### PR TITLE
Temporarily disable Angular tests until we implement them for client-rest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,27 +19,27 @@ matrix:
       # Nothing to customize here. Travis knows to use Gradle (including running tests) based on
       # the presence of gradle build file
       language: java
-    - name: "AngularJS"
-      # The AngularJS flow below is customized. There is some nodejs setup to do as well as
-      # configuration to use the version of Chrome that is installed in Travis images.
-      language: node_js
-      node_js:
-        - '8.9'
-      cache:
-        directories:
-          - ./client-rest/node_modules
-      before_script:
-        - cd client-rest
-        - npm install
-        - npm install -g karma
-        - npm install -g @angular/cli
-        - export CHROME_BIN=chromium-browser
-        - export DISPLAY=:99.0
-        - sh -e /etc/init.d/xvfb start
-      script:
-        # TODO: Re-enable Angular tests once they are working for client-rest (#511)
-        # - ng test --single-run --no-progress --browser=ChromeNoSandbox --environment local
-        # - ng e2e --no-progress --config=protractor-ci.conf.js --environment local
+    # TODO: Re-enable Angular tests once they are working for client-rest (#511)
+    # - name: "AngularJS"
+    #  # The AngularJS flow below is customized. There is some nodejs setup to do as well as
+    #  # configuration to use the version of Chrome that is installed in Travis images.
+    #  language: node_js
+    #  node_js:
+    #    - '8.9'
+    #  cache:
+    #    directories:
+    #      - ./client-rest/node_modules
+    #  before_script:
+    #    - cd client-rest
+    #    - npm install
+    #    - npm install -g karma
+    #    - npm install -g @angular/cli
+    #    - export CHROME_BIN=chromium-browser
+    #    - export DISPLAY=:99.0
+    #    - sh -e /etc/init.d/xvfb start
+    #  script:
+    #    - ng test --single-run --no-progress --browser=ChromeNoSandbox --environment local
+    #    - ng e2e --no-progress --config=protractor-ci.conf.js --environment local
     - name: "Demo image"
       # This task will build our demo docker image. It will also deploy the image to docker hub,
       # on merges to master only.

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,9 @@ matrix:
         - export DISPLAY=:99.0
         - sh -e /etc/init.d/xvfb start
       script:
-        - ng test --single-run --no-progress --browser=ChromeNoSandbox --environment local
-        - ng e2e --no-progress --config=protractor-ci.conf.js --environment local
+        # TODO: Re-enable Angular tests once they are working for client-rest (#511)
+        # - ng test --single-run --no-progress --browser=ChromeNoSandbox --environment local
+        # - ng e2e --no-progress --config=protractor-ci.conf.js --environment local
     - name: "Demo image"
       # This task will build our demo docker image. It will also deploy the image to docker hub,
       # on merges to master only.


### PR DESCRIPTION
Previously, they were passing but didn't actually do anything (#511)

Now they are actually failing the build for #517 so I think they should be disabled so we don't block that PR