### PR TITLE
Clean up the Google photo handling

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.datatransferproject.datatransfer.google.photos.model.AlbumListResponse;
+import org.datatransferproject.datatransfer.google.photos.model.BatchMediaItemResponse;
 import org.datatransferproject.datatransfer.google.photos.model.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.photos.model.MediaItemSearchResponse;
 import org.datatransferproject.datatransfer.google.photos.model.NewMediaItemResult;
@@ -128,12 +129,12 @@ public class GooglePhotosInterface {
         String.class);
   }
 
-  NewMediaItemResult createPhoto(NewMediaItemUpload newMediaItemUpload) throws IOException {
+  BatchMediaItemResponse createPhoto(NewMediaItemUpload newMediaItemUpload) throws IOException {
     HashMap<String, Object> map = createJsonMap(newMediaItemUpload);
     HttpContent httpContent = new JsonHttpContent(new JacksonFactory(), map);
 
     return makePostRequest(BASE_URL + "mediaItems:batchCreate", Optional.empty(), httpContent,
-        NewMediaItemResult.class);
+        BatchMediaItemResponse.class);
   }
 
   private <T> T makeGetRequest(String url, Optional<Map<String, String>> parameters, Class<T> clazz)

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/BatchMediaItemResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/BatchMediaItemResponse.java
@@ -33,11 +33,4 @@ public class BatchMediaItemResponse {
   public NewMediaItemResult[] getResults() {
     return results;
   }
-
-  @Override
-  public String toString() {
-    return "BatchMediaItemResponse{" +
-        "results=" + Arrays.toString(results) +
-        '}';
-  }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/BatchMediaItemResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/BatchMediaItemResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Data Transfer Project Authors.
+ * Copyright 2019 The Data Transfer Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,27 +16,28 @@
 
 package org.datatransferproject.datatransfer.google.photos.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
 
-/**
- * Class containing the response from uploading {@code NewMediaItemUpload} to the Google Photos API.
- */
-public class NewMediaItemResult {
+public class BatchMediaItemResponse {
+  @JsonProperty("newMediaItemResults")
+  private NewMediaItemResult[] results;
 
-  @JsonProperty("uploadToken")
-  private String uploadToken;
-
-  @JsonProperty("status")
-  private Status status;
-
-  @JsonProperty("mediaItem")
-  private GoogleMediaItem mediaItem;
-
-  public Status getStatus() {
-    return status;
+  @JsonCreator
+  public BatchMediaItemResponse(
+      @JsonProperty("newMediaItemResults") NewMediaItemResult[] results) {
+    this.results = results;
   }
 
-  public GoogleMediaItem getMediaItem() {
-    return mediaItem;
+  public NewMediaItemResult[] getResults() {
+    return results;
+  }
+
+  @Override
+  public String toString() {
+    return "BatchMediaItemResponse{" +
+        "results=" + Arrays.toString(results) +
+        '}';
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/GoogleMediaItem.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/GoogleMediaItem.java
@@ -40,6 +40,9 @@ public class GoogleMediaItem {
   @JsonProperty("filename")
   private String filename;
 
+  @JsonProperty("productUrl")
+  private String productUrl;
+
   public String getId() { return id; }
 
   public String getDescription() { return description; }
@@ -47,6 +50,10 @@ public class GoogleMediaItem {
   public String getBaseUrl() { return baseUrl; }
 
   public String getMimeType() { return mimeType; }
+
+  public String getProductUrl() {
+    return productUrl;
+  }
 
   public MediaMetadata getMediaMetadata() { return mediaMetadata; }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/Status.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/model/Status.java
@@ -27,4 +27,12 @@ public class Status {
 
   @JsonProperty("message")
   private String message;
+
+  public int getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
 }


### PR DESCRIPTION
A small change to alter the return type Google's createPhoto to be correct and add some other small tweaks.

This came up when trying to use photos to hold imported Blogger photos, that code ended up getting thrown away, but these changes should make the photos stack a little easier to use in the future.