### PR TITLE
Don't require sessionSecretKey be present when validating authorization state

### DIFF
--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
@@ -230,18 +230,15 @@ public abstract class PortabilityJob {
       switch (jobAuthorization.state()) {
         case INITIAL:
         case CREDS_AVAILABLE:
-          // SessionKey required to create a job
-          isSet(jobAuthorization.sessionSecretKey());
           isUnset(jobAuthorization.encryptedAuthData());
           break;
         case CREDS_ENCRYPTION_KEY_GENERATED:
           // Expected associated keys from the assigned transfer worker to be present
-          isSet(jobAuthorization.sessionSecretKey(), jobAuthorization.authPublicKey());
+          isSet(jobAuthorization.authPublicKey());
           isUnset(jobAuthorization.encryptedAuthData());
           break;
         case CREDS_STORED:
           isSet(
-              jobAuthorization.sessionSecretKey(),
               jobAuthorization.authPublicKey(),
               jobAuthorization.encryptedAuthData());
           break;


### PR DESCRIPTION
See https://github.com/google/data-transfer-project/pull/661