### PR TITLE
Maven-based Artifact publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 .gradle/
-gradle/
-**/gradlew
-**/gradlew.bat
 *.log
 
 secrets.csv

--- a/build.gradle
+++ b/build.gradle
@@ -91,84 +91,99 @@ configure(sourceProjects()) {
     }
 }
 
-// Setup publishing configuration for all subprojects that have applied the Maven Publish plugin
-subprojects {
-
-    plugins.withId('maven-publish') {
-
-        apply plugin: 'io.spring.bintray'
-
-        // Configure artifact publication
-        def pomConfig = {
-            licenses {
-                license {
-                    name 'Apache 2.0'
-                    url 'https://www.apache.org/licenses/LICENSE-2.0.html'
-                    distribution 'repo'
-                }
-            }
-            developers {
-                developer {
-                    id 'dtp'
-                    name 'Data Transfer Project'
-                    email "dev@null.com"
-                }
-            }
-
-            scm {
-                url 'https://github.com/google/data-transfer-project'
-            }
-        }
-        publishing {
-            publications {
-                mavenJava(MavenPublication) {
-                    from components.java
-                    artifact sourcesJar
-                    artifact javadocJar
-                    pom.withXml {
-                        def root = asNode()
-                        root.appendNode('description', 'The Data Transfer Project')
-                        root.appendNode('name', 'DTP')
-                        root.appendNode('url', 'https://datatransferproject.dev/')
-                        root.children().last() + pomConfig
-                    }
-                }
-            }
-        }
-
-        // Configuration for uploading to Bintray
-        // secrets stored in ~/.gradle/gradle.properties
-        def bUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : 'undefined'
-        def bKey = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : 'undefined'
-
-        bintray {
-
-            bintrayUser = bUser
-            bintrayKey = bKey
-
-            repo = 'TBD'
-            publication = 'mavenJava'
-
-            org = 'TBD'
-            labels = ['TBD', 'TBD']
-            licenses = ['Apache']
-            overrideOnUpload = false // upload task should not override existing artifacts
-
-            websiteUrl = 'https://datatransferproject.dev/'
-            issueTrackerUrl = 'https://github.com/google/data-transfer-project/issues'
-            vcsUrl = 'https://github.com/google/data-transfer-project'
-
-            // if syncing to Maven Central
-            // ossrhUser =
-            // ossrhPassword =
-            // gpgPassphrase =
-        }
-
-    }
-}
-
 def addCloudExtensionDependency(proj) {
     proj.dependencies { compile project(":extensions:cloud:portability-cloud-${proj.rootProject.ext.cloudType}") }
+}
+
+/**
+ * Configures the project to publish Maven artifacts to BinTray.
+ */
+def configurePublication(project) {
+    // Configure artifact publication
+
+    project.publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+                artifact project.sourcesJar
+                artifact project.javadocJar
+                pom.withXml {
+                    def root = asNode()
+                    root.appendNode('description', 'The Data Transfer Project')
+                    root.appendNode('name', 'DTP')
+                    root.appendNode('url', 'https://datatransferproject.dev/')
+                    root.children().last() + getPomConfig();
+                }
+            }
+        }
+    }
+
+    configBinTray(project);
+
+}
+
+/**
+ * Configures the project to upload artifacts to BinTray.
+ */
+def configBinTray(project) {
+    // Configuration for uploading to BinTray and signing artifacts
+    // secrets stored in ~/.gradle/gradle.properties
+    def bUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : 'undefined'
+    def bKey = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : 'undefined'
+    def gpgPhrase = project.hasProperty('gpgPassphrase') ? project.property('gpgPassphrase') : 'undefined'
+
+    project.bintray {
+
+        bintrayUser = bUser
+        bintrayKey = bKey
+        gpgPassphrase = gpgPhrase
+        publication = 'mavenJava'
+
+        org = 'test-dtp'   // TODO currently publish to a test org and repo - these will be changed when permanents ones are established
+        repo = 'DTP'
+        labels = ['data transfer']
+        licenses = ['Apache-2.0']
+        overrideOnUpload = false // upload task should not override existing artifacts
+
+        websiteUrl = 'https://datatransferproject.dev/'
+        issueTrackerUrl = 'https://github.com/google/data-transfer-project/issues'
+        vcsUrl = 'https://github.com/google/data-transfer-project'
+
+        // if syncing to Maven Central
+        // ossrhUser =
+        // ossrhPassword =
+        // gpgPassphrase =
+    }
+
+}
+
+/**
+ * Returns the sections of a Maven POM required for publication.
+ */
+def getPomConfig() {
+    return {
+        licenses {
+            license {
+                name 'Apache 2.0'
+                url 'https://www.apache.org/licenses/LICENSE-2.0.html'
+                distribution 'repo'
+            }
+        }
+        developers {
+            developer {
+                id 'dtp'
+                name 'Data Transfer Project'
+                email "dev@null.com"
+            }
+        }
+
+        scm {
+            url 'https://github.com/google/data-transfer-project'
+            developerConnection 'scm:git:ssh://git@github.com:google/data-transfer-project.git'
+
+        }
+    }
+
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,10 +32,16 @@
  *
  * To specify whether to use a local or host installation of Node to build the client web app, use: "-PnodeType=local"
  * (default) or "-PnodeType=host"
+ *
+ *
+ * Note that if you add a submodule and want it published with official releases, add the 'maven-publish' plugin to the submodule configuration.
  */
 buildscript {
     repositories {
         jcenter()
+    }
+    dependencies {
+        classpath "io.spring.gradle:spring-bintray-plugin:0.11.1"
     }
 }
 
@@ -59,6 +65,9 @@ configure(sourceProjects()) {
 
     apply plugin: 'java'
 
+    group = "${projectGroup}"
+    version = "${projectVersion}"
+
     sourceCompatibility = 1.8
 
     dependencies {
@@ -70,8 +79,96 @@ configure(sourceProjects()) {
         testCompile "junit:junit:${junitVersion}"
         testCompile "com.google.truth:truth:0.39"
     }
+
+    task sourcesJar(type: Jar) {
+        classifier = 'sources'
+        from sourceSets.main.allJava
+    }
+
+    task javadocJar(type: Jar) {
+        classifier = 'javadoc'
+        from "../notice/javadoc/README.md"
+    }
+}
+
+// Setup publishing configuration for all subprojects that have applied the Maven Publish plugin
+subprojects {
+
+    plugins.withId('maven-publish') {
+
+        apply plugin: 'io.spring.bintray'
+
+        // Configure artifact publication
+        def pomConfig = {
+            licenses {
+                license {
+                    name 'Apache 2.0'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.html'
+                    distribution 'repo'
+                }
+            }
+            developers {
+                developer {
+                    id 'dtp'
+                    name 'Data Transfer Project'
+                    email "dev@null.com"
+                }
+            }
+
+            scm {
+                url 'https://github.com/google/data-transfer-project'
+            }
+        }
+        publishing {
+            publications {
+                mavenJava(MavenPublication) {
+                    from components.java
+                    artifact sourcesJar
+                    artifact javadocJar
+                    pom.withXml {
+                        def root = asNode()
+                        root.appendNode('description', 'The Data Transfer Project')
+                        root.appendNode('name', 'DTP')
+                        root.appendNode('url', 'https://datatransferproject.dev/')
+                        root.children().last() + pomConfig
+                    }
+                }
+            }
+        }
+
+        // Configuration for uploading to Bintray
+        // secrets stored in ~/.gradle/gradle.properties
+        def bUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : 'undefined'
+        def bKey = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : 'undefined'
+
+        bintray {
+
+            bintrayUser = bUser
+            bintrayKey = bKey
+
+            repo = 'TBD'
+            publication = 'mavenJava'
+
+            org = 'TBD'
+            labels = ['TBD', 'TBD']
+            licenses = ['Apache']
+            overrideOnUpload = false // upload task should not override existing artifacts
+
+            websiteUrl = 'https://datatransferproject.dev/'
+            issueTrackerUrl = 'https://github.com/google/data-transfer-project/issues'
+            vcsUrl = 'https://github.com/google/data-transfer-project'
+
+            // if syncing to Maven Central
+            // ossrhUser =
+            // ossrhPassword =
+            // gpgPassphrase =
+        }
+
+    }
 }
 
 def addCloudExtensionDependency(proj) {
     proj.dependencies { compile project(":extensions:cloud:portability-cloud-${proj.rootProject.ext.cloudType}") }
 }
+
+

--- a/client-rest/build.gradle
+++ b/client-rest/build.gradle
@@ -16,6 +16,7 @@
  */
 plugins {
     id "com.moowork.node" version "1.2.0"
+    id 'maven-publish'
 }
 
 task installLocalAngularCli(type: NpmTask) {
@@ -93,5 +94,33 @@ task installTools {
         dependsOn installLocalAngularCli
     }
 }
+
+// creates the distribution ZIP containing the compiled Angular application
+task createDistribution(type: Zip) {
+    from "dist/portability-demo"
+    include "*"
+    include "*/*"
+    archiveName "client-rest.zip"
+    destinationDir(file("${buildDir}/libs"))
+}
+
+def distFile = file("${buildDir}/libs/client-rest.zip")
+def distArtifact = artifacts.add('archives', distFile) {
+}
+
+publishing {
+
+    publications {
+
+        maven(MavenPublication) {
+            artifact distArtifact
+        }
+    }
+}
+
+// link the publish task to archive creation to ensure the latter is present
+tasks.findAll { it.name.startsWith('publish') }*.dependsOn(createDistribution)
+
+
 
 

--- a/client-rest/build.gradle
+++ b/client-rest/build.gradle
@@ -17,6 +17,7 @@
 plugins {
     id "com.moowork.node" version "1.2.0"
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 task installLocalAngularCli(type: NpmTask) {
@@ -108,15 +109,22 @@ def distFile = file("${buildDir}/libs/client-rest.zip")
 def distArtifact = artifacts.add('archives', distFile) {
 }
 
-publishing {
-
+project.publishing {
     publications {
-
-        maven(MavenPublication) {
+        mavenJava(MavenPublication) {
             artifact distArtifact
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'The Data Transfer Project')
+                root.appendNode('name', 'DTP')
+                root.appendNode('url', 'https://datatransferproject.dev/')
+                root.children().last() + getPomConfig();
+            }
         }
     }
 }
+
+configBinTray(project);
 
 // link the publish task to archive creation to ensure the latter is present
 tasks.findAll { it.name.startsWith('publish') }*.dependsOn(createDistribution)

--- a/extensions/auth/portability-auth-flickr/build.gradle
+++ b/extensions/auth/portability-auth-flickr/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/auth/portability-auth-flickr/build.gradle
+++ b/extensions/auth/portability-auth-flickr/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -30,3 +31,5 @@ dependencies {
     testCompile("org.mockito:mockito-core:${mockitoVersion}")
     testCompile project(":extensions:cloud:portability-cloud-local")
 }
+
+configurePublication(project)

--- a/extensions/auth/portability-auth-google/build.gradle
+++ b/extensions/auth/portability-auth-google/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-api')

--- a/extensions/auth/portability-auth-google/build.gradle
+++ b/extensions/auth/portability-auth-google/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -41,3 +42,4 @@ dependencies {
 }
 
 
+configurePublication(project)

--- a/extensions/auth/portability-auth-harness-microsoft/build.gradle
+++ b/extensions/auth/portability-auth-harness-microsoft/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':extensions:auth:portability-auth-microsoft')

--- a/extensions/auth/portability-auth-harness-microsoft/build.gradle
+++ b/extensions/auth/portability-auth-harness-microsoft/build.gradle
@@ -15,10 +15,12 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
     compile project(':extensions:auth:portability-auth-microsoft')
 }
 
+configurePublication(project)
 

--- a/extensions/auth/portability-auth-instagram/build.gradle
+++ b/extensions/auth/portability-auth-instagram/build.gradle
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     compile project(':portability-spi-api')
     compile project(':portability-spi-cloud')

--- a/extensions/auth/portability-auth-instagram/build.gradle
+++ b/extensions/auth/portability-auth-instagram/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -33,3 +34,5 @@ dependencies {
     testCompile("org.mockito:mockito-all:${mockitoVersion}")
 }
 
+
+configurePublication(project)

--- a/extensions/auth/portability-auth-microsoft/build.gradle
+++ b/extensions/auth/portability-auth-microsoft/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-api')

--- a/extensions/auth/portability-auth-microsoft/build.gradle
+++ b/extensions/auth/portability-auth-microsoft/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -27,3 +28,4 @@ dependencies {
 }
 
 
+configurePublication(project)

--- a/extensions/auth/portability-auth-offline-demo/build.gradle
+++ b/extensions/auth/portability-auth-offline-demo/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -23,3 +24,4 @@ dependencies {
 }
       
 
+configurePublication(project)

--- a/extensions/auth/portability-auth-offline-demo/build.gradle
+++ b/extensions/auth/portability-auth-offline-demo/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-api')

--- a/extensions/auth/portability-auth-rememberthemilk/build.gradle
+++ b/extensions/auth/portability-auth-rememberthemilk/build.gradle
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     compile project(':portability-spi-api')
     compile project(':portability-spi-cloud')

--- a/extensions/auth/portability-auth-rememberthemilk/build.gradle
+++ b/extensions/auth/portability-auth-rememberthemilk/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -28,3 +29,5 @@ dependencies {
     compile("com.google.http-client:google-http-client-xml:${googleApiClient}")
     compile("com.google.api-client:google-api-client:${googleApiClient}")
 }
+
+configurePublication(project)

--- a/extensions/auth/portability-auth-smugmug/build.gradle
+++ b/extensions/auth/portability-auth-smugmug/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -26,3 +27,5 @@ dependencies {
     compile("com.google.http-client:google-http-client:${googleApiClient}")
     compile("org.scribe:scribe:1.3.7")
 }
+
+configurePublication(project)

--- a/extensions/auth/portability-auth-smugmug/build.gradle
+++ b/extensions/auth/portability-auth-smugmug/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-api')

--- a/extensions/auth/portability-auth-twitter/build.gradle
+++ b/extensions/auth/portability-auth-twitter/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-api')

--- a/extensions/auth/portability-auth-twitter/build.gradle
+++ b/extensions/auth/portability-auth-twitter/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -26,3 +27,5 @@ dependencies {
 
     compile 'org.twitter4j:twitter4j-core:4.0.3'
 }
+
+configurePublication(project)

--- a/extensions/cloud/portability-cloud-google/build.gradle
+++ b/extensions/cloud/portability-cloud-google/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -37,3 +38,5 @@ dependencies {
     compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
 
 }
+
+configurePublication(project)

--- a/extensions/cloud/portability-cloud-google/build.gradle
+++ b/extensions/cloud/portability-cloud-google/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':libraries:config')

--- a/extensions/cloud/portability-cloud-local/build.gradle
+++ b/extensions/cloud/portability-cloud-local/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/cloud/portability-cloud-local/build.gradle
+++ b/extensions/cloud/portability-cloud-local/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -25,3 +26,5 @@ dependencies {
     compile("org.slf4j:slf4j-api:${slf4jVersion}")
     compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
 }
+
+configurePublication(project)

--- a/extensions/cloud/portability-cloud-microsoft/build.gradle
+++ b/extensions/cloud/portability-cloud-microsoft/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     

--- a/extensions/cloud/portability-cloud-microsoft/build.gradle
+++ b/extensions/cloud/portability-cloud-microsoft/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -31,3 +32,5 @@ dependencies {
     compile 'com.microsoft.azure:azure-storage:7.0.0'
     
 }
+
+configurePublication(project)

--- a/extensions/config/portability-config-yaml/build.gradle
+++ b/extensions/config/portability-config-yaml/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -28,3 +29,5 @@ dependencies {
     testCompile("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
     testCompile("org.mockito:mockito-core:${mockitoVersion}")
 }
+
+configurePublication(project)

--- a/extensions/config/portability-config-yaml/build.gradle
+++ b/extensions/config/portability-config-yaml/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':libraries:config')

--- a/extensions/data-transfer/portability-data-transfer-flickr/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-flickr/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/data-transfer/portability-data-transfer-flickr/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-flickr/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -30,3 +31,5 @@ dependencies {
     testCompile("org.mockito:mockito-core:${mockitoVersion}")
     testCompile project(":extensions:cloud:portability-cloud-local")
 }
+
+configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-google/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-google/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -40,3 +41,5 @@ dependencies {
     testCompile("org.mockito:mockito-core:${mockitoVersion}")
     testCompile project(':extensions:cloud:portability-cloud-local')
 }
+
+configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-google/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-google/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/data-transfer/portability-data-transfer-instagram/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-instagram/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -29,3 +30,5 @@ dependencies {
 
     testCompile("org.mockito:mockito-core:${mockitoVersion}")
 }
+
+configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-instagram/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-instagram/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/data-transfer/portability-data-transfer-microsoft/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -31,3 +32,5 @@ dependencies {
     testCompile group: 'com.squareup.okhttp', name: 'mockwebserver', version: '2.7.5'
 
 }
+
+configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-microsoft/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -24,3 +25,5 @@ dependencies {
 
 
 }
+
+configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -29,3 +30,5 @@ dependencies {
     compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
 
 }
+
+configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-smugmug/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -28,3 +29,5 @@ dependencies {
 
     compile("org.scribe:scribe:1.3.7")
 }
+
+configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-smugmug/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/data-transfer/portability-data-transfer-twitter/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-twitter/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-cloud')

--- a/extensions/data-transfer/portability-data-transfer-twitter/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-twitter/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -29,3 +30,7 @@ dependencies {
 
     compile 'org.twitter4j:twitter4j-core:4.0.3'
 }
+
+
+configurePublication(project)
+

--- a/extensions/security/portability-security-cleartext/build.gradle
+++ b/extensions/security/portability-security-cleartext/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-transfer')

--- a/extensions/security/portability-security-cleartext/build.gradle
+++ b/extensions/security/portability-security-cleartext/build.gradle
@@ -15,8 +15,11 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
     compile project(':portability-spi-transfer')
 }
+
+configurePublication(project)

--- a/extensions/security/portability-security-jwe/build.gradle
+++ b/extensions/security/portability-security-jwe/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(':portability-spi-transfer')

--- a/extensions/security/portability-security-jwe/build.gradle
+++ b/extensions/security/portability-security-jwe/build.gradle
@@ -15,9 +15,12 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
     compile project(':portability-spi-transfer')
     compile group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '5.14'
 }
+
+configurePublication(project)

--- a/extensions/transport/portability-transport-jettyrest/build.gradle
+++ b/extensions/transport/portability-transport-jettyrest/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
 

--- a/extensions/transport/portability-transport-jettyrest/build.gradle
+++ b/extensions/transport/portability-transport-jettyrest/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -43,3 +44,5 @@ dependencies {
     compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
 
 }
+
+configurePublication(project)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectGroup=org.datatransferproject
-projectVersion=1.0-SNAPSHOT
+projectVersion=0.1
 annotationApiVersion=1.2
 autoValueVersion=1.5.3
 commonsLangVersion=3.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 12 12:33:31 CST 2018
+#Mon Sep 24 14:23:52 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/libraries/config/build.gradle
+++ b/libraries/config/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile project(":portability-api-launcher")

--- a/libraries/config/build.gradle
+++ b/libraries/config/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -25,3 +26,5 @@ dependencies {
     compile("org.slf4j:slf4j-api:${slf4jVersion}")
     compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
 }
+
+configurePublication(project)

--- a/libraries/logging/build.gradle
+++ b/libraries/logging/build.gradle
@@ -16,9 +16,12 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
     compile("org.slf4j:slf4j-api:${slf4jVersion}")
     compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
 }
+
+configurePublication(project)

--- a/libraries/logging/build.gradle
+++ b/libraries/logging/build.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     compile("org.slf4j:slf4j-api:${slf4jVersion}")
     compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")

--- a/libraries/security/build.gradle
+++ b/libraries/security/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -24,3 +25,5 @@ dependencies {
     compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
     testCompile("org.mockito:mockito-all:${mockitoVersion}")
 }
+
+configurePublication(project)

--- a/libraries/security/build.gradle
+++ b/libraries/security/build.gradle
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id 'maven-publish'
+}
 
 dependencies {
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}")

--- a/libraries/transfer/build.gradle
+++ b/libraries/transfer/build.gradle
@@ -15,4 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
+
+configurePublication(project)

--- a/libraries/transfer/build.gradle
+++ b/libraries/transfer/build.gradle
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-dependencies {
-    // Logging
-    compile("org.slf4j:slf4j-api:${slf4jVersion}")
-    compile("org.slf4j:slf4j-log4j12:${slf4jVersion}")
+plugins {
+    id 'maven-publish'
 }

--- a/portability-api-launcher/build.gradle
+++ b/portability-api-launcher/build.gradle
@@ -1,0 +1,4 @@
+
+plugins {
+    id 'maven-publish'
+}

--- a/portability-api-launcher/build.gradle
+++ b/portability-api-launcher/build.gradle
@@ -1,4 +1,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
+
+configurePublication(project)

--- a/portability-api/build.gradle
+++ b/portability-api/build.gradle
@@ -15,6 +15,7 @@
  */
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 jar {
@@ -67,3 +68,5 @@ dependencies {
 sourceSets.test {
     resources.srcDirs = ["src/test/resources"]
 }
+
+configurePublication(project)

--- a/portability-api/build.gradle
+++ b/portability-api/build.gradle
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-group = 'org.datatransferproject'
-version = '1.0-SNAPSHOT'
+plugins {
+    id 'maven-publish'
+}
 
 jar {
     // TODO: consider using the gradle fatjar plugin rather than this dependency jar building logic

--- a/portability-bootstrap-vm/build.gradle
+++ b/portability-bootstrap-vm/build.gradle
@@ -15,6 +15,10 @@
  */
 
 
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     compile project(':portability-api')
     compile project(':portability-transfer')

--- a/portability-bootstrap-vm/build.gradle
+++ b/portability-bootstrap-vm/build.gradle
@@ -17,9 +17,12 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
     compile project(':portability-api')
     compile project(':portability-transfer')
 }
+
+configurePublication(project)

--- a/portability-spi-api/build.gradle
+++ b/portability-spi-api/build.gradle
@@ -16,6 +16,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -23,3 +24,4 @@ dependencies {
     compile project(':portability-types-transfer')
     compile project(':portability-api-launcher')
 }
+configurePublication(project)

--- a/portability-spi-api/build.gradle
+++ b/portability-spi-api/build.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     compile project(':portability-types-common')
     compile project(':portability-types-transfer')

--- a/portability-spi-cloud/build.gradle
+++ b/portability-spi-cloud/build.gradle
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     compile project(':portability-types-transfer')
     compile project(':portability-api-launcher')

--- a/portability-spi-cloud/build.gradle
+++ b/portability-spi-cloud/build.gradle
@@ -17,6 +17,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -41,3 +42,5 @@ sourceSets {
         }
     }
 }
+
+configurePublication(project)

--- a/portability-spi-service/build.gradle
+++ b/portability-spi-service/build.gradle
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
 
     compile project(':portability-api-launcher')

--- a/portability-spi-service/build.gradle
+++ b/portability-spi-service/build.gradle
@@ -17,6 +17,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -24,3 +25,5 @@ dependencies {
     compile project(':portability-api-launcher')
 
 }
+
+configurePublication(project)

--- a/portability-spi-transfer/build.gradle
+++ b/portability-spi-transfer/build.gradle
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
 
     compile project(':portability-types-transfer')

--- a/portability-spi-transfer/build.gradle
+++ b/portability-spi-transfer/build.gradle
@@ -17,6 +17,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -25,3 +26,5 @@ dependencies {
     compile project(':portability-api-launcher')
 
 }
+
+configurePublication(project)

--- a/portability-transfer/build.gradle
+++ b/portability-transfer/build.gradle
@@ -17,6 +17,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 group = "${projectGroup}"
@@ -91,3 +92,6 @@ dependencies {
     testCompile project(':extensions:cloud:portability-cloud-local')
 
 }
+
+configurePublication(project)
+

--- a/portability-transfer/build.gradle
+++ b/portability-transfer/build.gradle
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+
+plugins {
+    id 'maven-publish'
+}
+
 group = "${projectGroup}"
 version = "${projectVersion}"
 

--- a/portability-types-client/build.gradle
+++ b/portability-types-client/build.gradle
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     compile project(":portability-types-common")
     compile("io.swagger:swagger-annotations:${swaggerVersion}")

--- a/portability-types-client/build.gradle
+++ b/portability-types-client/build.gradle
@@ -17,6 +17,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -24,3 +25,5 @@ dependencies {
     compile("io.swagger:swagger-annotations:${swaggerVersion}")
     testCompile("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
 }
+
+configurePublication(project)

--- a/portability-types-common/build.gradle
+++ b/portability-types-common/build.gradle
@@ -17,5 +17,8 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 dependencies {}
+
+configurePublication(project);

--- a/portability-types-common/build.gradle
+++ b/portability-types-common/build.gradle
@@ -14,4 +14,8 @@
  * limitations under the License.
  */
 
+
+plugins {
+    id 'maven-publish'
+}
 dependencies {}

--- a/portability-types-transfer/build.gradle
+++ b/portability-types-transfer/build.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
     compile("com.google.auto.value:auto-value:${autoValueVersion}")
     compile("com.google.gdata:core:${gdataVersion}") {

--- a/portability-types-transfer/build.gradle
+++ b/portability-types-transfer/build.gradle
@@ -16,6 +16,7 @@
 
 plugins {
     id 'maven-publish'
+    id 'io.spring.bintray'
 }
 
 dependencies {
@@ -34,3 +35,4 @@ dependencies {
 }
 
 
+configurePublication(project)


### PR DESCRIPTION
This is an updated PR that adds support for publishing Maven-based artifacts to the build and uploading them to Bintray.

Relates to https://github.com/google/data-transfer-project/issues/580