### PR TITLE
Marking JobAuthorization.sessionSecretKey field nullable

### DIFF
--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/JobAuthorization.java
@@ -43,6 +43,7 @@ public abstract class JobAuthorization {
    * for storage.
    */
   @Deprecated
+  @Nullable
   @JsonProperty("sessionSecretKey")
   public abstract String sessionSecretKey();
 


### PR DESCRIPTION
I don't recall the entire history of this key, but it is marked deprecated and is only used in one class, GenerateServiceAuthDataAction, which some DTP implementations may not use.

In our case we are seeing a NullPointerException upon deserializing with this field null, so this should fix that:

```
	at org.datatransferproject.transfer.JobPoller.pollJob(JobPoller.java:38)
	at org.datatransferproject.transfer.Worker.doWork(Worker.java:32)
	at org.datatransferproject.transfer.WorkerMain.poll(WorkerMain.java:135)
	at org.datatransferproject.transfer.WorkerMain.main(WorkerMain.java:65)
Caused by: java.lang.NullPointerException: Null sessionSecretKey
	at org.datatransferproject.spi.cloud.types.AutoValue_JobAuthorization$Builder.setSessionSecretKey(AutoValue_JobAuthorization.java:190)
```