### PR TITLE
Transferring albumless photos

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -41,8 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.datatransferproject.datatransfer.google.photos.model.AlbumListResponse;
-import org.datatransferproject.datatransfer.google.photos.model.MediaItemSearchResponse;
-import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.datatransferproject.datatransfer.google.photos.model.MediaItemListResponse;
 
 public class GooglePhotosInterface {
 
@@ -60,11 +59,11 @@ public class GooglePhotosInterface {
   private final HttpTransport httpTransport = new NetHttpTransport();
   private final Credential credential;
 
-  public GooglePhotosInterface(Credential credential) {
+  GooglePhotosInterface(Credential credential) {
     this.credential = credential;
   }
 
-  public AlbumListResponse listAlbums(Optional<String> pageToken) throws IOException {
+  AlbumListResponse listAlbums(Optional<String> pageToken) throws IOException {
     Map<String, String> params = new LinkedHashMap<>();
     params.put(PAGE_SIZE_KEY, String.valueOf(ALBUM_PAGE_SIZE));
     if (pageToken.isPresent()) {
@@ -74,7 +73,7 @@ public class GooglePhotosInterface {
         AlbumListResponse.class);
   }
 
-  public MediaItemSearchResponse listAlbumContents(Optional<String> albumId, Optional<String> pageToken)
+  MediaItemListResponse listAlbumContents(Optional<String> albumId, Optional<String> pageToken)
       throws IOException {
     Map<String, String> params = new LinkedHashMap<>();
     params.put(PAGE_SIZE_KEY, String.valueOf(MEDIA_PAGE_SIZE));
@@ -86,7 +85,17 @@ public class GooglePhotosInterface {
     }
     HttpContent content = new JsonHttpContent(new JacksonFactory(), params);
     return makePostRequest(BASE_URL + "mediaItems:search", Optional.empty(), content,
-        MediaItemSearchResponse.class);
+        MediaItemListResponse.class);
+  }
+
+  MediaItemListResponse listAllMediaItems(Optional<String> pageToken) throws IOException {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put(PAGE_SIZE_KEY, String.valueOf(MEDIA_PAGE_SIZE));
+    if (pageToken.isPresent()) {
+      params.put(TOKEN_KEY, pageToken.get());
+    }
+    return makeGetRequest(BASE_URL + "mediaItems", Optional.of(params),
+        MediaItemListResponse.class);
   }
 
   private <T> T makeGetRequest(String url, Optional<Map<String, String>> parameters, Class<T> clazz)

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/MediaItemListResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/MediaItemListResponse.java
@@ -18,7 +18,7 @@ package org.datatransferproject.datatransfer.google.photos.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class MediaItemSearchResponse {
+public class MediaItemListResponse {
   @JsonProperty("mediaItems")
   private GoogleMediaItem[] mediaItems;
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
@@ -18,6 +18,7 @@ package org.datatransferproject.datatransfer.google.photos;
 import static com.google.common.truth.Truth.assertThat;
 import static org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.ALBUM_TOKEN_PREFIX;
 import static org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.PHOTO_TOKEN_PREFIX;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -25,21 +26,24 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.photos.model.AlbumListResponse;
 import org.datatransferproject.datatransfer.google.photos.model.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.photos.model.GoogleMediaItem;
-import org.datatransferproject.datatransfer.google.photos.model.MediaItemSearchResponse;
+import org.datatransferproject.datatransfer.google.photos.model.MediaItemListResponse;
 import org.datatransferproject.datatransfer.google.photos.model.MediaMetadata;
 import org.datatransferproject.datatransfer.google.photos.model.Photo;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
+import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
-import org.datatransferproject.spi.transfer.types.ExportInformation;
 import org.datatransferproject.spi.transfer.types.IdOnlyContainerResource;
+import org.datatransferproject.spi.transfer.types.PaginationData;
 import org.datatransferproject.spi.transfer.types.StringPaginationToken;
 import org.datatransferproject.types.transfer.models.ContainerResource;
 import org.datatransferproject.types.transfer.models.photos.PhotoAlbum;
@@ -51,9 +55,7 @@ import org.mockito.Matchers;
 
 public class GooglePhotosExporterTest {
 
-  private String PHOTO_TITLE = "Google photo title";
   private String IMG_URI = "image uri";
-  private String JPEG_MEDIA_TYPE = "image/jpeg";
   private String ALBUM_ID = "GoogleAlbum id";
   private String ALBUM_TOKEN = "album_token";
   private String PHOTO_TOKEN = "photo_token";
@@ -62,38 +64,39 @@ public class GooglePhotosExporterTest {
 
   private GooglePhotosExporter googlePhotosExporter;
 
-  private GoogleCredentialFactory credentialFactory;
   private GooglePhotosInterface photosInterface;
 
   private AlbumListResponse albumListResponse;
-  private MediaItemSearchResponse mediaItemSearchResponse;
+  private MediaItemListResponse mediaItemListResponse;
 
   @Before
   public void setup() throws IOException {
-    credentialFactory = mock(GoogleCredentialFactory.class);
+    GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
     photosInterface = mock(GooglePhotosInterface.class);
 
     albumListResponse = mock(AlbumListResponse.class);
-    mediaItemSearchResponse = mock(MediaItemSearchResponse.class);
+    mediaItemListResponse = mock(MediaItemListResponse.class);
 
     googlePhotosExporter =
         new GooglePhotosExporter(credentialFactory, photosInterface);
 
     when(photosInterface.listAlbums(Matchers.any(Optional.class)))
         .thenReturn(albumListResponse);
-    when(photosInterface.listAlbumContents(Matchers.any(Optional.class), Matchers.any(Optional.class)))
-        .thenReturn(mediaItemSearchResponse);
+    when(photosInterface
+        .listAlbumContents(Matchers.any(Optional.class), Matchers.any(Optional.class)))
+        .thenReturn(mediaItemListResponse);
 
     verifyZeroInteractions(credentialFactory);
   }
 
   @Test
   public void exportAlbumFirstSet() throws IOException {
-    setUpSingleAlbumResponse();
+    setUpSingleAlbum();
+    when(albumListResponse.getNextPageToken()).thenReturn(ALBUM_TOKEN);
 
     // Run test
     ExportResult<PhotosContainerResource> result = googlePhotosExporter
-        .export(uuid, null, Optional.empty());
+        .exportAlbums(null, Optional.empty());
 
     // Check results
     // Verify correct methods were called
@@ -101,7 +104,7 @@ public class GooglePhotosExporterTest {
     verify(albumListResponse).getAlbums();
 
     // Check pagination token
-    ContinuationData continuationData = (ContinuationData) result.getContinuationData();
+    ContinuationData continuationData = result.getContinuationData();
     StringPaginationToken paginationToken =
         (StringPaginationToken) continuationData.getPaginationData();
     assertThat(paginationToken.getToken()).isEqualTo(ALBUM_TOKEN_PREFIX + ALBUM_TOKEN);
@@ -127,44 +130,45 @@ public class GooglePhotosExporterTest {
 
   @Test
   public void exportAlbumSubsequentSet() throws IOException {
-    setUpSingleAlbumResponse();
+    setUpSingleAlbum();
+    when(albumListResponse.getNextPageToken()).thenReturn(null);
+
     StringPaginationToken inputPaginationToken =
         new StringPaginationToken(ALBUM_TOKEN_PREFIX + ALBUM_TOKEN);
-    ExportInformation inputExportInformation = new ExportInformation(inputPaginationToken, null);
 
     // Run test
-    ExportResult<PhotosContainerResource> result =
-        googlePhotosExporter.export(uuid, null, Optional.of(inputExportInformation));
+    ExportResult<PhotosContainerResource> result = googlePhotosExporter
+        .exportAlbums(null, Optional.of(inputPaginationToken));
 
     // Check results
     // Verify correct methods were called
     verify(photosInterface).listAlbums(Optional.of(ALBUM_TOKEN));
     verify(albumListResponse).getAlbums();
 
-    // Check pagination token
-    ContinuationData continuationData = (ContinuationData) result.getContinuationData();
-    StringPaginationToken paginationToken =
-        (StringPaginationToken) continuationData.getPaginationData();
-    assertThat(paginationToken.getToken()).isEqualTo(ALBUM_TOKEN_PREFIX + ALBUM_TOKEN);
+    // Check pagination token - should be absent
+    ContinuationData continuationData = result.getContinuationData();
+    PaginationData paginationData = continuationData.getPaginationData();
+    assertNull(paginationData);
   }
 
   @Test
   public void exportPhotoFirstSet() throws IOException {
-    setUpSinglePhotoResponse();
-
-    ContainerResource inputContainerResource = new IdOnlyContainerResource(ALBUM_ID);
-    ExportInformation inputExportInformation = new ExportInformation(null, inputContainerResource);
+    setUpSingleAlbum();
+    when(albumListResponse.getNextPageToken()).thenReturn(null);
+    GoogleMediaItem mediaItem = setUpSinglePhoto(IMG_URI, ALBUM_ID);
+    when(mediaItemListResponse.getMediaItems()).thenReturn(new GoogleMediaItem[]{mediaItem});
+    when(mediaItemListResponse.getNextPageToken()).thenReturn(PHOTO_TOKEN);
 
     ExportResult<PhotosContainerResource> result =
-        googlePhotosExporter.export(uuid, null, Optional.of(inputExportInformation));
+        googlePhotosExporter.exportPhotos(null, ALBUM_ID, Optional.empty());
 
     // Check results
     // Verify correct methods were called
     verify(photosInterface).listAlbumContents(Optional.of(ALBUM_ID), Optional.empty());
-    verify(mediaItemSearchResponse).getMediaItems();
+    verify(mediaItemListResponse).getMediaItems();
 
     // Check pagination
-    ContinuationData continuationData = (ContinuationData) result.getContinuationData();
+    ContinuationData continuationData = result.getContinuationData();
     StringPaginationToken paginationToken =
         (StringPaginationToken) continuationData.getPaginationData();
     assertThat(paginationToken.getToken()).isEqualTo(PHOTO_TOKEN_PREFIX + PHOTO_TOKEN);
@@ -183,57 +187,138 @@ public class GooglePhotosExporterTest {
 
   @Test
   public void exportPhotoSubsequentSet() throws IOException {
-    setUpSinglePhotoResponse();
+    setUpSingleAlbum();
+    when(albumListResponse.getNextPageToken()).thenReturn(null);
+    GoogleMediaItem mediaItem = setUpSinglePhoto(IMG_URI, ALBUM_ID);
+    when(mediaItemListResponse.getMediaItems()).thenReturn(new GoogleMediaItem[]{mediaItem});
+    when(mediaItemListResponse.getNextPageToken()).thenReturn(null);
 
     StringPaginationToken inputPaginationToken =
         new StringPaginationToken(PHOTO_TOKEN_PREFIX + PHOTO_TOKEN);
-    ContainerResource inputContainerResource = new IdOnlyContainerResource(ALBUM_ID);
-    ExportInformation inputExportInformation =
-        new ExportInformation(inputPaginationToken, inputContainerResource);
 
     // Run test
-    ExportResult<PhotosContainerResource> result =
-        googlePhotosExporter.export(uuid, null, Optional.of(inputExportInformation));
+    ExportResult<PhotosContainerResource> result = googlePhotosExporter
+        .exportPhotos(null, ALBUM_ID, Optional.of(inputPaginationToken));
 
     // Check results
     // Verify correct methods were called
     verify(photosInterface).listAlbumContents(Optional.of(ALBUM_ID), Optional.of(PHOTO_TOKEN));
-    verify(mediaItemSearchResponse).getMediaItems();
+    verify(mediaItemListResponse).getMediaItems();
 
     // Check pagination token
-    ContinuationData continuationData = (ContinuationData) result.getContinuationData();
-    StringPaginationToken paginationToken =
-        (StringPaginationToken) continuationData.getPaginationData();
-    assertThat(paginationToken.getToken()).isEqualTo(PHOTO_TOKEN_PREFIX + PHOTO_TOKEN);
+    ContinuationData continuationData = result.getContinuationData();
+    PaginationData paginationToken = continuationData.getPaginationData();
+    assertNull(paginationToken);
+  }
+
+  @Test
+  public void exportAlbumLessPhoto() throws IOException {
+    // Set up an album with a photo, and then an albumless photo
+    setUpSingleAlbum();
+    when(albumListResponse.getNextPageToken()).thenReturn(null);
+
+    MediaItemListResponse albumMediaResponse = mock(MediaItemListResponse.class);
+    GoogleMediaItem albumPhoto = setUpSinglePhoto(IMG_URI, ALBUM_ID);
+    when(photosInterface
+        .listAlbumContents(Matchers.eq(Optional.of(ALBUM_ID)), Matchers.any(Optional.class)))
+        .thenReturn(albumMediaResponse);
+    when(albumMediaResponse.getMediaItems()).thenReturn(new GoogleMediaItem[]{albumPhoto});
+    when(albumMediaResponse.getNextPageToken()).thenReturn(null);
+
+    MediaItemListResponse albumlessMediaResponse = mock(MediaItemListResponse.class);
+    String albumlessUri = "albumlessUri";
+    GoogleMediaItem albumlessPhoto = setUpSinglePhoto(albumlessUri, null);
+    when(photosInterface
+        .listAllMediaItems(Matchers.any(Optional.class)))
+        .thenReturn(albumlessMediaResponse);
+    when(albumlessMediaResponse.getMediaItems()).thenReturn(new GoogleMediaItem[]{albumlessPhoto});
+    when(albumlessMediaResponse.getNextPageToken()).thenReturn(null);
+
+    // Run test
+    ExportResult<PhotosContainerResource> result =
+        googlePhotosExporter.export(uuid, null, Optional.empty());
+
+    // Check result
+    assertThat(result.getExportedData()).isNotNull();
+    PhotosContainerResource exportedResource = result.getExportedData();
+
+    // Verify correct methods were called
+    verify(photosInterface).listAlbumContents(Optional.of(ALBUM_ID), Optional.empty());
+    verify(photosInterface).listAllMediaItems(Optional.empty());
+
+    // Check photo content of exportResult
+    assertThat(exportedResource.getPhotos()).hasSize(1); // one photo, hopefully albumless
+    PhotoModel exportedPhoto = exportedResource.getPhotos().iterator().next();
+    assertThat(exportedPhoto.getFetchableUrl()).isEqualTo(albumlessUri + "=d"); // for download
+
+    // Check album content of exportResult
+    assertThat(exportedResource.getAlbums()).hasSize(1); // one album
+    PhotoAlbum exportedAlbum = exportedResource.getAlbums().iterator().next();
+    assertThat(exportedAlbum.getId()).isEqualTo(ALBUM_ID);
+  }
+
+  @Test
+  public void addPhotosToExportResult() {
+    // Set up
+    String albumId = "albumId";
+    String containerPhotoId = "containerPhotoId";
+    String additionalPhotoId = "additionalPhotoId";
+    PhotoAlbum album = new PhotoAlbum(albumId, null, null);
+    PhotoModel containerPhoto = new PhotoModel(containerPhotoId, null, null, null, null, albumId,
+        false);
+    PhotoModel additionalPhoto = new PhotoModel(additionalPhotoId, null, null, null, null, null,
+        false);
+
+    ResultType resultType = ResultType.CONTINUE;
+    ContinuationData continuationData = new ContinuationData(
+        new StringPaginationToken("token"));
+
+    ExportResult<PhotosContainerResource> originalExportResult = new ExportResult<>(
+        resultType,
+        new PhotosContainerResource(Collections.singleton(album),
+            Collections.singleton(containerPhoto)),
+        continuationData);
+    List<PhotoModel> additionalPhotos = Collections.singletonList(additionalPhoto);
+
+    // Run test
+    ExportResult<PhotosContainerResource> newExportResult = googlePhotosExporter
+        .addMorePhotos(originalExportResult, additionalPhotos);
+
+    // Check results
+    assertThat(newExportResult.getType()).isEqualTo(resultType);
+    assertThat(newExportResult.getContinuationData()).isEqualTo(continuationData);
+
+    PhotosContainerResource newResource = newExportResult.getExportedData();
+    assertThat(newResource.getAlbums()).hasSize(1);
+    assertThat(newResource.getAlbums().iterator().next()).isEqualTo(album);
+    assertThat(newResource.getPhotos()).hasSize(2);
+    assertThat(newResource.getPhotos()).containsExactly(containerPhoto, additionalPhoto);
   }
 
   /**
    * Sets up a response with a single album, containing a single photo
    */
-  private void setUpSingleAlbumResponse() {
+  private void setUpSingleAlbum() {
     GoogleAlbum albumEntry = new GoogleAlbum();
     albumEntry.setId(ALBUM_ID);
     albumEntry.setTitle("Title");
 
     when(albumListResponse.getAlbums()).thenReturn(new GoogleAlbum[]{albumEntry});
-    when(albumListResponse.getNextPageToken()).thenReturn(ALBUM_TOKEN);
-
-    setUpSinglePhotoResponse();
   }
 
   /**
    * Sets up a response for a single photo
    */
-  private void setUpSinglePhotoResponse() {
+  private GoogleMediaItem setUpSinglePhoto(String imageUri, @Nullable String photoToken) {
     GoogleMediaItem photoEntry = new GoogleMediaItem();
     photoEntry.setDescription("Description");
-    photoEntry.setMimeType(JPEG_MEDIA_TYPE);
-    photoEntry.setBaseUrl(IMG_URI);
+    photoEntry.setMimeType("image/jpeg");
+    photoEntry.setBaseUrl(imageUri);
     MediaMetadata mediaMetadata = new MediaMetadata();
     mediaMetadata.setPhoto(new Photo());
     photoEntry.setMediaMetadata(mediaMetadata);
 
-    when(mediaItemSearchResponse.getMediaItems()).thenReturn(new GoogleMediaItem[]{photoEntry});
-    when(mediaItemSearchResponse.getNextPageToken()).thenReturn(PHOTO_TOKEN);
+    return photoEntry;
   }
+
 }


### PR DESCRIPTION
Basics of transferring albumless photos.

Due to API limitations, this is an inefficient process.  First, we get a list of all media items in a user's library.  We then get a list of all albums, and a list of media items in each album.  We subtract the set of all album-assigned photos to get the set of albumless photos and export those as part of the initial export step.

There is a **lot** of room for improvement here.  We don't yet address what would happen if any of those sets are too big for memory, and we don't take any advantage of having a list of all albums and their contents at the beginning.  This is just Step 1.

#581 