### PR TITLE
Allow retry library to be read in by including it in the jar

### DIFF
--- a/distributions/demo-google-deployment/transfer/build.gradle
+++ b/distributions/demo-google-deployment/transfer/build.gradle
@@ -83,6 +83,7 @@ task copyConfig(type: Copy) {
     into 'build/resources/main'
     from('../resources') {
         include 'config/common.yaml'
+        include 'config/retry/default.yaml'
     }
 }
 


### PR DESCRIPTION
Note: we could include the whole config folder and all yaml files in the environment folders, but I wasn't sure we wanted to do that, given the values in the other yaml files.  The advantage of including all the yaml files is that YamlSettingsExtension will behave as expected, i.e., all the files that are defined (COMMON_SETTINGS_PATH, ENV_API_SETTINGS_PATH, etc) will actually be read.  Only including a subset of the files in the jar makes it hard to understand what's happening.