### PR TITLE
Fix JettyMonitor

### DIFF
--- a/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/http/JettyMonitor.java
+++ b/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/http/JettyMonitor.java
@@ -24,7 +24,7 @@ public class JettyMonitor implements Logger {
   }
 
   public void warn(String msg, Throwable thrown) {
-    DELEGATE.info(() -> msg, thrown);
+    DELEGATE.severe(() -> msg, thrown);
   }
 
   public void info(String msg, Object... args) {
@@ -60,7 +60,7 @@ public class JettyMonitor implements Logger {
   }
 
   public void debug(String msg, Throwable thrown) {
-    DELEGATE.info(() -> msg, thrown);
+    DELEGATE.debug(() -> msg, thrown);
   }
 
   public Logger getLogger(String name) {


### PR DESCRIPTION
When a RuntimeException is thrown on the API, JettyMonitor currently logs it as info rather than severe. This changes the mapping to make it severe.

Mapping everything to info makes it much harder to detect issues with the api.