### PR TITLE
Define callback URLs in the frontend, rather than API

### DIFF
--- a/client-rest/src/app/transfer/auth-callback.component.ts
+++ b/client-rest/src/app/transfer/auth-callback.component.ts
@@ -3,6 +3,7 @@ import {TransferService} from "./transfer.service";
 import {ProgressService, Step} from "../progress";
 import {ActivatedRoute, Router} from "@angular/router";
 import {transportError} from "../transport";
+import {environment} from "../../environments/environment";
 
 /**
  * Receives callbacks from external OAuth export and import services. Updates the application state with corresponding OAuth tokens.
@@ -33,7 +34,12 @@ export class AuthCallbackComponent implements OnInit {
         if (Step.AUTHENTICATE_EXPORT === this.progressService.currentStep()) {
             // export auth step: received the export auth callback, generate the export auth data from the export token
             // and redirect to the import url. Use SSL as the token is sent cleartext.
-            this.transferService.generateAuthData({id: transferId, authToken: token, mode: "EXPORT"}).subscribe(
+            this.transferService.generateAuthData({
+              id: transferId,
+              authToken: token,
+              mode: "EXPORT",
+              callbackUrl: `${environment.apiBaseUrl}/callback/${this.progressService.exportService().toLowerCase()}`
+            }).subscribe(
             (data => {
                 this.progressService.authExportComplete(data.authData);
 
@@ -44,7 +50,12 @@ export class AuthCallbackComponent implements OnInit {
         } else {
             // import auth step: received the import auth callback, generate the import auth data from the import token
             // and continue the transfer process. Use SSL as the token is sent cleartext.
-            this.transferService.generateAuthData({id: transferId, authToken: token, mode: "IMPORT"}).subscribe(
+            this.transferService.generateAuthData({
+              id: transferId,
+              authToken: token,
+              mode: "IMPORT",
+              callbackUrl: `${environment.apiBaseUrl}/callback/${this.progressService.importService().toLowerCase()}`
+            }).subscribe(
             data => {
                 this.progressService.authImportComplete(data.authData);
 

--- a/client-rest/src/app/transfer/create-transfer.component.ts
+++ b/client-rest/src/app/transfer/create-transfer.component.ts
@@ -49,8 +49,9 @@ export class CreateTransferComponent implements OnInit {
         this.transferService.createTransferJob({
             exportService: this.progressService.exportService(),
             importService: this.progressService.importService(),
+            exportCallbackUrl: `${environment.apiBaseUrl}/callback/${this.progressService.exportService().toLowerCase()}`,
+            importCallbackUrl: `${environment.apiBaseUrl}/callback/${this.progressService.importService().toLowerCase()}`,
             dataType: this.progressService.dataType(),
-            callbackUrl: `${environment.apiBaseUrl}`
         }).subscribe(transferJob => {
             // redirect to OAuth service
             this.progressService.createComplete(transferJob.id, transferJob.exportUrl, transferJob.importUrl);

--- a/client-rest/src/app/types/create-transfer-job.ts
+++ b/client-rest/src/app/types/create-transfer-job.ts
@@ -13,12 +13,17 @@ export interface CreateTransferJob {
     importService: string;
 
     /**
+    * The URL for export auth callback.
+    */
+    exportCallbackUrl: string;
+
+    /**
+    * The URL for import auth callback.
+    */
+    importCallbackUrl: string;
+
+    /**
     * The data type to transfer.
     */
     dataType: string;
-
-    /**
-    * The URL for auth callbacks.
-    */
-    callbackUrl: string;
 }

--- a/client-rest/src/app/types/generate-service-auth-data.ts
+++ b/client-rest/src/app/types/generate-service-auth-data.ts
@@ -5,5 +5,5 @@ export interface GenerateServiceAuthData {
     id: string;
     authToken: string;
     mode: "EXPORT" | "IMPORT";
-
+    callbackUrl: string;
 }

--- a/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrAuthDataGenerator.java
@@ -52,9 +52,9 @@ public class FlickrAuthDataGenerator implements AuthDataGenerator {
   }
 
   @Override
-  public AuthFlowConfiguration generateConfiguration(String callbackBaseUrl, String id) {
+  public AuthFlowConfiguration generateConfiguration(String callbackUrl, String id) {
     AuthInterface authInterface = flickr.getAuthInterface();
-    Token token = authInterface.getRequestToken(callbackBaseUrl + "/callback/flickr");
+    Token token = authInterface.getRequestToken(callbackUrl);
     String url =
             authInterface.getAuthorizationUrl(
                     token, Permission.WRITE);
@@ -63,7 +63,7 @@ public class FlickrAuthDataGenerator implements AuthDataGenerator {
 
   @Override
   public AuthData generateAuthData(
-      String callbackBaseUrl, String authCode, String id, AuthData initialAuthData, String extra) {
+      String callbackUrl, String authCode, String id, AuthData initialAuthData, String extra) {
     Preconditions.checkArgument(Strings.isNullOrEmpty(extra), "Extra data not expected");
     Preconditions.checkNotNull(initialAuthData, "Earlier auth data not expected for Flickr flow");
     AuthInterface authInterface = flickr.getAuthInterface();

--- a/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleAuthServiceExtension.java
+++ b/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleAuthServiceExtension.java
@@ -103,8 +103,7 @@ public class GoogleAuthServiceExtension implements AuthServiceExtension {
       generators.put(
           transferDataType,
           new GoogleAuthDataGenerator(
-              REDIRECT_PATH,
-              appCredentials,
+                  appCredentials,
               httpTransport,
               typeManager.getMapper(),
               transferDataType,

--- a/extensions/auth/portability-auth-google/src/test/java/org/datatransferproject/auth/google/GoogleAuthDataGeneratorTest.java
+++ b/extensions/auth/portability-auth-google/src/test/java/org/datatransferproject/auth/google/GoogleAuthDataGeneratorTest.java
@@ -24,7 +24,7 @@ public class GoogleAuthDataGeneratorTest {
                 appCredentials, httpTransport, null, "CALENDAR", AuthMode.IMPORT);
 
     AuthFlowConfiguration config =
-        generator.generateConfiguration("http://localhost/test", "54321");
+        generator.generateConfiguration("http://localhost/testredirect", "54321");
 
     Assert.assertEquals(
         "https://accounts.google.com/o/oauth2/auth?"
@@ -43,7 +43,7 @@ public class GoogleAuthDataGeneratorTest {
                 appCredentials, httpTransport, null, "CALENDAR", AuthMode.EXPORT);
 
     AuthFlowConfiguration config =
-        generator.generateConfiguration("http://localhost/test", "54321");
+        generator.generateConfiguration("http://localhost/testredirect", "54321");
 
     Assert.assertEquals(
         "https://accounts.google.com/o/oauth2/auth?"

--- a/extensions/auth/portability-auth-google/src/test/java/org/datatransferproject/auth/google/GoogleAuthDataGeneratorTest.java
+++ b/extensions/auth/portability-auth-google/src/test/java/org/datatransferproject/auth/google/GoogleAuthDataGeneratorTest.java
@@ -21,7 +21,7 @@ public class GoogleAuthDataGeneratorTest {
   public void generateConfigurationImport() {
     GoogleAuthDataGenerator generator =
         new GoogleAuthDataGenerator(
-            "redirect", appCredentials, httpTransport, null, "CALENDAR", AuthMode.IMPORT);
+                appCredentials, httpTransport, null, "CALENDAR", AuthMode.IMPORT);
 
     AuthFlowConfiguration config =
         generator.generateConfiguration("http://localhost/test", "54321");
@@ -40,7 +40,7 @@ public class GoogleAuthDataGeneratorTest {
   public void generateConfigurationExport() {
     GoogleAuthDataGenerator generator =
         new GoogleAuthDataGenerator(
-            "redirect", appCredentials, httpTransport, null, "CALENDAR", AuthMode.EXPORT);
+                appCredentials, httpTransport, null, "CALENDAR", AuthMode.EXPORT);
 
     AuthFlowConfiguration config =
         generator.generateConfiguration("http://localhost/test", "54321");

--- a/extensions/auth/portability-auth-harness-microsoft/src/main/java/org/datatransferproject/auth/microsoft/harness/AuthTestDriver.java
+++ b/extensions/auth/portability-auth-harness-microsoft/src/main/java/org/datatransferproject/auth/microsoft/harness/AuthTestDriver.java
@@ -52,7 +52,7 @@ public class AuthTestDriver {
 
     MicrosoftAuthDataGenerator dataGenerator =
         new MicrosoftAuthDataGenerator(
-            "/response", () -> clientId, () -> secret, client, mapper, "CONTACTS", AuthMode.EXPORT);
+                () -> clientId, () -> secret, client, mapper, "CONTACTS", AuthMode.EXPORT);
 
     AuthFlowConfiguration configuration = dataGenerator.generateConfiguration(callbackBase, "1");
 

--- a/extensions/auth/portability-auth-instagram/src/main/java/org/datatransferproject/auth/instagram/InstagramAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-instagram/src/main/java/org/datatransferproject/auth/instagram/InstagramAuthDataGenerator.java
@@ -43,7 +43,6 @@ import static org.datatransferproject.types.common.PortabilityCommon.AuthProtoco
  */
 public class InstagramAuthDataGenerator implements AuthDataGenerator {
   private static final AuthProtocol AUTHORIZATION_PROTOCOL = OAUTH_2;
-  private static final String CALLBACK_PATH = "/callback/instagram";
   private static final String AUTHORIZATION_SERVER_URL =
       "https://api.instagram.com/oauth/authorize";
   private static final String TOKEN_SERVER_URL = "https://api.instagram.com/oauth/access_token";
@@ -57,13 +56,13 @@ public class InstagramAuthDataGenerator implements AuthDataGenerator {
   }
 
   @Override
-  public AuthFlowConfiguration generateConfiguration(String callbackBaseUrl, String id) {
+  public AuthFlowConfiguration generateConfiguration(String callbackUrl, String id) {
     // TODO: move to common location
     String encodedJobId = BaseEncoding.base64Url().encode(id.getBytes(Charsets.UTF_8));
     String url =
         createFlow()
             .newAuthorizationUrl()
-            .setRedirectUri(callbackBaseUrl + CALLBACK_PATH)
+            .setRedirectUri(callbackUrl)
             .setState(encodedJobId)
             .build();
     return new AuthFlowConfiguration(url, AUTHORIZATION_PROTOCOL, getTokenUrl());
@@ -71,7 +70,7 @@ public class InstagramAuthDataGenerator implements AuthDataGenerator {
 
   @Override
   public AuthData generateAuthData(
-      String callbackBaseUrl, String authCode, String id, AuthData initialAuthData, String extra) {
+      String callbackUrl, String authCode, String id, AuthData initialAuthData, String extra) {
     Preconditions.checkArgument(
         Strings.isNullOrEmpty(extra), "Extra data not expected for Instagram oauth flow");
     Preconditions.checkArgument(
@@ -81,7 +80,7 @@ public class InstagramAuthDataGenerator implements AuthDataGenerator {
     try {
       response =
           flow.newTokenRequest(authCode)
-              .setRedirectUri(callbackBaseUrl + CALLBACK_PATH) // TODO(chuy): Parameterize
+              .setRedirectUri(callbackUrl)
               .execute();
     } catch (IOException e) {
       throw new RuntimeException("Error calling AuthorizationCodeFlow.execute ", e);

--- a/extensions/auth/portability-auth-instagram/src/test/java/org/datatransferproject/auth/instagram/InstagramAuthDataGeneratorTest.java
+++ b/extensions/auth/portability-auth-instagram/src/test/java/org/datatransferproject/auth/instagram/InstagramAuthDataGeneratorTest.java
@@ -43,7 +43,7 @@ public class InstagramAuthDataGeneratorTest {
         .isEqualTo(
             "https://api.instagram.com/oauth/authorize"
                 + "?client_id=dummy-id"
-                + "&redirect_uri=http://localhost/test/callback/instagram"
+                + "&redirect_uri=http://localhost/test"
                 + "&response_type=code"
                 + "&scope=basic"
                 + "&state=NTQzMjE%3D");

--- a/extensions/auth/portability-auth-microsoft/src/main/java/org/datatransferproject/auth/microsoft/MicrosoftAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-microsoft/src/main/java/org/datatransferproject/auth/microsoft/MicrosoftAuthDataGenerator.java
@@ -62,7 +62,6 @@ public class MicrosoftAuthDataGenerator implements AuthDataGenerator {
           .put("OFFLINE-DATA", ImmutableList.of("user.read", "Files.Read.All"))
           .build();
 
-  private final String redirectPath;
   private final Supplier<String> clientIdSupplier;
   private final Supplier<String> clientSecretSupplier;
   private final OkHttpClient httpClient;
@@ -71,10 +70,7 @@ public class MicrosoftAuthDataGenerator implements AuthDataGenerator {
 
   /**
    * Ctor.
-   *
-   * @param redirectPath the path part this generator is configured to request OAuth authentication
-   *     code responses be sent to
-   * @param clientIdSupplier The Application ID that the registration portal
+   *  @param clientIdSupplier The Application ID that the registration portal
    *     (apps.dev.microsoft.com) assigned the portability instance
    * @param clientSecretSupplier The application secret that was created in the app registration
    *     portal for the portability instance
@@ -83,17 +79,15 @@ public class MicrosoftAuthDataGenerator implements AuthDataGenerator {
    * @param mode the mode to create this authorization generator for
    */
   public MicrosoftAuthDataGenerator(
-      String redirectPath,
-      Supplier<String> clientIdSupplier,
-      Supplier<String> clientSecretSupplier,
-      OkHttpClient client,
-      ObjectMapper mapper,
-      String transferDataType,
-      AuthMode mode) {
+          Supplier<String> clientIdSupplier,
+          Supplier<String> clientSecretSupplier,
+          OkHttpClient client,
+          ObjectMapper mapper,
+          String transferDataType,
+          AuthMode mode) {
     Preconditions.checkArgument(
         !Strings.isNullOrEmpty(transferDataType) && mode != null,
         "A valid mode and transfer data type must be present");
-    this.redirectPath = redirectPath;
     this.clientIdSupplier = clientIdSupplier;
     this.clientSecretSupplier = clientSecretSupplier;
     httpClient = client;
@@ -104,17 +98,15 @@ public class MicrosoftAuthDataGenerator implements AuthDataGenerator {
             : importAuthScopes.get(transferDataType);
   }
 
-  public AuthFlowConfiguration generateConfiguration(String callbackBaseUrl, String id) {
+  public AuthFlowConfiguration generateConfiguration(String callbackUrl, String id) {
     // constructs a request for the Microsoft Graph authorization code.
-    String redirectUrl = callbackBaseUrl + redirectPath;
-    String queryPart = constructAuthQueryPart(redirectUrl, id, scopes);
+    String queryPart = constructAuthQueryPart(callbackUrl, id, scopes);
     return new AuthFlowConfiguration(AUTHORIZATION_URL + "?" + queryPart, AUTHORIZATION_PROTOCOL, getTokenUrl());
   }
 
   public TokenAuthData generateAuthData(
-      String callbackBaseUrl, String authCode, String id, AuthData initialAuthData, String extra) {
-    String redirectUrl = callbackBaseUrl + redirectPath;
-    String params = constructTokenParams(authCode, redirectUrl, "user.read", "Contacts.ReadWrite");
+      String callbackUrl, String authCode, String id, AuthData initialAuthData, String extra) {
+    String params = constructTokenParams(authCode, callbackUrl, "user.read", "Contacts.ReadWrite");
 
     Request.Builder tokenReqBuilder = new Request.Builder().url(TOKEN_URL);
     tokenReqBuilder.header("Content-Type", "application/x-www-form-urlencoded");

--- a/extensions/auth/portability-auth-microsoft/src/main/java/org/datatransferproject/auth/microsoft/MicrosoftAuthServiceExtension.java
+++ b/extensions/auth/portability-auth-microsoft/src/main/java/org/datatransferproject/auth/microsoft/MicrosoftAuthServiceExtension.java
@@ -38,7 +38,6 @@ import java.util.Map;
  * runtime with a system property: -DofflineData=true
  */
 public class MicrosoftAuthServiceExtension implements AuthServiceExtension {
-  private static final String REDIRECT_PATH = "/callback/microsoft";
   private static final ImmutableList<String> SUPPORTED_SERVICES;
 
   static {
@@ -115,8 +114,7 @@ public class MicrosoftAuthServiceExtension implements AuthServiceExtension {
       authGenerators.put(
           transferDataType,
           new MicrosoftAuthDataGenerator(
-              REDIRECT_PATH,
-              appCredentials::getKey,
+                  appCredentials::getKey,
               appCredentials::getSecret,
               okHttpClient,
               mapper,

--- a/extensions/auth/portability-auth-rememberthemilk/src/main/java/org/datatransferproject/auth/rememberthemilk/RememberTheMilkAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-rememberthemilk/src/main/java/org/datatransferproject/auth/rememberthemilk/RememberTheMilkAuthDataGenerator.java
@@ -82,7 +82,7 @@ public class RememberTheMilkAuthDataGenerator implements AuthDataGenerator {
 
   @Override
   public AuthData generateAuthData(
-      String callbackBaseUrl, String authCode, String id, AuthData initialAuthData, String extra) {
+      String callbackUrl, String authCode, String id, AuthData initialAuthData, String extra) {
     // callbackbaseurl, id, initialAuthData and extra are not used.
     try {
       return new TokenAuthData(getToken(authCode));

--- a/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugAuthDataGenerator.java
@@ -52,11 +52,11 @@ public class SmugMugAuthDataGenerator implements AuthDataGenerator {
   }
 
   @Override
-  public AuthFlowConfiguration generateConfiguration(String callbackBaseUrl, String id) {
+  public AuthFlowConfiguration generateConfiguration(String callbackUrl, String id) {
     // Generate a request token and include that as initial auth data
     TokenSecretAuthData authData = null;
     try {
-      authData = smugMugOauthInterface.getRequestToken(callbackBaseUrl + "/callback/smugmug");
+      authData = smugMugOauthInterface.getRequestToken(callbackUrl);
     } catch (IOException e) {
       logger.warn("Couldnt get authData {}", e.getMessage());
       return null;
@@ -68,7 +68,7 @@ public class SmugMugAuthDataGenerator implements AuthDataGenerator {
 
   @Override
   public AuthData generateAuthData(
-      String callbackBaseUrl, String authCode, String id, AuthData initialAuthData, String extra) {
+      String callbackUrl, String authCode, String id, AuthData initialAuthData, String extra) {
 
     Preconditions.checkArgument(Strings.isNullOrEmpty(extra), "Extra data not expected");
     Preconditions.checkNotNull(

--- a/extensions/auth/portability-auth-twitter/src/main/java/org/datatransferproject/auth/twitter/TwitterAuthDataGenerator.java
+++ b/extensions/auth/portability-auth-twitter/src/main/java/org/datatransferproject/auth/twitter/TwitterAuthDataGenerator.java
@@ -58,12 +58,12 @@ final class TwitterAuthDataGenerator implements AuthDataGenerator {
   }
 
   @Override
-  public AuthFlowConfiguration generateConfiguration(String callbackBaseUrl, String id) {
+  public AuthFlowConfiguration generateConfiguration(String callbackUrl, String id) {
     // Generate a request token and include that as initial auth data
     RequestToken requestToken;
     try {
        requestToken =
-          twitterApi.getOAuthRequestToken(callbackBaseUrl + "/callback/twitter", perms);
+          twitterApi.getOAuthRequestToken(callbackUrl, perms);
     } catch (TwitterException e) {
       logger.warn("Couldn't get authData", e);
       return null;
@@ -78,7 +78,7 @@ final class TwitterAuthDataGenerator implements AuthDataGenerator {
 
   @Override
   public AuthData generateAuthData(
-      String callbackBaseUrl, String authCode, String id, AuthData initialAuthData, String extra) {
+      String callbackUrl, String authCode, String id, AuthData initialAuthData, String extra) {
     Preconditions.checkArgument(Strings.isNullOrEmpty(extra), "Extra data not expected");
     Preconditions.checkNotNull(
         initialAuthData,

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/CreateTransferJobAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/CreateTransferJobAction.java
@@ -55,7 +55,8 @@ public class CreateTransferJobAction implements Action<CreateTransferJob, Transf
         String dataType = request.getDataType();
         String exportService = request.getExportService();
         String importService = request.getImportService();
-        String callbackUrl = request.getCallbackUrl();
+        String exportCallbackUrl = request.getExportCallbackUrl();
+        String importCallbackUrl = request.getImportCallbackUrl();
 
         // Create a new job and persist
         UUID jobId = UUID.randomUUID();
@@ -85,9 +86,9 @@ public class CreateTransferJobAction implements Action<CreateTransferJob, Transf
             String encodedJobId = encodeJobId(jobId);
 
             AuthFlowConfiguration exportConfiguration =
-                    exportGenerator.generateConfiguration(callbackUrl, encodedJobId);
+                    exportGenerator.generateConfiguration(exportCallbackUrl, encodedJobId);
             AuthFlowConfiguration importConfiguration =
-                    importGenerator.generateConfiguration(callbackUrl, encodedJobId);
+                    importGenerator.generateConfiguration(importCallbackUrl, encodedJobId);
 
             boolean jobNeedsUpdate = false;
             // If present, store initial auth data for export services, e.g. used for oauth1

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/GenerateServiceAuthDataAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/GenerateServiceAuthDataAction.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.datatransferproject.api.action.Action;
 import org.datatransferproject.api.launcher.TypeManager;
 import org.datatransferproject.security.DecrypterFactory;
@@ -32,19 +31,16 @@ public class GenerateServiceAuthDataAction
   private final AuthServiceProviderRegistry registry;
   private final SymmetricKeyGenerator symmetricKeyGenerator;
   private final ObjectMapper objectMapper;
-  private final String baseUrl;
 
   @Inject
   public GenerateServiceAuthDataAction(
-      JobStore jobStore,
-      AuthServiceProviderRegistry registry,
-      SymmetricKeyGenerator symmetricKeyGenerator,
-      TypeManager typeManager,
-      @Named("baseUrl") String baseUrl) {
+          JobStore jobStore,
+          AuthServiceProviderRegistry registry,
+          SymmetricKeyGenerator symmetricKeyGenerator,
+          TypeManager typeManager) {
     this.jobStore = jobStore;
     this.registry = registry;
     this.symmetricKeyGenerator = symmetricKeyGenerator;
-    this.baseUrl = baseUrl;
     this.objectMapper = typeManager.getMapper();
   }
 
@@ -96,7 +92,7 @@ public class GenerateServiceAuthDataAction
       // Generate auth data
       AuthData authData =
           generator.generateAuthData(
-                  baseUrl, request.getAuthToken(), jobId.toString(), initialAuthData, null);
+                  request.getCallbackUrl(), request.getAuthToken(), jobId.toString(), initialAuthData, null);
       Preconditions.checkNotNull(authData, "Auth data should not be null");
 
       // Serialize and encrypt the auth data

--- a/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/CreateTransferJob.java
+++ b/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/CreateTransferJob.java
@@ -25,19 +25,22 @@ import io.swagger.annotations.ApiModelProperty;
 public class CreateTransferJob {
     private final String exportService;
     private final String importService;
+    private final String exportCallbackUrl;
+    private final String importCallbackUrl;
     private final String dataType;
-    private final String callbackUrl;
 
     @JsonCreator
     public CreateTransferJob(
             @JsonProperty(value = "exportService", required = true) String exportService,
             @JsonProperty(value = "importService", required = true) String importService,
-            @JsonProperty(value = "dataType", required = true) String dataType,
-            @JsonProperty(value = "callbackUrl", required = true) String callbackUrl) {
+            @JsonProperty(value = "exportCallbackUrl", required = true) String exportCallbackUrl,
+            @JsonProperty(value = "importCallbackUrl", required = true) String importCallbackUrl,
+            @JsonProperty(value = "dataType", required = true) String dataType) {
         this.exportService = exportService;
         this.importService = importService;
+        this.exportCallbackUrl = exportCallbackUrl;
+        this.importCallbackUrl = importCallbackUrl;
         this.dataType = dataType;
-        this.callbackUrl = callbackUrl;
     }
 
     @ApiModelProperty(value = "The service to transfer data from", dataType = "string", required = true)
@@ -50,13 +53,18 @@ public class CreateTransferJob {
         return importService;
     }
 
+    @ApiModelProperty(value = "The export auth callback URL", dataType = "string", required = true)
+    public String getExportCallbackUrl() {
+        return exportCallbackUrl;
+    }
+
+    @ApiModelProperty(value = "The import auth callback URL", dataType = "string", required = true)
+    public String getImportCallbackUrl() {
+        return importCallbackUrl;
+    }
+
     @ApiModelProperty(value = "The type of data to transfer", dataType = "string", required = true)
     public String getDataType() {
         return dataType;
-    }
-
-    @ApiModelProperty(value = "The auth callback URL", dataType = "string", required = true)
-    public String getCallbackUrl() {
-        return callbackUrl;
     }
 }

--- a/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/GenerateServiceAuthData.java
+++ b/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/GenerateServiceAuthData.java
@@ -32,14 +32,17 @@ public class GenerateServiceAuthData {
   private final String id;
   private final String authToken;
   private final Mode mode;
+  private final String callbackUrl;
 
   public GenerateServiceAuthData(
       @JsonProperty(value = "id", required = true) String id,
       @JsonProperty(value = "authToken", required = true) String authToken,
-      @JsonProperty(value = "mode", required = true) Mode mode) {
+      @JsonProperty(value = "mode", required = true) Mode mode,
+      @JsonProperty(value = "callbackUrl", required = true) String callbackUrl) {
     this.id = id;
     this.authToken = authToken;
     this.mode = mode;
+    this.callbackUrl = callbackUrl;
   }
 
   public String getId() {
@@ -52,5 +55,9 @@ public class GenerateServiceAuthData {
 
   public Mode getMode() {
     return mode;
+  }
+
+  public String getCallbackUrl() {
+    return callbackUrl;
   }
 }

--- a/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/CreateTransferJobTest.java
+++ b/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/CreateTransferJobTest.java
@@ -29,14 +29,20 @@ public class CreateTransferJobTest {
 
     String serialized =
         objectMapper.writeValueAsString(
-            new CreateTransferJob("testSource", "testDestination", "PHOTOS", "https://localhost:3000"));
+            new CreateTransferJob(
+                    "testSource",
+                    "testDestination",
+                    "https://localhost:3000/callback/testSource",
+                    "https://localhost:3000/callback/testDestination",
+                    "PHOTOS"));
 
     CreateTransferJob deserialized =
         objectMapper.readValue(serialized, CreateTransferJob.class);
 
     Assert.assertEquals("testSource", deserialized.getExportService());
     Assert.assertEquals("testDestination", deserialized.getImportService());
+    Assert.assertEquals("https://localhost:3000/callback/testSource", deserialized.getExportCallbackUrl());
+    Assert.assertEquals("https://localhost:3000/callback/testDestination", deserialized.getImportCallbackUrl());
     Assert.assertEquals("PHOTOS", deserialized.getDataType());
-    Assert.assertEquals("https://localhost:3000", deserialized.getCallbackUrl());
   }
 }


### PR DESCRIPTION
Different frontends may configure callbacks differently, and not necessarily use the "/callback/servicename" convention we had in the API server

Tested photos transfer locally with the demo server