### PR TITLE
Convert Job Hooks interface into an extension

### DIFF
--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/hooks/DefaultJobHooks.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/hooks/DefaultJobHooks.java
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.datatransferproject.spi.cloud.hooks;
-
-import java.util.UUID;
+package org.datatransferproject.spi.transfer.hooks;
 
 /** A default implementation of the job hooks. */
-public interface JobHooks {
-
-  /**
-   * Called when a job starts processing on a worker.
-   */
-  void jobStarted(UUID jobId);
-
-  /**
-   * Called when a job finishes processing on a worker. The {@code success} parameter
-   * indicates whether the transfer was succesful or not.
-   */
-  void jobFinished(UUID jobId, boolean success);
-}
+public class DefaultJobHooks implements JobHooks {}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/hooks/JobHooksExtension.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/hooks/JobHooksExtension.java
@@ -15,22 +15,11 @@
  */
 package org.datatransferproject.spi.transfer.hooks;
 
-import java.util.UUID;
+import org.datatransferproject.api.launcher.BootExtension;
 
-/**
- * This interface allows implementations to handle certain events in the job
- * life time (e.g. job started, job finished) and take actions accordingly.
- */
-public interface JobHooks {
+/** Job Hooks extensions implement this contract to be loaded in a transfer worker process. */
+public interface JobHooksExtension extends BootExtension {
 
-  /** Called when a job starts processing on a worker. */
-  default void jobStarted(UUID jobId) {
-  }
-
-  /**
-   * Called when a job finishes processing on a worker. The {@code success} parameter indicates
-   * whether the transfer was succesful or not.
-   */
-  default void jobFinished(UUID jobId, boolean success) {
-  }
+  /** Returns a Job Hooks implementation. */
+  JobHooks getJobHooks();
 }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/hooks/MultiplexJobHooks.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/hooks/MultiplexJobHooks.java
@@ -17,20 +17,23 @@ package org.datatransferproject.spi.transfer.hooks;
 
 import java.util.UUID;
 
-/**
- * This interface allows implementations to handle certain events in the job
- * life time (e.g. job started, job finished) and take actions accordingly.
- */
-public interface JobHooks {
+/** Forwards job hook events to a set of delegates. */
+public class MultiplexJobHooks implements JobHooks {
+  private JobHooks[] delegates;
 
-  /** Called when a job starts processing on a worker. */
-  default void jobStarted(UUID jobId) {
+  public MultiplexJobHooks(JobHooks... delegates) {
+    this.delegates = delegates != null ? delegates : new JobHooks[0];
   }
 
-  /**
-   * Called when a job finishes processing on a worker. The {@code success} parameter indicates
-   * whether the transfer was succesful or not.
-   */
-  default void jobFinished(UUID jobId, boolean success) {
+  public void jobStarted(UUID jobId) {
+    for (JobHooks delegate : delegates) {
+      delegate.jobStarted(jobId);
+    }
+  }
+
+  public void jobFinished(UUID jobId, boolean success) {
+    for (JobHooks delegate : delegates) {
+      delegate.jobFinished(jobId, success);
+    }
   }
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
@@ -35,6 +35,7 @@ import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.service.extension.ServiceExtension;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
+import org.datatransferproject.spi.transfer.hooks.JobHooks;
 import org.datatransferproject.spi.transfer.security.AuthDataDecryptService;
 import org.datatransferproject.spi.transfer.security.PublicKeySerializer;
 import org.datatransferproject.spi.transfer.security.SecurityExtension;
@@ -48,6 +49,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.datatransferproject.config.extension.SettingsExtensionLoader.getSettingsExtension;
 import static org.datatransferproject.launcher.monitor.MonitorLoader.loadMonitor;
 import static org.datatransferproject.spi.cloud.extension.CloudExtensionLoader.getCloudExtension;
+import static org.datatransferproject.spi.transfer.hooks.JobHooksLoader.loadJobHooks;
 
 /**
  * Main class to bootstrap a portability transfer worker that will operate on a single job whose
@@ -115,6 +117,8 @@ public class WorkerMain {
     SymmetricKeyGenerator symmetricKeyGenerator = new AesSymmetricKeyGenerator(monitor);
     AsymmetricKeyGenerator asymmetricKeyGenerator = new RsaSymmetricKeyGenerator(monitor);
 
+    JobHooks jobHooks = loadJobHooks();
+
     Injector injector =
         Guice.createInjector(
             new WorkerModule(
@@ -124,7 +128,8 @@ public class WorkerMain {
                 publicKeySerializers,
                 decryptServices,
                 symmetricKeyGenerator,
-                asymmetricKeyGenerator));
+                asymmetricKeyGenerator,
+                jobHooks));
     worker = injector.getInstance(Worker.class);
 
     // Reset the JobMetadata in case set previously when running SingleVMMain

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
@@ -55,6 +55,7 @@ final class WorkerModule extends FlagBindingModule {
   private final Set<AuthDataDecryptService> decryptServices;
   private final SymmetricKeyGenerator symmetricKeyGenerator;
   private final AsymmetricKeyGenerator asymmetricKeyGenerator;
+  private final JobHooks jobHooks;
 
   WorkerModule(
       ExtensionContext context,
@@ -63,7 +64,8 @@ final class WorkerModule extends FlagBindingModule {
       Set<PublicKeySerializer> publicKeySerializers,
       Set<AuthDataDecryptService> decryptServices,
       SymmetricKeyGenerator symmetricKeyGenerator,
-      AsymmetricKeyGenerator asymmetricKeyGenerator) {
+      AsymmetricKeyGenerator asymmetricKeyGenerator,
+      JobHooks jobHooks) {
     this.cloudExtension = cloudExtension;
     this.context = context;
     this.transferExtensions = transferExtensions;
@@ -71,6 +73,7 @@ final class WorkerModule extends FlagBindingModule {
     this.decryptServices = decryptServices;
     this.symmetricKeyGenerator = symmetricKeyGenerator;
     this.asymmetricKeyGenerator = asymmetricKeyGenerator;
+    this.jobHooks = jobHooks;
   }
 
   @VisibleForTesting
@@ -95,9 +98,7 @@ final class WorkerModule extends FlagBindingModule {
     // binds flags from ExtensionContext to @Named annotations
     bindFlags(context);
 
-    // TODO make this an extension
-    bind(JobHooks.class).toInstance(new JobHooks() {});
-
+    bind(JobHooks.class).toInstance(jobHooks);
     bind(SymmetricKeyGenerator.class).toInstance(symmetricKeyGenerator);
     bind(AsymmetricKeyGenerator.class).toInstance(asymmetricKeyGenerator);
     bind(InMemoryDataCopier.class).to(PortabilityInMemoryDataCopier.class);


### PR DESCRIPTION
As discussed in PR624, converting this interface into an extension that can be loaded using ServiceLoader.