### PR TITLE
Support serving API requests over HTTP, in addition to HTTPS

### DIFF
--- a/distributions/demo-google-deployment/resources/config/api.yaml
+++ b/distributions/demo-google-deployment/resources/config/api.yaml
@@ -17,3 +17,7 @@
 # API settings for Google cloud common to all environments
 baseUrl: http://localhost:3000 # default to local
 baseApiUrl: http://localhost:8080 # default to local
+# Whether the API server should serve requests using HTTPS. False because we
+# implement HTTPS at the load balancer in front of our API servers and don't
+# need it for communication within our network.
+useHttps: false

--- a/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/JettyRestExtension.java
+++ b/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/JettyRestExtension.java
@@ -35,10 +35,9 @@ public class JettyRestExtension implements ServiceExtension {
 
   @Override
   public void initialize(ExtensionContext context) {
-
     KeyStore keyStore = context.getService(KeyStore.class);
-
-    transport = new JettyTransport(keyStore);
+    boolean useHttps = context.getSetting("useHttps", true);
+    transport = new JettyTransport(keyStore, useHttps);
     binder = new JerseyTransportBinder(transport);
     context.registerService(TransportBinder.class, binder);
   }

--- a/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/http/JettyTransport.java
+++ b/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/http/JettyTransport.java
@@ -48,36 +48,45 @@ public class JettyTransport {
   private static final String LOG_CLASS = "org.eclipse.jetty.util.log.class";
 
   private final KeyStore keyStore;
+  private final boolean useHttps;
 
   private int httpPort = 8080; // TODO configure
 
   private Server server;
   private List<Handler> handlers = new ArrayList<>();
 
-  public JettyTransport(KeyStore keyStore) {
+  public JettyTransport(KeyStore keyStore, boolean useHttps) {
     this.keyStore = keyStore;
+    this.useHttps = useHttps;
     System.setProperty(LOG_CLASS, JettyMonitor.class.getName()); // required by Jetty
     System.setProperty(ANNOUNCE, "false");
+    logger.info("Creating JettyTransport. useHttps=" + useHttps);
   }
 
   public void start() {
-    server = new Server();
-
-    HttpConfiguration https = new HttpConfiguration();
-    https.addCustomizer(new SecureRequestCustomizer());
-    SslContextFactory sslContextFactory = new SslContextFactory();
-    sslContextFactory.setKeyStore(keyStore);
-    sslContextFactory.setKeyStorePassword("password");
-    sslContextFactory.setKeyManagerPassword("password");
-    ServerConnector sslConnector =
-        new ServerConnector(
-            server,
-            new SslConnectionFactory(sslContextFactory, "http/1.1"),
-            new HttpConnectionFactory(https));
-    sslConnector.setPort(httpPort);
-    server.setConnectors(new Connector[] {sslConnector});
+    if (useHttps) {
+      server = new Server();
+      SslContextFactory sslContextFactory = new SslContextFactory();
+      sslContextFactory.setKeyStore(keyStore);
+      sslContextFactory.setKeyStorePassword("password");
+      sslContextFactory.setKeyManagerPassword("password");
+      HttpConfiguration https = new HttpConfiguration();
+      ServerConnector sslConnector =
+              new ServerConnector(
+                      server,
+                      new SslConnectionFactory(sslContextFactory, "http/1.1"),
+                      new HttpConnectionFactory(https));
+      sslConnector.setPort(httpPort);
+      server.setConnectors(new Connector[]{sslConnector});
+    } else {
+      server = new Server(httpPort);
+      ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(new HttpConfiguration()));
+      connector.setPort(httpPort);
+      server.setConnectors(new Connector[]{connector});
+    }
 
     server.setErrorHandler(new JettyErrorHandler());
+
     ContextHandlerCollection contexts = new ContextHandlerCollection();
     contexts.setHandlers(handlers.toArray(new Handler[0]));
     server.setHandler(contexts);

--- a/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/http/JettyTransport.java
+++ b/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/http/JettyTransport.java
@@ -68,6 +68,7 @@ public class JettyTransport {
       server = new Server();
       SslContextFactory sslContextFactory = new SslContextFactory();
       sslContextFactory.setKeyStore(keyStore);
+      // TODO configure
       sslContextFactory.setKeyStorePassword("password");
       sslContextFactory.setKeyManagerPassword("password");
       HttpConfiguration https = new HttpConfiguration();


### PR DESCRIPTION
This is necessary for our demo-google-deployment to work with the Jetty transport.

We can't serve HTTPS since don't have certs installed at our API servers; we have them installed at our LB instead.

Keep the default HTTPS for the demo server.