### PR TITLE
Fixing bug in MonitorLoader

### DIFF
--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/MonitorLoader.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/MonitorLoader.java
@@ -37,9 +37,13 @@ public class MonitorLoader {
               extension.initialize();
               monitors.add(extension.getMonitor());
             });
-    return monitors.isEmpty()
-        ? new ConsoleMonitor(DEBUG)
-        : new MultiplexMonitor((Monitor[]) monitors.toArray());
+    if (monitors.isEmpty()) {
+      return new ConsoleMonitor(DEBUG);
+    } else {
+      Monitor[] monitorArray = new Monitor[monitors.size()];
+      monitorArray = monitors.toArray(monitorArray);
+      return new MultiplexMonitor(monitorArray);
+    }
   }
 
   private MonitorLoader() {}


### PR DESCRIPTION
Previously, if there were any elements in the list of loaded monitors, line 42 would error out because Java can't cast an Object to a Monitor.  @seehamrun found this page about this bug: https://stackoverflow.com/questions/5374311/convert-arrayliststring-to-string-array