### PR TITLE
Add support for retrieving the current project version and Git hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,16 @@
  *
  * Note that if you add a submodule and want it published with official releases, add the 'maven-publish' plugin to the submodule configuration.
  */
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.RepositoryBuilder
+
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
         classpath "io.spring.gradle:spring-bintray-plugin:0.11.1"
+        classpath 'org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r'
     }
 }
 
@@ -52,6 +56,8 @@ plugins {
 ext.nodeType = hasProperty('nodeType') ? nodeType : 'local'
 ext.cloudType = hasProperty('cloudType') ? cloudType : 'local'
 println "Node installation: ${ext.nodeType}, Cloud type: ${ext.cloudType}";
+
+setGitVersion()
 
 def sourceProjects() {
     // define projects containing source code
@@ -112,6 +118,7 @@ def configurePublication(project) {
                     root.appendNode('description', 'The Data Transfer Project')
                     root.appendNode('name', 'DTP')
                     root.appendNode('url', 'https://datatransferproject.dev/')
+                    root.appendNode('properties').appendNode('git-version', project.rootProject.ext.gitVersion)
                     root.children().last() + getPomConfig();
                 }
             }
@@ -187,4 +194,12 @@ def getPomConfig() {
 
 }
 
+
+def setGitVersion() {
+    def repo = new RepositoryBuilder().setGitDir(new File(project.rootDir, '/.git')).readEnvironment().build()
+
+    def version = repo.findRef('HEAD').getObjectId().name
+    def clean = Git.wrap(repo).status().call().isClean()
+    ext.gitVersion = version + (clean ? '' : '.modified')
+}
 

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ def configurePublication(project) {
                     root.appendNode('description', 'The Data Transfer Project')
                     root.appendNode('name', 'DTP')
                     root.appendNode('url', 'https://datatransferproject.dev/')
-                    root.appendNode('properties').appendNode('git-version', project.rootProject.ext.gitVersion)
+                    root.appendNode('properties').appendNode('build-commit', project.rootProject.ext.gitVersion)
                     root.children().last() + getPomConfig();
                 }
             }

--- a/portability-api-launcher/build.gradle
+++ b/portability-api-launcher/build.gradle
@@ -1,3 +1,12 @@
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.RepositoryBuilder
+
+
+buildscript {
+    dependencies {
+        classpath 'org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r'
+    }
+}
 
 plugins {
     id 'maven-publish'
@@ -5,3 +14,23 @@ plugins {
 }
 
 configurePublication(project)
+
+
+jar {
+    dependsOn "generateGitHash"
+    from "$buildDir/resources/generated"
+}
+
+//noinspection GroovyAssignabilityCheck
+task generateGitHash() {
+    def repo = new RepositoryBuilder().setGitDir(new File(project.rootDir, '/.git')).readEnvironment().build()
+
+    def version = repo.findRef('HEAD').getObjectId().name
+    def clean = Git.wrap(repo).status().call().isClean()
+
+    def dest = new File("${project.buildDir}/resources/generated/META-INF")
+    dest.mkdirs()
+    def propFile = new File(dest, "launcher.properties")
+    propFile.createNewFile();
+    propFile.write("version=${project.version}\nhash=${version + (clean ? '' : '.modified')}")
+}

--- a/portability-api-launcher/build.gradle
+++ b/portability-api-launcher/build.gradle
@@ -1,7 +1,3 @@
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.lib.RepositoryBuilder
-
-
 buildscript {
     dependencies {
         classpath 'org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r'
@@ -23,14 +19,10 @@ jar {
 
 //noinspection GroovyAssignabilityCheck
 task generateGitHash() {
-    def repo = new RepositoryBuilder().setGitDir(new File(project.rootDir, '/.git')).readEnvironment().build()
-
-    def version = repo.findRef('HEAD').getObjectId().name
-    def clean = Git.wrap(repo).status().call().isClean()
-
     def dest = new File("${project.buildDir}/resources/generated/META-INF")
     dest.mkdirs()
     def propFile = new File(dest, "launcher.properties")
     propFile.createNewFile();
-    propFile.write("version=${project.version}\nhash=${version + (clean ? '' : '.modified')}")
+
+    propFile.write("version=${project.version}\nhash=${project.rootProject.ext.gitVersion}")
 }

--- a/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/Version.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/Version.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 /** Provides versioning information to the runtime. */
 public class Version {
   private static final String UNKNOWN = "unknown";
-  private static String VERSION;
+  private static final String VERSION;
   private static final String HASH;
 
   public static String getVersion() {

--- a/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/Version.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/Version.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.api.launcher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+/** Provides versioning information to the runtime. */
+public class Version {
+  private static final String UNKNOWN = "unknown";
+  private static String VERSION;
+  private static final String HASH;
+
+  public static String getVersion() {
+    return VERSION;
+  }
+
+  public static String getSourceHash() {
+    return HASH;
+  }
+
+  private Version() {}
+
+  static {
+    Properties properties = new Properties();
+    URL url = Version.class.getResource("/META-INF/launcher.properties");
+    if (url == null) {
+      System.err.println("Launcher version file (launcher.properties) not found");
+    } else {
+      try (final InputStream stream = url.openStream()) {
+        properties.load(stream);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    VERSION = properties.getProperty("version", UNKNOWN);
+    HASH = properties.getProperty("hash", UNKNOWN);
+  }
+}

--- a/portability-bootstrap-vm/src/main/java/org/datatransferproject/bootstrap/vm/SingleVMMain.java
+++ b/portability-bootstrap-vm/src/main/java/org/datatransferproject/bootstrap/vm/SingleVMMain.java
@@ -3,6 +3,7 @@ package org.datatransferproject.bootstrap.vm;
 import com.google.common.util.concurrent.UncaughtExceptionHandlers;
 import org.datatransferproject.api.ApiMain;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.api.launcher.Version;
 import org.datatransferproject.transfer.WorkerMain;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -13,6 +14,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
+import static java.lang.String.format;
 import static org.datatransferproject.launcher.monitor.MonitorLoader.loadMonitor;
 
 /**
@@ -42,6 +44,12 @@ public class SingleVMMain {
 
   public void initializeGateway() {
     Monitor monitor = loadMonitor();
+
+    String version = Version.getVersion();
+    String hash = Version.getSourceHash();
+
+    monitor.info(() -> format("Running version %s. Source repository hash %s", version, hash));
+
     ApiMain apiMain = new ApiMain(monitor);
 
     try (InputStream stream =


### PR DESCRIPTION
This PR uses JGit during build to generate a launcher properties file which will be packaged in the API Launcher JAR (or runtime uber jar). The class Version reads the properties file and retrieves the project version and Git hash. The Runtime bootstrap can then access that information.

I updated the SingleVM bootstrapper to output the version and has to the monitor. Other bootstrappers could do the same.

 