### PR TITLE
Timeout if waiting too long for creds

### DIFF
--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
@@ -67,6 +67,8 @@ public abstract class JobAuthorization {
     CREDS_ENCRYPTION_KEY_GENERATED,
     // The api server has encrypted the credentials for the transfer worker to use.
     CREDS_STORED,
+    // The worker has timed out
+    TIMED_OUT,
   }
 
   @AutoValue.Builder

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/CredsTimeoutException.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/CredsTimeoutException.java
@@ -1,0 +1,16 @@
+package org.datatransferproject.transfer;
+
+import java.util.UUID;
+
+public class CredsTimeoutException extends RuntimeException {
+  private UUID jobId;
+
+  public CredsTimeoutException(String message, UUID jobId) {
+    super(message);
+    this.jobId = jobId;
+  }
+
+  public UUID getJobId() {
+    return jobId;
+  }
+}

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -20,8 +20,8 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.inject.Inject;
-import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.api.launcher.ExtensionContext;
+import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.security.AsymmetricKeyGenerator;
 import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
@@ -104,6 +104,11 @@ class JobPollingService extends AbstractScheduledService {
               .build());
     } catch (IOException e) {
       // Suppress exception so we still pass out the original exception
+      monitor.debug(
+          () ->
+              format(
+                  "IOException while marking job as timed out. JobId: %s; Exception: %s",
+                  jobId, e));
     }
   }
 

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -104,7 +104,7 @@ class JobPollingService extends AbstractScheduledService {
               .build());
     } catch (IOException e) {
       // Suppress exception so we still pass out the original exception
-      monitor.debug(
+      monitor.severe(
           () ->
               format(
                   "IOException while marking job as timed out. JobId: %s; Exception: %s",

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
@@ -126,6 +126,9 @@ public class WorkerMain {
                 symmetricKeyGenerator,
                 asymmetricKeyGenerator));
     worker = injector.getInstance(Worker.class);
+
+    // Reset the JobMetadata in case set previously when running SingleVMMain
+    JobMetadata.reset();
   }
 
   public void poll() {

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
@@ -172,4 +172,10 @@ final class WorkerModule extends FlagBindingModule {
   Monitor getMonitor() {
     return context.getMonitor();
   }
+
+  @Provides
+  @Singleton
+  ExtensionContext getContext() {
+    return context;
+  }
 }

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
@@ -16,6 +16,7 @@
 package org.datatransferproject.transfer;
 
 import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
+import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.cloud.local.LocalJobStore;
 import org.datatransferproject.security.AsymmetricKeyGenerator;
@@ -42,6 +43,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -131,8 +133,10 @@ public class JobPollingServiceTest {
     Scheduler scheduler = Scheduler.newFixedDelaySchedule(0, 20, TimeUnit.SECONDS);
     Set<PublicKeySerializer> serializers = Collections.singleton(serializer);
     Monitor monitor = new Monitor() {};
+    ExtensionContext extensionContext = mock(ExtensionContext.class);
+    when(extensionContext.getSetting("credTimeoutSeconds", 300)).thenReturn(300);
     jobPollingService =
-        new JobPollingService(store, asymmetricKeyGenerator, serializers, scheduler, monitor);
+        new JobPollingService(store, asymmetricKeyGenerator, serializers, scheduler, monitor, extensionContext);
   }
 
   // TODO(data-transfer-project/issues/43): Make this an integration test which uses both the API


### PR DESCRIPTION
The timeout can be set in `transfer.yaml` using the property `credTimeoutSeconds`. If not it will default to 5 minutes.

If the worker times out waiting for creds then it will mark the job state as ERROR and the auth state as TIMED_OUT.

Fixes #594 