### PR TITLE
Switch Google Photos import scope to appendonly

### DIFF
--- a/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleOAuthConfig.java
+++ b/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleOAuthConfig.java
@@ -69,7 +69,7 @@ public class GoogleOAuthConfig implements OAuth2Config {
         .put("CALENDAR", ImmutableSet.of("https://www.googleapis.com/auth/calendar"))
         .put("CONTACTS", ImmutableSet.of("https://www.googleapis.com/auth/contacts"))
         .put("MAIL", ImmutableSet.of("https://www.googleapis.com/auth/gmail.modify"))
-        .put("PHOTOS", ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary"))
+        .put("PHOTOS", ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.appendonly"))
         .put("TASKS", ImmutableSet.of("https://www.googleapis.com/auth/tasks"))
         .build();
   }


### PR DESCRIPTION
I've tested this and import still works fine for me. This limits the scope and changes the text a user sees on the OAuth screen.

![screenshot 2019-02-05 at 17 04 50](https://user-images.githubusercontent.com/932266/53175857-c971ba00-35e4-11e9-9e0d-b336eff82cd7.png)
