### PR TITLE
Video datatype

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-spotify/src/main/java/org/datatransferproject/transfer/spotify/playlists/SpotifyPlaylistImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-spotify/src/main/java/org/datatransferproject/transfer/spotify/playlists/SpotifyPlaylistImporter.java
@@ -65,10 +65,10 @@ public class SpotifyPlaylistImporter
   private void createPlaylist(MusicPlaylist playlist, String userId)
       throws IOException, SpotifyWebApiException {
     Playlist createPlaylistResult = spotifyApi
-        .createPlaylist(userId, playlist.headline())
+        .createPlaylist(userId, playlist.getHeadline())
         .collaborative(false)
         .public_(false)
-        .name("Imported - " + playlist.headline())
+        .name("Imported - " + playlist.getHeadline())
         .build()
         .execute();
     for (MusicRecording track : playlist.getTrack()) {
@@ -91,13 +91,13 @@ public class SpotifyPlaylistImporter
     // TODO: right now this depends on an ISRC being present, we should add fallback
     // logic.
     checkArgument(!Strings.isNullOrEmpty(track.getIsrcCode()), "No ISRC code present for: "
-        + track.headline());
+        + track.getHeadline());
     Paging<Track> searchResponse = spotifyApi
         .searchTracks("isrc:" + track.getIsrcCode())
         .build()
         .execute();
     if (searchResponse.getItems().length == 0) {
-      throw new IOException("Couldn't find track: " + track.headline()
+      throw new IOException("Couldn't find track: " + track.getHeadline()
           + " with code: " + track.getIsrcCode());
     }
     return searchResponse.getItems()[0];

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/CreativeWork.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/CreativeWork.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models;
+
+public class CreativeWork extends Thing {
+
+  private String headline;
+
+  public String getHeadline() {
+    return headline;
+  }
+
+  public void setHeadline(String headlin) {
+    this.headline = headline;
+  }
+}

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/MediaObject.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/MediaObject.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class MediaObject extends CreativeWork {
+
+  private URI contentUrl;
+  private String encodingFormat;
+
+  public URI getContentUrl() {
+    return contentUrl;
+  }
+
+  public void setContentUrl(URI uri) {
+    this.contentUrl = uri;
+  }
+
+  public void setContentUrl(String uri) {
+    try {
+      this.contentUrl = new URI(uri);
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public String getEncodingFormat() {
+    return encodingFormat;
+  }
+
+  public void setEncodingFormat(String encodingFormat) {
+    this.encodingFormat = encodingFormat;
+  }
+}

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/Thing.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/Thing.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models;
+
+public class Thing {
+
+  private String name;
+
+  private String description;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/playlists/MusicAlbum.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/playlists/MusicAlbum.java
@@ -1,14 +1,14 @@
 package org.datatransferproject.types.common.models.playlists;
 
+import org.datatransferproject.types.common.models.CreativeWork;
 /**
  * POJO https://schema.org/MusicAlbum
  */
 public class MusicAlbum extends CreativeWork {
   // NOTE: only a subset of fields are used so far, feel free to add more fields from the spec as
   // needed.
-  private String headline;
 
   public MusicAlbum(String headline) {
-    super(headline);
+    setHeadline(headline);
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/playlists/MusicPlaylist.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/playlists/MusicPlaylist.java
@@ -1,6 +1,7 @@
 package org.datatransferproject.types.common.models.playlists;
 
 import com.google.common.collect.ImmutableList;
+import org.datatransferproject.types.common.models.CreativeWork;
 
 public class MusicPlaylist extends CreativeWork {
   // NOTE: only a subset of fields are used so far, feel free to add more fields from the spec as
@@ -8,7 +9,7 @@ public class MusicPlaylist extends CreativeWork {
   private ImmutableList<MusicRecording> track;
 
   public MusicPlaylist(String headline, Iterable<MusicRecording> tracks) {
-    super(headline);
+    setHeadline(headline);
     this.track = ImmutableList.copyOf(tracks);
   }
 

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/playlists/MusicRecording.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/playlists/MusicRecording.java
@@ -1,5 +1,7 @@
 package org.datatransferproject.types.common.models.playlists;
 
+import org.datatransferproject.types.common.models.CreativeWork;
+
 /**
  * POJO for https://schema.org/MusicRecording
  */
@@ -11,10 +13,10 @@ public class MusicRecording extends CreativeWork {
   private MusicGroup byArtist;
 
   public MusicRecording(String headline,
-      String isrcCode,
-      MusicAlbum musicAlbum,
-      MusicGroup byArtist) {
-    super(headline);
+                        String isrcCode,
+                        MusicAlbum musicAlbum,
+                        MusicGroup byArtist) {
+    setHeadline(headline);
     this.isrcCode = isrcCode;
     this.musicAlbum = musicAlbum;
     this.byArtist = byArtist;

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideoAlbum.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideoAlbum.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models.videos;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+import java.util.Objects;
+
+public class VideoAlbum {
+  private final String id;
+  private final String name;
+  private final String description;
+
+  /**
+   * The {@code id} is used to associate videos with this album. *
+   */
+  @JsonCreator
+  public VideoAlbum(
+          @JsonProperty("id") String id,
+          @JsonProperty("name") String name,
+          @JsonProperty("description") String description) {
+    Preconditions.checkNotNull(id);
+    this.id = id;
+    this.name = name;
+    this.description = description;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    VideoAlbum that = (VideoAlbum) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideoObject.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideoObject.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models.videos;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import org.datatransferproject.types.common.models.MediaObject;
+
+public class VideoObject extends MediaObject {
+
+  private String dataId;
+  private String albumId;
+  private boolean inTempStore;
+
+  @JsonCreator
+  public VideoObject(
+          @JsonProperty("name") String name,
+          @JsonProperty("contentUrl") String contentUrl,
+          @JsonProperty("description") String description,
+          @JsonProperty("encodingFormat") String encodingFormat,
+          @JsonProperty("dataId") String dataId,
+          @JsonProperty("albumId") String albumId,
+          @JsonProperty("inTempStore") boolean inTempStore) {
+    setName(name);
+    setContentUrl(contentUrl);
+    setDescription(description);
+    setEncodingFormat(encodingFormat);
+    this.dataId = dataId;
+    this.albumId = albumId;
+    this.inTempStore = inTempStore;
+  }
+
+  public String getAlbumId() {
+    return albumId;
+  }
+
+  public String getDataId() {
+    return dataId;
+  }
+
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+            .add("name", getName())
+            .add("contentUrl", getContentUrl())
+            .add("description", getDescription())
+            .add("encodingFormat", getEncodingFormat())
+            .add("dataId", dataId)
+            .add("albumId", albumId)
+            .add("inTempStore", inTempStore)
+            .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    VideoObject that = (VideoObject) o;
+    return Objects.equal(getName(), that.getName()) &&
+            Objects.equal(getContentUrl(), that.getContentUrl()) &&
+            Objects.equal(getDescription(), that.getDescription()) &&
+            Objects.equal(getEncodingFormat(), that.getEncodingFormat()) &&
+            Objects.equal(getDataId(), that.getDataId()) &&
+            Objects.equal(getAlbumId(), that.getAlbumId());
+  }
+}

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models.videos;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import org.datatransferproject.types.common.models.ContainerResource;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class VideosContainerResource extends ContainerResource {
+  private final Collection<VideoAlbum> albums;
+  private final Collection<VideoObject> videos;
+
+  @JsonCreator
+  public VideosContainerResource(
+          @JsonProperty("albums") Collection<VideoAlbum> albums,
+          @JsonProperty("videos") Collection<VideoObject> videos) {
+    this.albums = albums == null ? ImmutableList.of() : albums;
+    this.videos = videos == null ? ImmutableList.of() : videos;
+  }
+
+  public Collection<VideoAlbum> getAlbums() {
+    return albums;
+  }
+
+  public Collection<VideoObject> getVideos() {
+    return videos;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    VideosContainerResource that = (VideosContainerResource) o;
+    return Objects.equals(getAlbums(), that.getAlbums()) &&
+            Objects.equals(getVideos(), that.getVideos());
+  }
+}

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models.videos;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.junit.Test;
+
+import java.util.List;
+
+public class VideosContainerResourceTest {
+  @Test
+  public void verifySerializeDeserialize() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerSubtypes(VideosContainerResource.class);
+
+    List<VideoAlbum> albums =
+            ImmutableList.of(new VideoAlbum("id1", "album1", "This is a fake album"));
+
+    List<VideoObject> videos =
+            ImmutableList.of(
+                    new VideoObject("Vid1", "http://example.com/1.mp4", "A video", "video/mp4", "v1", "id1",
+                            false),
+                    new VideoObject(
+                            "Vid2", "https://example.com/2.mpeg", "A 2. video", "video/mpeg", "v2", "id1", false));
+    
+    ContainerResource data = new VideosContainerResource(albums, videos);
+
+    String serialized = objectMapper.writeValueAsString(data);
+
+    ContainerResource deserializedModel =
+            objectMapper.readValue(serialized, ContainerResource.class);
+
+    Truth.assertThat(deserializedModel).isNotNull();
+    Truth.assertThat(deserializedModel).isInstanceOf(VideosContainerResource.class);
+    VideosContainerResource deserialized = (VideosContainerResource) deserializedModel;
+    Truth.assertThat(deserialized.getAlbums()).hasSize(1);
+    Truth.assertThat(deserialized.getVideos()).hasSize(2);
+  }
+}


### PR DESCRIPTION
This pull request introduces a video datatype in order to prepare for video exporters/importers. Due to the similarity between photos and videos (both MediaItems) the video data type is defined analog to what was already present for photos. Video-importer and -exporter for Google Photos and Facebook will follow in future pull requests.