### PR TITLE
Client encryption extensibility

### DIFF
--- a/client-rest/src/app/transfer/create-transfer.component.ts
+++ b/client-rest/src/app/transfer/create-transfer.component.ts
@@ -52,6 +52,7 @@ export class CreateTransferComponent implements OnInit {
             exportCallbackUrl: `${environment.apiBaseUrl}/callback/${this.progressService.exportService().toLowerCase()}`,
             importCallbackUrl: `${environment.apiBaseUrl}/callback/${this.progressService.importService().toLowerCase()}`,
             dataType: this.progressService.dataType(),
+            encryptionScheme: environment.encryptionScheme
         }).subscribe(transferJob => {
             // redirect to OAuth service
             this.progressService.createComplete(transferJob.id, transferJob.exportUrl, transferJob.importUrl);

--- a/client-rest/src/app/transfer/initiate-transfer.component.ts
+++ b/client-rest/src/app/transfer/initiate-transfer.component.ts
@@ -60,6 +60,7 @@ export class InitiateTransferComponent implements OnInit {
 
     encryptAndStartTransfer() {
         // encrypt the export/import auth data pair as a JWE using the public key associated with the transfer job
+        // .cf https://tools.ietf.org/html/rfc7516#page-32
         let cryptographer = new Jose.WebCryptographer();
         (<any>cryptographer).setContentEncryptionAlgorithm("A128CBC-HS256"); // workaround missing method definition in Typescript type definition for WebCryptographer
         cryptographer.setKeyEncryptionAlgorithm("RSA-OAEP");

--- a/client-rest/src/app/transfer/initiate-transfer.component.ts
+++ b/client-rest/src/app/transfer/initiate-transfer.component.ts
@@ -60,7 +60,6 @@ export class InitiateTransferComponent implements OnInit {
 
     encryptAndStartTransfer() {
         // encrypt the export/import auth data pair as a JWE using the public key associated with the transfer job
-        // .cf https://tools.ietf.org/html/rfc7516#page-32
         let cryptographer = new Jose.WebCryptographer();
         (<any>cryptographer).setContentEncryptionAlgorithm("A128CBC-HS256"); // workaround missing method definition in Typescript type definition for WebCryptographer
         cryptographer.setKeyEncryptionAlgorithm("RSA-OAEP");

--- a/client-rest/src/app/types/create-transfer-job.ts
+++ b/client-rest/src/app/types/create-transfer-job.ts
@@ -1,29 +1,34 @@
 /**
-* Data required to create a transfer job.
-*/
+ * Data required to create a transfer job.
+ */
 export interface CreateTransferJob {
     /**
-    * Source (export) service.
-    */
+     * Source (export) service.
+     */
     exportService: string;
 
     /**
-    * Target (import) service.
-    */
+     * Target (import) service.
+     */
     importService: string;
 
     /**
-    * The URL for export auth callback.
-    */
+     * The URL for export auth callback.
+     */
     exportCallbackUrl: string;
 
     /**
-    * The URL for import auth callback.
-    */
+     * The URL for import auth callback.
+     */
     importCallbackUrl: string;
 
     /**
-    * The data type to transfer.
-    */
+     * The data type to transfer.
+     */
     dataType: string;
+
+    /**
+     * The encryptionScheme to use.
+     */
+    encryptionScheme: string;
 }

--- a/client-rest/src/app/types/start-transfer-job.ts
+++ b/client-rest/src/app/types/start-transfer-job.ts
@@ -5,7 +5,7 @@ export interface StartTransferJob {
     id: string;
 
     /**
-     * A JWE containing the auth data pair in the form {exportAuthData: AuthData, importAuthData: AuthData}
+     * The auth data pair in the form {exportAuthData: AuthData, importAuthData: AuthData} encrypted according to the scheme in use by the client and server.
      */
-    encryptedAuthData?: string;
+    encryptedAuthData: string;
 }

--- a/client-rest/src/environments/environment.ts
+++ b/client-rest/src/environments/environment.ts
@@ -4,5 +4,6 @@
 
 export const environment = {
     production: false,
+    encryptionScheme: "jwe", // supported values are "jwe" and "cleartext" which must correspond to the schemes supported by the server
     apiBaseUrl: 'https://localhost:3000'
 };

--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -50,6 +50,7 @@ repositories {
 }
 
 def transportType = project.hasProperty('transportType') ? transportType : "jettyrest"
+def encryptionScheme = project.hasProperty('encryptionScheme') ? encryptionScheme : "jwe"
 def offlineData = project.hasProperty('offlineData') ? offlineData : "false"
 def demoDomain = project.hasProperty('appDomain') ? appDomain : "localhost"
 def appPort = project.hasProperty('appPort') ? appPort : "3000"
@@ -86,6 +87,8 @@ dependencies {
         compile project(':extensions:auth:portability-auth-offline-demo')
         compile project(':extensions:data-transfer:portability-data-transfer-offline-demo')
     }
+
+    compile project(":extensions:security:portability-security-${encryptionScheme}")
 
 }
 

--- a/extensions/security/portability-security-cleartext/build.gradle
+++ b/extensions/security/portability-security-cleartext/build.gradle
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+    compile project(':portability-spi-transfer')
+}

--- a/extensions/security/portability-security-cleartext/src/main/java/org/datatransferproject/security/cleartext/ClearTextAuthDataDecryptService.java
+++ b/extensions/security/portability-security-cleartext/src/main/java/org/datatransferproject/security/cleartext/ClearTextAuthDataDecryptService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.security.cleartext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.datatransferproject.spi.transfer.security.AuthDataDecryptService;
+import org.datatransferproject.types.transfer.auth.AuthDataPair;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+
+/** */
+public class ClearTextAuthDataDecryptService implements AuthDataDecryptService {
+  private final ObjectMapper objectMapper;
+
+  public ClearTextAuthDataDecryptService(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean canHandle(String scheme) {
+    return "cleartext".equals(scheme);
+  }
+
+  @Override
+  public AuthDataPair decrypt(String encrypted, PrivateKey privateKey) {
+    try {
+      return objectMapper.readValue(encrypted, AuthDataPair.class);
+    } catch (IOException e) {
+      throw new SecurityException("Error decrypting auth tokens", e);
+    }
+  }
+}

--- a/extensions/security/portability-security-cleartext/src/main/java/org/datatransferproject/security/cleartext/ClearTextPublicKeySerializer.java
+++ b/extensions/security/portability-security-cleartext/src/main/java/org/datatransferproject/security/cleartext/ClearTextPublicKeySerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.security.cleartext;
+
+import com.google.common.io.BaseEncoding;
+import org.datatransferproject.spi.transfer.security.PublicKeySerializer;
+import org.datatransferproject.spi.transfer.security.SecurityException;
+
+import java.security.PublicKey;
+
+/** */
+public class ClearTextPublicKeySerializer implements PublicKeySerializer {
+
+  @Override
+  public boolean canHandle(String scheme) {
+    return "cleartext".equals(scheme);
+  }
+
+  @Override
+  public String serialize(PublicKey publicKey) throws SecurityException {
+    return BaseEncoding.base64().encode(publicKey.getEncoded());
+  }
+}

--- a/extensions/security/portability-security-cleartext/src/main/java/org/datatransferproject/security/cleartext/ClearTextSecurityExtension.java
+++ b/extensions/security/portability-security-cleartext/src/main/java/org/datatransferproject/security/cleartext/ClearTextSecurityExtension.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.security.cleartext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.datatransferproject.api.launcher.ExtensionContext;
+import org.datatransferproject.api.launcher.TypeManager;
+import org.datatransferproject.spi.transfer.security.AuthDataDecryptService;
+import org.datatransferproject.spi.transfer.security.PublicKeySerializer;
+import org.datatransferproject.spi.transfer.security.SecurityExtension;
+
+import java.util.Set;
+
+import static java.util.Collections.singleton;
+
+/** Handles auth data transfer between the client UI and the server using cleartext */
+public class ClearTextSecurityExtension implements SecurityExtension {
+  private TypeManager typeManager;
+
+  @Override
+  public void initialize(ExtensionContext context) {
+    typeManager = context.getTypeManager();
+  }
+
+  @Override
+  public Set<PublicKeySerializer> getPublicKeySerializers() {
+    return singleton(new ClearTextPublicKeySerializer());
+  }
+
+  @Override
+  public Set<AuthDataDecryptService> getDecryptServices() {
+    ObjectMapper objectMapper = typeManager.getMapper();
+    return singleton(new ClearTextAuthDataDecryptService(objectMapper));
+  }
+}

--- a/extensions/security/portability-security-cleartext/src/main/resources/META-INF/services/org.datatransferproject.spi.transfer.security.SecurityExtension
+++ b/extensions/security/portability-security-cleartext/src/main/resources/META-INF/services/org.datatransferproject.spi.transfer.security.SecurityExtension
@@ -1,0 +1,1 @@
+org.datatransferproject.security.cleartext.ClearTextSecurityExtension

--- a/extensions/security/portability-security-jwe/build.gradle
+++ b/extensions/security/portability-security-jwe/build.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+dependencies {
+    compile project(':portability-spi-transfer')
+    compile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '5.14'
+}

--- a/extensions/security/portability-security-jwe/src/main/java/org/datatransferproject/security/jwe/JWEAuthDataDecryptService.java
+++ b/extensions/security/portability-security-jwe/src/main/java/org/datatransferproject/security/jwe/JWEAuthDataDecryptService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.security.jwe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import org.datatransferproject.spi.transfer.security.AuthDataDecryptService;
+import org.datatransferproject.types.transfer.auth.AuthDataPair;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.text.ParseException;
+
+/** */
+public class JWEAuthDataDecryptService implements AuthDataDecryptService {
+  private final ObjectMapper objectMapper;
+
+  public JWEAuthDataDecryptService(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public boolean canHandle(String scheme) {
+    return "jwe".equals(scheme);
+  }
+
+  @Override
+  public AuthDataPair decrypt(String encrypted, PrivateKey privateKey) {
+    try {
+      RSADecrypter decrypter = new RSADecrypter(privateKey);
+      JWEObject object = JWEObject.parse(encrypted);
+      object.decrypt(decrypter);
+      return objectMapper.readValue(object.getPayload().toString(), AuthDataPair.class);
+    } catch (IOException | ParseException | JOSEException e) {
+      throw new SecurityException("Error decrypting auth tokens", e);
+    }
+  }
+}

--- a/extensions/security/portability-security-jwe/src/main/java/org/datatransferproject/security/jwe/JWEPublicKeySerializer.java
+++ b/extensions/security/portability-security-jwe/src/main/java/org/datatransferproject/security/jwe/JWEPublicKeySerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.security.jwe;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import org.datatransferproject.spi.transfer.security.PublicKeySerializer;
+import org.datatransferproject.spi.transfer.security.SecurityException;
+
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.UUID;
+
+/** */
+public class JWEPublicKeySerializer implements PublicKeySerializer {
+
+  @Override
+  public boolean canHandle(String scheme) {
+    return "jwe".equals(scheme);
+  }
+
+  @Override
+  public String serialize(PublicKey publicKey) throws SecurityException {
+    String kid = UUID.randomUUID().toString();
+    JWK jwk = new RSAKey.Builder((RSAPublicKey) publicKey).keyID(kid).build();
+    return jwk.toString();
+  }
+}

--- a/extensions/security/portability-security-jwe/src/main/java/org/datatransferproject/security/jwe/JWESecurityExtension.java
+++ b/extensions/security/portability-security-jwe/src/main/java/org/datatransferproject/security/jwe/JWESecurityExtension.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.security.jwe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.datatransferproject.api.launcher.ExtensionContext;
+import org.datatransferproject.api.launcher.TypeManager;
+import org.datatransferproject.spi.transfer.security.AuthDataDecryptService;
+import org.datatransferproject.spi.transfer.security.PublicKeySerializer;
+import org.datatransferproject.spi.transfer.security.SecurityExtension;
+
+import java.util.Set;
+
+import static java.util.Collections.singleton;
+
+/** Handles auth data transfer between the client UI and server using JWE messages. */
+public class JWESecurityExtension implements SecurityExtension {
+  private TypeManager typeManager;
+
+  @Override
+  public void initialize(ExtensionContext context) {
+    typeManager = context.getTypeManager();
+  }
+
+
+  @Override
+  public Set<PublicKeySerializer> getPublicKeySerializers() {
+    return singleton(new JWEPublicKeySerializer());
+  }
+
+  @Override
+  public Set<AuthDataDecryptService> getDecryptServices() {
+    ObjectMapper objectMapper = typeManager.getMapper();
+    return singleton(new JWEAuthDataDecryptService(objectMapper));
+  }
+}

--- a/extensions/security/portability-security-jwe/src/main/resources/META-INF/services/org.datatransferproject.spi.transfer.security.SecurityExtension
+++ b/extensions/security/portability-security-jwe/src/main/resources/META-INF/services/org.datatransferproject.spi.transfer.security.SecurityExtension
@@ -1,0 +1,1 @@
+org.datatransferproject.security.jwe.JWESecurityExtension

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/CreateTransferJobAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/CreateTransferJobAction.java
@@ -26,142 +26,161 @@ import static org.datatransferproject.api.action.ActionUtils.encodeJobId;
 import static org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode.EXPORT;
 import static org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode.IMPORT;
 
-/** Creates a transfer job and prepares it for both the export and import service authentication flow. */
+/**
+ * Creates a transfer job and prepares it for both the export and import service authentication
+ * flow.
+ */
 public class CreateTransferJobAction implements Action<CreateTransferJob, TransferJob> {
-    private final JobStore jobStore;
-    private final AuthServiceProviderRegistry registry;
-    private final SymmetricKeyGenerator symmetricKeyGenerator;
-    private final ObjectMapper objectMapper;
+  private final JobStore jobStore;
+  private final AuthServiceProviderRegistry registry;
+  private final SymmetricKeyGenerator symmetricKeyGenerator;
+  private final ObjectMapper objectMapper;
 
-    @Inject
-    CreateTransferJobAction(
-            JobStore jobStore,
-            AuthServiceProviderRegistry registry,
-            SymmetricKeyGenerator symmetricKeyGenerator,
-            TypeManager typeManager) {
-        this.jobStore = jobStore;
-        this.registry = registry;
-        this.symmetricKeyGenerator = symmetricKeyGenerator;
-        this.objectMapper = typeManager.getMapper();
-    }
+  @Inject
+  CreateTransferJobAction(
+      JobStore jobStore,
+      AuthServiceProviderRegistry registry,
+      SymmetricKeyGenerator symmetricKeyGenerator,
+      TypeManager typeManager) {
+    this.jobStore = jobStore;
+    this.registry = registry;
+    this.symmetricKeyGenerator = symmetricKeyGenerator;
+    this.objectMapper = typeManager.getMapper();
+  }
 
-    @Override
-    public Class<CreateTransferJob> getRequestType() {
-        return CreateTransferJob.class;
-    }
+  @Override
+  public Class<CreateTransferJob> getRequestType() {
+    return CreateTransferJob.class;
+  }
 
-    @Override
-    public TransferJob handle(CreateTransferJob request) {
-        String dataType = request.getDataType();
-        String exportService = request.getExportService();
-        String importService = request.getImportService();
-        String exportCallbackUrl = request.getExportCallbackUrl();
-        String importCallbackUrl = request.getImportCallbackUrl();
+  @Override
+  public TransferJob handle(CreateTransferJob request) {
+    String dataType = request.getDataType();
+    String exportService = request.getExportService();
+    String importService = request.getImportService();
+    String exportCallbackUrl = request.getExportCallbackUrl();
+    String importCallbackUrl = request.getImportCallbackUrl();
 
-        // Create a new job and persist
-        UUID jobId = UUID.randomUUID();
-        SecretKey sessionKey = symmetricKeyGenerator.generate();
-        String encodedSessionKey = BaseEncoding.base64Url().encode(sessionKey.getEncoded());
+    // Create a new job and persist
+    UUID jobId = UUID.randomUUID();
+    SecretKey sessionKey = symmetricKeyGenerator.generate();
+    String encodedSessionKey = BaseEncoding.base64Url().encode(sessionKey.getEncoded());
 
-        PortabilityJob job = createJob(encodedSessionKey, dataType, exportService, importService);
+    String encryptionScheme = request.getEncryptionScheme();
+    PortabilityJob job =
+        createJob(encodedSessionKey, dataType, exportService, importService, encryptionScheme);
 
-        AuthDataGenerator exportGenerator =
-                registry.getAuthDataGenerator(job.exportService(), job.transferDataType(), EXPORT);
-        Preconditions.checkNotNull(
-                exportGenerator,
-                "Generator not found for type: %s, service: %s",
-                job.transferDataType(),
-                job.exportService());
+    AuthDataGenerator exportGenerator =
+        registry.getAuthDataGenerator(job.exportService(), job.transferDataType(), EXPORT);
+    Preconditions.checkNotNull(
+        exportGenerator,
+        "Generator not found for type: %s, service: %s",
+        job.transferDataType(),
+        job.exportService());
 
-        AuthDataGenerator importGenerator =
-                registry.getAuthDataGenerator(job.importService(), job.transferDataType(), IMPORT);
-        Preconditions.checkNotNull(
-                importGenerator,
-                "Generator not found for type: %s, service: %s",
-                job.transferDataType(),
-                job.importService());
+    AuthDataGenerator importGenerator =
+        registry.getAuthDataGenerator(job.importService(), job.transferDataType(), IMPORT);
+    Preconditions.checkNotNull(
+        importGenerator,
+        "Generator not found for type: %s, service: %s",
+        job.transferDataType(),
+        job.importService());
 
-        try {
-            jobStore.createJob(jobId, job);
-            String encodedJobId = encodeJobId(jobId);
+    try {
+      jobStore.createJob(jobId, job);
+      String encodedJobId = encodeJobId(jobId);
 
-            AuthFlowConfiguration exportConfiguration =
-                    exportGenerator.generateConfiguration(exportCallbackUrl, encodedJobId);
-            AuthFlowConfiguration importConfiguration =
-                    importGenerator.generateConfiguration(importCallbackUrl, encodedJobId);
+      AuthFlowConfiguration exportConfiguration =
+          exportGenerator.generateConfiguration(exportCallbackUrl, encodedJobId);
+      AuthFlowConfiguration importConfiguration =
+          importGenerator.generateConfiguration(importCallbackUrl, encodedJobId);
 
-            boolean jobNeedsUpdate = false;
-            // If present, store initial auth data for export services, e.g. used for oauth1
-            if (exportConfiguration.getInitialAuthData() != null) {
-                jobNeedsUpdate = true;
-                // Ensure initial auth data for export has not already been set
-                Preconditions.checkState(
-                        Strings.isNullOrEmpty(job.jobAuthorization().encryptedInitialExportAuthData()));
+      boolean jobNeedsUpdate = false;
+      // If present, store initial auth data for export services, e.g. used for oauth1
+      if (exportConfiguration.getInitialAuthData() != null) {
+        jobNeedsUpdate = true;
+        // Ensure initial auth data for export has not already been set
+        Preconditions.checkState(
+            Strings.isNullOrEmpty(job.jobAuthorization().encryptedInitialExportAuthData()));
 
-                // Serialize and encrypt the initial auth data
-                String serialized = objectMapper.writeValueAsString(exportConfiguration.getInitialAuthData());
-                String encryptedInitialAuthData = EncrypterFactory.create(sessionKey).encrypt(serialized);
+        // Serialize and encrypt the initial auth data
+        String serialized =
+            objectMapper.writeValueAsString(exportConfiguration.getInitialAuthData());
+        String encryptedInitialAuthData = EncrypterFactory.create(sessionKey).encrypt(serialized);
 
-                // Add the serialized and encrypted initial auth data to the job authorization
-                JobAuthorization updatedJobAuthorization =
-                        job.jobAuthorization()
-                                .toBuilder()
-                                .setEncryptedInitialExportAuthData(encryptedInitialAuthData)
-                                .build();
-
-                // Persist the updated PortabilityJob with the updated JobAuthorization
-                job = job.toBuilder().setAndValidateJobAuthorization(updatedJobAuthorization).build();
-            }
-            if (importConfiguration.getInitialAuthData() != null) {
-                jobNeedsUpdate = true;
-
-                // Ensure initial auth data for import has not already been set
-                Preconditions.checkState(
-                        Strings.isNullOrEmpty(job.jobAuthorization().encryptedInitialImportAuthData()));
-
-                // Serialize and encrypt the initial auth data
-                String serialized = objectMapper.writeValueAsString(importConfiguration.getInitialAuthData());
-                String encryptedInitialAuthData = EncrypterFactory.create(sessionKey).encrypt(serialized);
-
-                // Add the serialized and encrypted initial auth data to the job authorization
-                JobAuthorization updatedJobAuthorization =
-                        job.jobAuthorization()
-                                .toBuilder()
-                                .setEncryptedInitialImportAuthData(encryptedInitialAuthData)
-                                .build();
-
-                // Persist the updated PortabilityJob with the updated JobAuthorization
-                job = job.toBuilder().setAndValidateJobAuthorization(updatedJobAuthorization).build();
-            }
-            if (jobNeedsUpdate) {
-                jobStore.updateJob(jobId, job);
-            }
-
-            return new TransferJob(encodedJobId, job.exportService(), job.importService(), job.transferDataType(),
-                    exportConfiguration.getAuthUrl(), importConfiguration.getAuthUrl(),
-                    exportConfiguration.getTokenUrl(), importConfiguration.getTokenUrl(),
-                    exportConfiguration.getAuthProtocol(), importConfiguration.getAuthProtocol());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /** Populates the initial state of the {@link PortabilityJob} instance. */
-    private static PortabilityJob createJob(
-            String encodedSessionKey, String dataType, String exportService, String importService) {
-
-        // Job auth data
-        JobAuthorization jobAuthorization =
-                JobAuthorization.builder()
-                        .setSessionSecretKey(encodedSessionKey)
-                        .setState(JobAuthorization.State.INITIAL)
-                        .build();
-
-        return PortabilityJob.builder()
-                .setTransferDataType(dataType)
-                .setExportService(exportService)
-                .setImportService(importService)
-                .setAndValidateJobAuthorization(jobAuthorization)
+        // Add the serialized and encrypted initial auth data to the job authorization
+        JobAuthorization updatedJobAuthorization =
+            job.jobAuthorization()
+                .toBuilder()
+                .setEncryptedInitialExportAuthData(encryptedInitialAuthData)
                 .build();
+
+        // Persist the updated PortabilityJob with the updated JobAuthorization
+        job = job.toBuilder().setAndValidateJobAuthorization(updatedJobAuthorization).build();
+      }
+      if (importConfiguration.getInitialAuthData() != null) {
+        jobNeedsUpdate = true;
+
+        // Ensure initial auth data for import has not already been set
+        Preconditions.checkState(
+            Strings.isNullOrEmpty(job.jobAuthorization().encryptedInitialImportAuthData()));
+
+        // Serialize and encrypt the initial auth data
+        String serialized =
+            objectMapper.writeValueAsString(importConfiguration.getInitialAuthData());
+        String encryptedInitialAuthData = EncrypterFactory.create(sessionKey).encrypt(serialized);
+
+        // Add the serialized and encrypted initial auth data to the job authorization
+        JobAuthorization updatedJobAuthorization =
+            job.jobAuthorization()
+                .toBuilder()
+                .setEncryptedInitialImportAuthData(encryptedInitialAuthData)
+                .build();
+
+        // Persist the updated PortabilityJob with the updated JobAuthorization
+        job = job.toBuilder().setAndValidateJobAuthorization(updatedJobAuthorization).build();
+      }
+      if (jobNeedsUpdate) {
+        jobStore.updateJob(jobId, job);
+      }
+
+      return new TransferJob(
+          encodedJobId,
+          job.exportService(),
+          job.importService(),
+          job.transferDataType(),
+          exportConfiguration.getAuthUrl(),
+          importConfiguration.getAuthUrl(),
+          exportConfiguration.getTokenUrl(),
+          importConfiguration.getTokenUrl(),
+          exportConfiguration.getAuthProtocol(),
+          importConfiguration.getAuthProtocol());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
+  }
+
+  /** Populates the initial state of the {@link PortabilityJob} instance. */
+  private static PortabilityJob createJob(
+      String encodedSessionKey,
+      String dataType,
+      String exportService,
+      String importService,
+      String encryptionScheme) {
+
+    // Job auth data
+    JobAuthorization jobAuthorization =
+        JobAuthorization.builder()
+            .setSessionSecretKey(encodedSessionKey)
+            .setEncryptionScheme(encryptionScheme)
+            .setState(JobAuthorization.State.INITIAL)
+            .build();
+
+    return PortabilityJob.builder()
+        .setTransferDataType(dataType)
+        .setExportService(exportService)
+        .setImportService(importService)
+        .setAndValidateJobAuthorization(jobAuthorization)
+        .build();
+  }
 }

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/StartTransferJobAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/StartTransferJobAction.java
@@ -45,7 +45,16 @@ public class StartTransferJobAction implements Action<StartTransferJob, Transfer
     job = updateJobWithCredentials(jobId, job, startTransferJob.getEncryptedAuthData());
 
     return new TransferJob(
-        id, job.exportService(), job.importService(), job.transferDataType(), null, null);
+        id,
+        job.exportService(),
+        job.importService(),
+        job.transferDataType(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
   }
 
   /**

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/StartTransferJobAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/StartTransferJobAction.java
@@ -42,7 +42,9 @@ public class StartTransferJobAction implements Action<StartTransferJob, Transfer
     UUID jobId = decodeJobId(id);
     PortabilityJob job = jobStore.findJob(jobId);
 
-    job = updateJobWithCredentials(jobId, job, startTransferJob.getEncryptedAuthData());
+    String authData = startTransferJob.getEncryptedAuthData();
+
+    job = updateJobWithCredentials(jobId, job, authData);
 
     return new TransferJob(
         id,

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/StartTransferJobAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/StartTransferJobAction.java
@@ -45,16 +45,7 @@ public class StartTransferJobAction implements Action<StartTransferJob, Transfer
     job = updateJobWithCredentials(jobId, job, startTransferJob.getEncryptedAuthData());
 
     return new TransferJob(
-        id,
-        job.exportService(),
-        job.importService(),
-        job.transferDataType(),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null);
+        id, job.exportService(), job.importService(), job.transferDataType(), null, null);
   }
 
   /**

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
@@ -31,16 +31,8 @@ public abstract class JobAuthorization {
   public abstract String encryptedInitialImportAuthData();
 
   @Nullable
-  @JsonProperty("encryptedExportAuthData")
-  public abstract String encryptedExportAuthData();
-
-  @Nullable
   @JsonProperty("encryptedAuthData")
   public abstract String encryptedAuthData();
-
-  @Nullable
-  @JsonProperty("encryptedImportAuthData")
-  public abstract String encryptedImportAuthData();
 
   /**
    * The SecretKey used to encrypt all data, including auth data, associated with this job, encoded
@@ -95,12 +87,6 @@ public abstract class JobAuthorization {
      */
     @JsonProperty("encryptedAuthData")
     public abstract Builder setEncryptedAuthData(String authData);
-
-    @JsonProperty("encryptedExportAuthData")
-    public abstract Builder setEncryptedExportAuthData(String authData);
-
-    @JsonProperty("encryptedImportAuthData")
-    public abstract Builder setEncryptedImportAuthData(String authData);
 
     /**
      * The SecretKey used to encrypt all data, including auth data, associated with this job,

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
@@ -31,8 +31,16 @@ public abstract class JobAuthorization {
   public abstract String encryptedInitialImportAuthData();
 
   @Nullable
+  @JsonProperty("encryptedExportAuthData")
+  public abstract String encryptedExportAuthData();
+
+  @Nullable
   @JsonProperty("encryptedAuthData")
   public abstract String encryptedAuthData();
+
+  @Nullable
+  @JsonProperty("encryptedImportAuthData")
+  public abstract String encryptedImportAuthData();
 
   /**
    * The SecretKey used to encrypt all data, including auth data, associated with this job, encoded
@@ -87,6 +95,12 @@ public abstract class JobAuthorization {
      */
     @JsonProperty("encryptedAuthData")
     public abstract Builder setEncryptedAuthData(String authData);
+
+    @JsonProperty("encryptedExportAuthData")
+    public abstract Builder setEncryptedExportAuthData(String authData);
+
+    @JsonProperty("encryptedImportAuthData")
+    public abstract Builder setEncryptedImportAuthData(String authData);
 
     /**
      * The SecretKey used to encrypt all data, including auth data, associated with this job,

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
@@ -34,6 +34,10 @@ public abstract class JobAuthorization {
   @JsonProperty("encryptedAuthData")
   public abstract String encryptedAuthData();
 
+  @Nullable
+  @JsonProperty("encryptionScheme")
+  public abstract String encryptionScheme();
+
   /**
    * The SecretKey used to encrypt all data, including auth data, associated with this job, encoded
    * for storage.
@@ -87,6 +91,9 @@ public abstract class JobAuthorization {
      */
     @JsonProperty("encryptedAuthData")
     public abstract Builder setEncryptedAuthData(String authData);
+
+    @JsonProperty("encryptionScheme")
+    public abstract Builder setEncryptionScheme(String scheme);
 
     /**
      * The SecretKey used to encrypt all data, including auth data, associated with this job,

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
@@ -25,8 +25,6 @@ public abstract class PortabilityJob {
   private static final String EXPORT_SERVICE_KEY = "EXPORT_SERVICE";
   private static final String IMPORT_SERVICE_KEY = "IMPORT_SERVICE";
   private static final String ENCRYPTED_CREDS_KEY = "ENCRYPTED_CREDS_KEY";
-  private static final String EXPORT_ENCRYPTED_CREDS_KEY = "EXPORT_ENCRYPTED_CREDS_KEY";
-  private static final String IMPORT_ENCRYPTED_CREDS_KEY = "IMPORT_ENCRYPTED_CREDS_KEY";
   private static final String ENCRYPTED_SESSION_KEY = "ENCRYPTED_SESSION_KEY";
   private static final String WORKER_INSTANCE_PUBLIC_KEY = "WORKER_INSTANCE_PUBLIC_KEY";
   private static final String IMPORT_ENCRYPTED_INITIAL_AUTH_DATA =
@@ -50,14 +48,6 @@ public abstract class PortabilityJob {
     String encryptedAuthData =
         properties.containsKey(ENCRYPTED_CREDS_KEY)
             ? (String) properties.get(ENCRYPTED_CREDS_KEY)
-            : null;
-    String encryptedExportAuthData =
-        properties.containsKey(EXPORT_ENCRYPTED_CREDS_KEY)
-            ? (String) properties.get(EXPORT_ENCRYPTED_CREDS_KEY)
-            : null;
-    String encryptedImportAuthData =
-        properties.containsKey(IMPORT_ENCRYPTED_CREDS_KEY)
-            ? (String) properties.get(IMPORT_ENCRYPTED_CREDS_KEY)
             : null;
     String encodedPublicKey =
         properties.containsKey(WORKER_INSTANCE_PUBLIC_KEY)
@@ -86,8 +76,6 @@ public abstract class PortabilityJob {
                 .setState(
                     JobAuthorization.State.valueOf((String) properties.get(AUTHORIZATION_STATE)))
                 .setEncryptedAuthData(encryptedAuthData)
-                .setEncryptedExportAuthData(encryptedExportAuthData)
-                .setEncryptedImportAuthData(encryptedImportAuthData)
                 .setSessionSecretKey((String) properties.get(ENCRYPTED_SESSION_KEY))
                 .setAuthPublicKey(encodedPublicKey)
                 .setEncryptedInitialExportAuthData(encryptedExportInitialAuthData)
@@ -142,12 +130,6 @@ public abstract class PortabilityJob {
             .put(AUTHORIZATION_STATE, jobAuthorization().state().toString())
             .put(ENCRYPTED_SESSION_KEY, jobAuthorization().sessionSecretKey());
 
-    if (null != jobAuthorization().encryptedExportAuthData()) {
-      builder.put(EXPORT_ENCRYPTED_CREDS_KEY, jobAuthorization().encryptedExportAuthData());
-    }
-    if (null != jobAuthorization().encryptedImportAuthData()) {
-      builder.put(IMPORT_ENCRYPTED_CREDS_KEY, jobAuthorization().encryptedImportAuthData());
-    }
     if (null != jobAuthorization().authPublicKey()) {
       builder.put(WORKER_INSTANCE_PUBLIC_KEY, jobAuthorization().authPublicKey());
     }
@@ -208,25 +190,18 @@ public abstract class PortabilityJob {
         case CREDS_AVAILABLE:
           // SessionKey required to create a job
           isSet(jobAuthorization.sessionSecretKey());
-          isUnset(
-              jobAuthorization.encryptedExportAuthData(),
-              jobAuthorization.encryptedImportAuthData(),
-              jobAuthorization.authPublicKey());
+          isUnset(jobAuthorization.encryptedAuthData());
           break;
         case CREDS_ENCRYPTION_KEY_GENERATED:
           // Expected associated keys from the assigned transfer worker to be present
           isSet(jobAuthorization.sessionSecretKey(), jobAuthorization.authPublicKey());
-          isUnset(
-              jobAuthorization.encryptedExportAuthData(),
-              jobAuthorization.encryptedImportAuthData());
+          isUnset(jobAuthorization.encryptedAuthData());
           break;
         case CREDS_STORED:
-          // Expected all fields set
-          //          isSet(
-          //              jobAuthorization.sessionSecretKey(),
-          //              jobAuthorization.authPublicKey(),
-          //              jobAuthorization.encryptedExportAuthData(),
-          //              jobAuthorization.encryptedImportAuthData());
+          isSet(
+              jobAuthorization.sessionSecretKey(),
+              jobAuthorization.authPublicKey(),
+              jobAuthorization.encryptedAuthData());
           break;
       }
       return setJobAuthorization(jobAuthorization);

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
@@ -26,6 +26,7 @@ public abstract class PortabilityJob {
   private static final String IMPORT_SERVICE_KEY = "IMPORT_SERVICE";
   private static final String ENCRYPTED_CREDS_KEY = "ENCRYPTED_CREDS_KEY";
   private static final String ENCRYPTED_SESSION_KEY = "ENCRYPTED_SESSION_KEY";
+  private static final String ENCRYPTION_SCHEME = "ENCRYPTION_SCHEME";
   private static final String WORKER_INSTANCE_PUBLIC_KEY = "WORKER_INSTANCE_PUBLIC_KEY";
   private static final String IMPORT_ENCRYPTED_INITIAL_AUTH_DATA =
       "IMPORT_ENCRYPTED_INITIAL_AUTH_DATA";
@@ -75,6 +76,7 @@ public abstract class PortabilityJob {
             JobAuthorization.builder()
                 .setState(
                     JobAuthorization.State.valueOf((String) properties.get(AUTHORIZATION_STATE)))
+                .setEncryptionScheme((String) properties.get(ENCRYPTION_SCHEME))
                 .setEncryptedAuthData(encryptedAuthData)
                 .setSessionSecretKey((String) properties.get(ENCRYPTED_SESSION_KEY))
                 .setAuthPublicKey(encodedPublicKey)
@@ -133,9 +135,16 @@ public abstract class PortabilityJob {
     if (null != jobAuthorization().authPublicKey()) {
       builder.put(WORKER_INSTANCE_PUBLIC_KEY, jobAuthorization().authPublicKey());
     }
+
     if (null != jobAuthorization().encryptedAuthData()) {
       builder.put(ENCRYPTED_CREDS_KEY, jobAuthorization().encryptedAuthData());
     }
+
+    builder.put(
+        ENCRYPTION_SCHEME,
+        null != jobAuthorization().encryptionScheme()
+            ? jobAuthorization().encryptionScheme()
+            : "jwe");
 
     if (null != jobAuthorization().encryptedInitialExportAuthData()) {
       builder.put(

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/security/AuthDataDecryptService.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/security/AuthDataDecryptService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.spi.transfer.security;
+
+import org.datatransferproject.types.transfer.auth.AuthDataPair;
+
+import java.security.PrivateKey;
+
+/** Decrypts authentication data for a given scheme. */
+public interface AuthDataDecryptService {
+
+  /** Returns true if this service supports the given scheme. */
+  boolean canHandle(String scheme);
+
+  /** Decrypts the data using the provided private key. */
+  AuthDataPair decrypt(String encrypted, PrivateKey privateKey) throws SecurityException;
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/security/PublicKeySerializer.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/security/PublicKeySerializer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.spi.transfer.security;
+
+import java.security.PublicKey;
+
+/** Serializes a public key for a given encryption scheme. */
+public interface PublicKeySerializer {
+
+  boolean canHandle(String scheme);
+
+  String serialize(PublicKey publicKey) throws SecurityException;
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/security/SecurityException.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/security/SecurityException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.spi.transfer.security;
+
+/** */
+public class SecurityException extends RuntimeException {
+  public SecurityException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/security/SecurityExtension.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/security/SecurityExtension.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.spi.transfer.security;
+
+import org.datatransferproject.api.launcher.AbstractExtension;
+
+import java.util.Set;
+
+/** Provides security-related services to the worker runtime */
+public interface SecurityExtension extends AbstractExtension {
+
+  Set<PublicKeySerializer> getPublicKeySerializers();
+
+  Set<AuthDataDecryptService> getDecryptServices();
+}

--- a/portability-transfer/build.gradle
+++ b/portability-transfer/build.gradle
@@ -85,7 +85,4 @@ dependencies {
     testCompile("org.mockito:mockito-all:${mockitoVersion}")
     testCompile project(':extensions:cloud:portability-cloud-local')
 
-    compile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '5.14'
-
-
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -52,7 +52,7 @@ class JobPollingService extends AbstractScheduledService {
   }
 
   @Override
-  protected void runOneIteration() throws Exception {
+  protected void runOneIteration() {
     if (JobMetadata.isInitialized()) {
       pollUntilJobIsReady();
     } else {
@@ -114,10 +114,7 @@ class JobPollingService extends AbstractScheduledService {
     }
 
     String kid = UUID.randomUUID().toString();
-    JWK jwk =
-        new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
-            .keyID(kid)
-            .build();
+    JWK jwk = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic()).keyID(kid).build();
 
     PortabilityJob updatedJob =
         existingJob
@@ -166,8 +163,7 @@ class JobPollingService extends AbstractScheduledService {
     } else if (job.jobAuthorization().state() == JobAuthorization.State.CREDS_STORED) {
       logger.debug("Polled job {} in state CREDS_STORED", jobId);
       JobAuthorization jobAuthorization = job.jobAuthorization();
-      if (!Strings.isNullOrEmpty(jobAuthorization.encryptedExportAuthData())
-          && !Strings.isNullOrEmpty(jobAuthorization.encryptedImportAuthData())) {
+      if (!Strings.isNullOrEmpty(jobAuthorization.encryptedAuthData())) {
         logger.debug("Polled job {} has auth data as expected. Done polling.", jobId);
       } else {
         logger.warn(

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -112,9 +112,6 @@ class JobPollingService extends AbstractScheduledService {
       logger.debug("public key cannot be persisted again");
       return false;
     }
-    // Populate job with public key to persist
-    // xcv  String encodedPublicKey =
-    // BaseEncoding.base64Url().encode(keyPair.getPublic().getEncoded());
 
     String kid = UUID.randomUUID().toString();
     JWK jwk =

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -70,6 +70,7 @@ final class JobProcessor {
           job.exportService(),
           job.importService());
 
+      // TODO refactor to a service extension
       // Decrypt the data
       RSADecrypter decrypter = new RSADecrypter(JobMetadata.getKeyPair().getPrivate());
       JWEObject object = JWEObject.parse(jobAuthorization.encryptedAuthData());

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -70,7 +70,6 @@ final class JobProcessor {
           job.exportService(),
           job.importService());
 
-      // TODO refactor to a service extension
       // Decrypt the data
       RSADecrypter decrypter = new RSADecrypter(JobMetadata.getKeyPair().getPrivate());
       JWEObject object = JWEObject.parse(jobAuthorization.encryptedAuthData());

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -18,20 +18,23 @@ package org.datatransferproject.transfer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWEObject;
-import com.nimbusds.jose.crypto.RSADecrypter;
 import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
+import org.datatransferproject.spi.transfer.security.AuthDataDecryptService;
+import org.datatransferproject.spi.transfer.security.SecurityException;
 import org.datatransferproject.types.transfer.auth.AuthData;
 import org.datatransferproject.types.transfer.auth.AuthDataPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
-import java.text.ParseException;
+import java.security.PrivateKey;
+import java.util.Set;
 import java.util.UUID;
+
+import static java.lang.String.format;
 
 /**
  * Process a job in two steps: <br>
@@ -46,12 +49,18 @@ final class JobProcessor {
   private final JobStore store;
   private final ObjectMapper objectMapper;
   private final InMemoryDataCopier copier;
+  private final Set<AuthDataDecryptService> decryptServices;
 
   @Inject
-  JobProcessor(JobStore store, ObjectMapper objectMapper, InMemoryDataCopier copier) {
+  JobProcessor(
+      JobStore store,
+      ObjectMapper objectMapper,
+      InMemoryDataCopier copier,
+      Set<AuthDataDecryptService> decryptServices) {
     this.store = store;
     this.objectMapper = objectMapper;
     this.copier = copier;
+    this.decryptServices = decryptServices;
   }
 
   /** Process our job, whose metadata is available via {@link JobMetadata}. */
@@ -70,14 +79,18 @@ final class JobProcessor {
           job.exportService(),
           job.importService());
 
-      // TODO refactor to a service extension
-      // Decrypt the data
-      RSADecrypter decrypter = new RSADecrypter(JobMetadata.getKeyPair().getPrivate());
-      JWEObject object = JWEObject.parse(jobAuthorization.encryptedAuthData());
-      object.decrypt(decrypter);
-      AuthDataPair pair =
-          objectMapper.readValue(object.getPayload().toString(), AuthDataPair.class);
-
+      String scheme = jobAuthorization.encryptionScheme();
+      AuthDataDecryptService decryptService = getAuthDecryptService(scheme);
+      if (decryptService == null) {
+        logger.error(
+            format(
+                "No auth decrypter found for scheme %s while processing job: %s", scheme, jobId));
+        return;
+      }
+      
+      String encrypted = jobAuthorization.encryptedAuthData();
+      PrivateKey privateKey = JobMetadata.getKeyPair().getPrivate();
+      AuthDataPair pair = decryptService.decrypt(encrypted, privateKey);
       AuthData exportAuthData = objectMapper.readValue(pair.getExportAuthData(), AuthData.class);
       AuthData importAuthData = objectMapper.readValue(pair.getImportAuthData(), AuthData.class);
 
@@ -85,7 +98,7 @@ final class JobProcessor {
       copier.copy(exportAuthData, importAuthData, jobId);
       logger.debug("Finished copy for jobId: " + jobId);
 
-    } catch (IOException | ParseException | JOSEException e) {
+    } catch (IOException | SecurityException e) {
       logger.error("Error processing jobId: " + jobId, e);
     } finally {
       try {
@@ -95,5 +108,15 @@ final class JobProcessor {
         logger.error("Error removing jobId: " + jobId, e);
       }
     }
+  }
+
+  @Nullable
+  private AuthDataDecryptService getAuthDecryptService(String scheme) {
+    for (AuthDataDecryptService decryptService : decryptServices) {
+      if (decryptService.canHandle(scheme)) {
+        return decryptService;
+      }
+    }
+    return null;
   }
 }

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
@@ -144,7 +144,8 @@ public class JobPollingServiceTest {
     job = store.findJob(TEST_ID);
     assertThat(job.jobAuthorization().state()).isEqualTo(State.INITIAL);
     // no auth data should exist yet
-    assertThat(job.jobAuthorization().encryptedAuthData()).isNull();
+    assertThat(job.jobAuthorization().encryptedExportAuthData()).isNull();
+    assertThat(job.jobAuthorization().encryptedImportAuthData()).isNull();
 
     // API atomically updates job to from 'initial' to 'creds available'
     job =
@@ -158,7 +159,8 @@ public class JobPollingServiceTest {
     job = store.findJob(TEST_ID);
     assertThat(job.jobAuthorization().state()).isEqualTo(State.CREDS_AVAILABLE);
     // no auth data should exist yet
-    assertThat(job.jobAuthorization().encryptedAuthData()).isNull();
+    assertThat(job.jobAuthorization().encryptedExportAuthData()).isNull();
+    assertThat(job.jobAuthorization().encryptedImportAuthData()).isNull();
 
     // Worker initiates the JobPollingService
     jobPollingService.runOneIteration();
@@ -177,7 +179,8 @@ public class JobPollingServiceTest {
             .setAndValidateJobAuthorization(
                 job.jobAuthorization()
                     .toBuilder()
-                    .setEncryptedAuthData("dummy export data")
+                    .setEncryptedExportAuthData("dummy export data")
+                    .setEncryptedImportAuthData("dummy import data")
                     .setState(State.CREDS_STORED)
                     .build())
             .build();
@@ -189,7 +192,8 @@ public class JobPollingServiceTest {
     job = store.findJob(TEST_ID);
     JobAuthorization jobAuthorization = job.jobAuthorization();
     assertThat(jobAuthorization.state()).isEqualTo(JobAuthorization.State.CREDS_STORED);
-    assertThat(jobAuthorization.encryptedAuthData()).isNotEmpty();
+    assertThat(jobAuthorization.encryptedExportAuthData()).isNotEmpty();
+    assertThat(jobAuthorization.encryptedImportAuthData()).isNotEmpty();
 
     store.remove(TEST_ID);
   }

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
@@ -144,8 +144,7 @@ public class JobPollingServiceTest {
     job = store.findJob(TEST_ID);
     assertThat(job.jobAuthorization().state()).isEqualTo(State.INITIAL);
     // no auth data should exist yet
-    assertThat(job.jobAuthorization().encryptedExportAuthData()).isNull();
-    assertThat(job.jobAuthorization().encryptedImportAuthData()).isNull();
+    assertThat(job.jobAuthorization().encryptedAuthData()).isNull();
 
     // API atomically updates job to from 'initial' to 'creds available'
     job =
@@ -159,8 +158,7 @@ public class JobPollingServiceTest {
     job = store.findJob(TEST_ID);
     assertThat(job.jobAuthorization().state()).isEqualTo(State.CREDS_AVAILABLE);
     // no auth data should exist yet
-    assertThat(job.jobAuthorization().encryptedExportAuthData()).isNull();
-    assertThat(job.jobAuthorization().encryptedImportAuthData()).isNull();
+    assertThat(job.jobAuthorization().encryptedAuthData()).isNull();
 
     // Worker initiates the JobPollingService
     jobPollingService.runOneIteration();
@@ -179,8 +177,7 @@ public class JobPollingServiceTest {
             .setAndValidateJobAuthorization(
                 job.jobAuthorization()
                     .toBuilder()
-                    .setEncryptedExportAuthData("dummy export data")
-                    .setEncryptedImportAuthData("dummy import data")
+                    .setEncryptedAuthData("dummy export data")
                     .setState(State.CREDS_STORED)
                     .build())
             .build();
@@ -192,8 +189,7 @@ public class JobPollingServiceTest {
     job = store.findJob(TEST_ID);
     JobAuthorization jobAuthorization = job.jobAuthorization();
     assertThat(jobAuthorization.state()).isEqualTo(JobAuthorization.State.CREDS_STORED);
-    assertThat(jobAuthorization.encryptedExportAuthData()).isNotEmpty();
-    assertThat(jobAuthorization.encryptedImportAuthData()).isNotEmpty();
+    assertThat(jobAuthorization.encryptedAuthData()).isNotEmpty();
 
     store.remove(TEST_ID);
   }

--- a/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/CreateTransferJob.java
+++ b/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/CreateTransferJob.java
@@ -23,48 +23,59 @@ import io.swagger.annotations.ApiModelProperty;
 /** Request to create a transfer job. */
 @ApiModel(description = "A request to create a data transfer job")
 public class CreateTransferJob {
-    private final String exportService;
-    private final String importService;
-    private final String exportCallbackUrl;
-    private final String importCallbackUrl;
-    private final String dataType;
+  private final String exportService;
+  private final String importService;
+  private final String exportCallbackUrl;
+  private final String importCallbackUrl;
+  private final String dataType;
+  private final String encryptionScheme;
 
-    @JsonCreator
-    public CreateTransferJob(
-            @JsonProperty(value = "exportService", required = true) String exportService,
-            @JsonProperty(value = "importService", required = true) String importService,
-            @JsonProperty(value = "exportCallbackUrl", required = true) String exportCallbackUrl,
-            @JsonProperty(value = "importCallbackUrl", required = true) String importCallbackUrl,
-            @JsonProperty(value = "dataType", required = true) String dataType) {
-        this.exportService = exportService;
-        this.importService = importService;
-        this.exportCallbackUrl = exportCallbackUrl;
-        this.importCallbackUrl = importCallbackUrl;
-        this.dataType = dataType;
-    }
+  @JsonCreator
+  public CreateTransferJob(
+      @JsonProperty(value = "exportService", required = true) String exportService,
+      @JsonProperty(value = "importService", required = true) String importService,
+      @JsonProperty(value = "exportCallbackUrl", required = true) String exportCallbackUrl,
+      @JsonProperty(value = "importCallbackUrl", required = true) String importCallbackUrl,
+      @JsonProperty(value = "dataType", required = true) String dataType,
+      @JsonProperty(value = "encryptionScheme", required = true) String encryptionScheme) {
+    this.exportService = exportService;
+    this.importService = importService;
+    this.exportCallbackUrl = exportCallbackUrl;
+    this.importCallbackUrl = importCallbackUrl;
+    this.dataType = dataType;
+    this.encryptionScheme = encryptionScheme;
+  }
 
-    @ApiModelProperty(value = "The service to transfer data from", dataType = "string", required = true)
-    public String getExportService() {
-        return exportService;
-    }
+  @ApiModelProperty(
+      value = "The service to transfer data from",
+      dataType = "string",
+      required = true)
+  public String getExportService() {
+    return exportService;
+  }
 
-    @ApiModelProperty(value = "The service to transfer data to", dataType = "string", required = true)
-    public String getImportService() {
-        return importService;
-    }
+  @ApiModelProperty(value = "The service to transfer data to", dataType = "string", required = true)
+  public String getImportService() {
+    return importService;
+  }
 
-    @ApiModelProperty(value = "The export auth callback URL", dataType = "string", required = true)
-    public String getExportCallbackUrl() {
-        return exportCallbackUrl;
-    }
+  @ApiModelProperty(value = "The export auth callback URL", dataType = "string", required = true)
+  public String getExportCallbackUrl() {
+    return exportCallbackUrl;
+  }
 
-    @ApiModelProperty(value = "The import auth callback URL", dataType = "string", required = true)
-    public String getImportCallbackUrl() {
-        return importCallbackUrl;
-    }
+  @ApiModelProperty(value = "The import auth callback URL", dataType = "string", required = true)
+  public String getImportCallbackUrl() {
+    return importCallbackUrl;
+  }
 
-    @ApiModelProperty(value = "The type of data to transfer", dataType = "string", required = true)
-    public String getDataType() {
-        return dataType;
-    }
+  @ApiModelProperty(value = "The type of data to transfer", dataType = "string", required = true)
+  public String getDataType() {
+    return dataType;
+  }
+
+  @ApiModelProperty(value = "The encryption scheme to use", dataType = "string", required = true)
+  public String getEncryptionScheme() {
+    return encryptionScheme;
+  }
 }

--- a/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/CreateTransferJobTest.java
+++ b/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/CreateTransferJobTest.java
@@ -30,19 +30,21 @@ public class CreateTransferJobTest {
     String serialized =
         objectMapper.writeValueAsString(
             new CreateTransferJob(
-                    "testSource",
-                    "testDestination",
-                    "https://localhost:3000/callback/testSource",
-                    "https://localhost:3000/callback/testDestination",
-                    "PHOTOS"));
+                "testSource",
+                "testDestination",
+                "https://localhost:3000/callback/testSource",
+                "https://localhost:3000/callback/testDestination",
+                "PHOTOS",
+                "cleartext"));
 
-    CreateTransferJob deserialized =
-        objectMapper.readValue(serialized, CreateTransferJob.class);
+    CreateTransferJob deserialized = objectMapper.readValue(serialized, CreateTransferJob.class);
 
     Assert.assertEquals("testSource", deserialized.getExportService());
     Assert.assertEquals("testDestination", deserialized.getImportService());
-    Assert.assertEquals("https://localhost:3000/callback/testSource", deserialized.getExportCallbackUrl());
-    Assert.assertEquals("https://localhost:3000/callback/testDestination", deserialized.getImportCallbackUrl());
+    Assert.assertEquals(
+        "https://localhost:3000/callback/testSource", deserialized.getExportCallbackUrl());
+    Assert.assertEquals(
+        "https://localhost:3000/callback/testDestination", deserialized.getImportCallbackUrl());
     Assert.assertEquals("PHOTOS", deserialized.getDataType());
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,9 @@ include ':extensions:cloud:portability-cloud-local', ':extensions:cloud:portabil
 // Transport Extensions
 include ':extensions:transport:portability-transport-jettyrest'
 
+// Security extensions
+include ':extensions:security:portability-security-cleartext', ':extensions:security:portability-security-jwe'
+
 // Service Integrations - Auth and Transfer Extensions
 // Flickr
 include ':extensions:auth:portability-auth-flickr'


### PR DESCRIPTION
This PR implements support for extending the server runtime with custom auth data encryption schemes via a worker security extension. Two schemes are provided out-of-the box: JWE and clear text.

JWE is enabled by default when building. To enable the cleartext extension:

1. Change the client-rest environment.ts entry 'encryptionScheme' to 'cleartext'
2. Build the server with the Gradle setting -PencryptionScheme=cleartext

Other schemes can be supported by supplying an extension module and changing the settings described above. 

Note that the server supports loading multiple security extension modules but the build is currently set to only enable one at a time for the demo server.

