### PR TITLE
Starts to split JobStore into 2 distinct interfaces

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/FlickrTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/FlickrTransferExtension.java
@@ -23,7 +23,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.flickr.photos.FlickrPhotosExporter;
 import org.datatransferproject.datatransfer.flickr.photos.FlickrPhotosImporter;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -42,7 +42,7 @@ public class FlickrTransferExtension implements TransferExtension {
 
   private Importer importer;
   private Exporter exporter;
-  private PersistentPerJobStorage jobStore;
+  private TemporaryPerJobDataStore jobStore;
   private boolean initialized = false;
   private AppCredentials appCredentials;
 
@@ -68,7 +68,7 @@ public class FlickrTransferExtension implements TransferExtension {
   @Override
   public void initialize(ExtensionContext context) {
     if (initialized) return;
-    jobStore = context.getService(PersistentPerJobStorage.class);
+    jobStore = context.getService(TemporaryPerJobDataStore.class);
     Monitor monitor = context.getMonitor();
 
     try {

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/FlickrTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/FlickrTransferExtension.java
@@ -23,7 +23,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.flickr.photos.FlickrPhotosExporter;
 import org.datatransferproject.datatransfer.flickr.photos.FlickrPhotosImporter;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -42,7 +42,7 @@ public class FlickrTransferExtension implements TransferExtension {
 
   private Importer importer;
   private Exporter exporter;
-  private JobStore jobStore;
+  private PersistentPerJobStorage jobStore;
   private boolean initialized = false;
   private AppCredentials appCredentials;
 
@@ -68,7 +68,7 @@ public class FlickrTransferExtension implements TransferExtension {
   @Override
   public void initialize(ExtensionContext context) {
     if (initialized) return;
-    jobStore = context.getService(JobStore.class);
+    jobStore = context.getService(PersistentPerJobStorage.class);
     Monitor monitor = context.getMonitor();
 
     try {

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -29,7 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -53,14 +53,17 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
   @VisibleForTesting
   static final String ORIGINAL_ALBUM_PREFIX = "original-album-";
 
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
   private final Flickr flickr;
   private final Uploader uploader;
   private final ImageStreamProvider imageStreamProvider;
   private final PhotosetsInterface photosetsInterface;
   private final Monitor monitor;
 
-  public FlickrPhotosImporter(AppCredentials appCredentials, JobStore jobStore, Monitor monitor) {
+  public FlickrPhotosImporter(
+      AppCredentials appCredentials,
+      PersistentPerJobStorage jobStore,
+      Monitor monitor) {
     this.jobStore = jobStore;
     this.flickr = new Flickr(appCredentials.getKey(), appCredentials.getSecret(), new REST());
     this.uploader = flickr.getUploader();
@@ -70,7 +73,10 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
   }
 
   @VisibleForTesting
-  FlickrPhotosImporter(Flickr flickr, JobStore jobstore, ImageStreamProvider imageStreamProvider,
+  FlickrPhotosImporter(
+      Flickr flickr,
+      PersistentPerJobStorage jobstore,
+      ImageStreamProvider imageStreamProvider,
       Monitor monitor) {
     this.flickr = flickr;
     this.imageStreamProvider = imageStreamProvider;

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -29,7 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -53,7 +53,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
   @VisibleForTesting
   static final String ORIGINAL_ALBUM_PREFIX = "original-album-";
 
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final Flickr flickr;
   private final Uploader uploader;
   private final ImageStreamProvider imageStreamProvider;
@@ -62,7 +62,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
 
   public FlickrPhotosImporter(
       AppCredentials appCredentials,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       Monitor monitor) {
     this.jobStore = jobStore;
     this.flickr = new Flickr(appCredentials.getKey(), appCredentials.getSecret(), new REST());
@@ -75,7 +75,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
   @VisibleForTesting
   FlickrPhotosImporter(
       Flickr flickr,
-      PersistentPerJobStorage jobstore,
+      TemporaryPerJobDataStore jobstore,
       ImageStreamProvider imageStreamProvider,
       Monitor monitor) {
     this.flickr = flickr;

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
@@ -28,7 +28,7 @@ import com.flickr4java.flickr.uploader.UploadMetaData;
 import com.flickr4java.flickr.uploader.Uploader;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.cloud.local.LocalJobStore;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
@@ -73,7 +73,7 @@ public class FlickrPhotosImporterTest {
   private Flickr flickr = mock(Flickr.class);
   private PhotosetsInterface photosetsInterface = mock(PhotosetsInterface.class);
   private Uploader uploader = mock(Uploader.class);
-  private PersistentPerJobStorage jobStore = new LocalJobStore();
+  private TemporaryPerJobDataStore jobStore = new LocalJobStore();
   private FlickrPhotosImporter.ImageStreamProvider imageStreamProvider =
       mock(FlickrPhotosImporter.ImageStreamProvider.class);
 

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
@@ -28,7 +28,7 @@ import com.flickr4java.flickr.uploader.UploadMetaData;
 import com.flickr4java.flickr.uploader.Uploader;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.cloud.local.LocalJobStore;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
@@ -73,7 +73,7 @@ public class FlickrPhotosImporterTest {
   private Flickr flickr = mock(Flickr.class);
   private PhotosetsInterface photosetsInterface = mock(PhotosetsInterface.class);
   private Uploader uploader = mock(Uploader.class);
-  private JobStore jobStore = new LocalJobStore();
+  private PersistentPerJobStorage jobStore = new LocalJobStore();
   private FlickrPhotosImporter.ImageStreamProvider imageStreamProvider =
       mock(FlickrPhotosImporter.ImageStreamProvider.class);
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
@@ -24,7 +24,7 @@ import org.datatransferproject.datatransfer.google.tasks.GoogleTasksImporter;
 import org.datatransferproject.datatransfer.google.videos.GoogleVideosExporter;
 import org.datatransferproject.datatransfer.google.videos.GoogleVideosImporter;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -71,7 +71,7 @@ public class GoogleTransferExtension implements TransferExtension {
     // times.
     if (initialized) return;
 
-    PersistentPerJobStorage jobStore = context.getService(PersistentPerJobStorage.class);
+    TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
     HttpTransport httpTransport = context.getService(HttpTransport.class);
     JsonFactory jsonFactory = context.getService(JsonFactory.class);
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
@@ -24,7 +24,7 @@ import org.datatransferproject.datatransfer.google.tasks.GoogleTasksImporter;
 import org.datatransferproject.datatransfer.google.videos.GoogleVideosExporter;
 import org.datatransferproject.datatransfer.google.videos.GoogleVideosImporter;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -71,7 +71,7 @@ public class GoogleTransferExtension implements TransferExtension {
     // times.
     if (initialized) return;
 
-    JobStore jobStore = context.getService(JobStore.class);
+    PersistentPerJobStorage jobStore = context.getService(PersistentPerJobStorage.class);
     HttpTransport httpTransport = context.getService(HttpTransport.class);
     JsonFactory jsonFactory = context.getService(JsonFactory.class);
 
@@ -103,7 +103,7 @@ public class GoogleTransferExtension implements TransferExtension {
     importerBuilder.put("TASKS", new GoogleTasksImporter(credentialFactory));
     importerBuilder.put(
             "PHOTOS", new GooglePhotosImporter(credentialFactory, jobStore, jsonFactory));
-    importerBuilder.put("VIDEOS", new GoogleVideosImporter(credentialFactory, jobStore, jsonFactory, monitor));
+    importerBuilder.put("VIDEOS", new GoogleVideosImporter(credentialFactory, jsonFactory, monitor));
     importerMap = importerBuilder.build();
 
     ImmutableMap.Builder<String, Exporter> exporterBuilder = ImmutableMap.builder();

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveExporter.java
@@ -10,7 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.common.GoogleStaticObjects;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Exporter;
@@ -64,14 +64,16 @@ public final class DriveExporter
           .build();
 
   private final GoogleCredentialFactory credentialFactory;
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
   private final Monitor monitor;
 
   // Don't access this directly, instead access via getDriveInterface.
   private Drive driveInterface;
 
   public DriveExporter(
-      GoogleCredentialFactory credentialFactory, JobStore jobStore, Monitor monitor) {
+      GoogleCredentialFactory credentialFactory,
+      PersistentPerJobStorage jobStore,
+      Monitor monitor) {
     this.credentialFactory = checkNotNull(credentialFactory, "Credential Factory can't be null");
     this.jobStore = checkNotNull(jobStore, "Job store can't be null");
     this.monitor = monitor;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveExporter.java
@@ -10,7 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.common.GoogleStaticObjects;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Exporter;
@@ -64,7 +64,7 @@ public final class DriveExporter
           .build();
 
   private final GoogleCredentialFactory credentialFactory;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final Monitor monitor;
 
   // Don't access this directly, instead access via getDriveInterface.
@@ -72,7 +72,7 @@ public final class DriveExporter
 
   public DriveExporter(
       GoogleCredentialFactory credentialFactory,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       Monitor monitor) {
     this.credentialFactory = checkNotNull(credentialFactory, "Credential Factory can't be null");
     this.jobStore = checkNotNull(jobStore, "Job store can't be null");

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveImporter.java
@@ -8,7 +8,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -30,13 +30,16 @@ public final class DriveImporter implements
   private static final String ROOT_FOLDER_ID = "root-id";
 
   private final GoogleCredentialFactory credentialFactory;
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
   private final Monitor monitor;
 
   // Don't access this directly, instead access via getDriveInterface.
   private Drive driveInterface;
 
-  public DriveImporter(GoogleCredentialFactory credentialFactory, JobStore jobStore, Monitor monitor) {
+  public DriveImporter(
+      GoogleCredentialFactory credentialFactory,
+      PersistentPerJobStorage jobStore,
+      Monitor monitor) {
     this.credentialFactory = credentialFactory;
     this.jobStore = checkNotNull(jobStore, "Job store can't be null");
     this.monitor = monitor;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveImporter.java
@@ -8,7 +8,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -30,7 +30,7 @@ public final class DriveImporter implements
   private static final String ROOT_FOLDER_ID = "root-id";
 
   private final GoogleCredentialFactory credentialFactory;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final Monitor monitor;
 
   // Don't access this directly, instead access via getDriveInterface.
@@ -38,7 +38,7 @@ public final class DriveImporter implements
 
   public DriveImporter(
       GoogleCredentialFactory credentialFactory,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       Monitor monitor) {
     this.credentialFactory = credentialFactory;
     this.jobStore = checkNotNull(jobStore, "Job store can't be null");

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
@@ -28,7 +28,7 @@ import org.datatransferproject.datatransfer.google.mediaModels.AlbumListResponse
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaItemSearchResponse;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Exporter;
@@ -62,7 +62,7 @@ public class GooglePhotosExporter
   static final String PHOTO_TOKEN_PREFIX = "media:";
 
   private final GoogleCredentialFactory credentialFactory;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final JsonFactory jsonFactory;
   private volatile GooglePhotosInterface photosInterface;
 
@@ -70,7 +70,7 @@ public class GooglePhotosExporter
 
   public GooglePhotosExporter(
       GoogleCredentialFactory credentialFactory,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       JsonFactory jsonFactory,
       Monitor monitor) {
     this.credentialFactory = credentialFactory;
@@ -82,7 +82,7 @@ public class GooglePhotosExporter
   @VisibleForTesting
   GooglePhotosExporter(
       GoogleCredentialFactory credentialFactory,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       JsonFactory jsonFactory,
       GooglePhotosInterface photosInterface,
       Monitor monitor) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -23,7 +23,7 @@ import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactor
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -45,20 +45,22 @@ public class GooglePhotosImporter
   private static final String COPY_PREFIX = "Copy of ";
 
   private final GoogleCredentialFactory credentialFactory;
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
   private final JsonFactory jsonFactory;
   private final ImageStreamProvider imageStreamProvider;
   private volatile GooglePhotosInterface photosInterface;
 
   public GooglePhotosImporter(
-      GoogleCredentialFactory credentialFactory, JobStore jobStore, JsonFactory jsonFactory) {
+      GoogleCredentialFactory credentialFactory,
+      PersistentPerJobStorage jobStore,
+      JsonFactory jsonFactory) {
     this(credentialFactory, jobStore, jsonFactory, null, new ImageStreamProvider());
   }
 
   @VisibleForTesting
   GooglePhotosImporter(
       GoogleCredentialFactory credentialFactory,
-      JobStore jobStore,
+      PersistentPerJobStorage jobStore,
       JsonFactory jsonFactory,
       GooglePhotosInterface photosInterface,
       ImageStreamProvider imageStreamProvider) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -23,7 +23,7 @@ import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactor
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -45,14 +45,14 @@ public class GooglePhotosImporter
   private static final String COPY_PREFIX = "Copy of ";
 
   private final GoogleCredentialFactory credentialFactory;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final JsonFactory jsonFactory;
   private final ImageStreamProvider imageStreamProvider;
   private volatile GooglePhotosInterface photosInterface;
 
   public GooglePhotosImporter(
       GoogleCredentialFactory credentialFactory,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       JsonFactory jsonFactory) {
     this(credentialFactory, jobStore, jsonFactory, null, new ImageStreamProvider());
   }
@@ -60,7 +60,7 @@ public class GooglePhotosImporter
   @VisibleForTesting
   GooglePhotosImporter(
       GoogleCredentialFactory credentialFactory,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       JsonFactory jsonFactory,
       GooglePhotosInterface photosInterface,
       ImageStreamProvider imageStreamProvider) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -35,10 +35,10 @@ import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.json.JsonFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
-import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -46,8 +46,6 @@ import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.videos.VideoObject;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.datatransferproject.api.launcher.Monitor;
-
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,26 +59,23 @@ public class GoogleVideosImporter
   private static final String COPY_PREFIX = "Copy of ";
 
   private final GoogleCredentialFactory credentialFactory;
-  private final JobStore jobStore;
   private final ImageStreamProvider videoStreamProvider;
   private volatile GoogleVideosInterface videosInterface;
   private Monitor monitor;
   private JsonFactory jsonFactory;
 
-  public GoogleVideosImporter(GoogleCredentialFactory credentialFactory, JobStore jobStore, JsonFactory jsonFactory, Monitor monitor) {
-    this(credentialFactory, jobStore, null, new ImageStreamProvider(), jsonFactory, monitor);
+  public GoogleVideosImporter(GoogleCredentialFactory credentialFactory, JsonFactory jsonFactory, Monitor monitor) {
+    this(credentialFactory, null, new ImageStreamProvider(), jsonFactory, monitor);
   }
 
   @VisibleForTesting
   GoogleVideosImporter(
           GoogleCredentialFactory credentialFactory,
-          JobStore jobStore,
           GoogleVideosInterface videosInterface,
           ImageStreamProvider videoStreamProvider,
           JsonFactory jsonFactory,
           Monitor monitor) {
     this.credentialFactory = credentialFactory;
-    this.jobStore = jobStore;
     this.videosInterface = videosInterface;
     this.videoStreamProvider = videoStreamProvider;
     this.jsonFactory = jsonFactory;

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
@@ -25,7 +25,7 @@ import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaItemSearchResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaMetadata;
 import org.datatransferproject.datatransfer.google.mediaModels.Photo;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.spi.transfer.types.TempPhotosData;
@@ -69,7 +69,7 @@ public class GooglePhotosExporterTest {
   private UUID uuid = UUID.randomUUID();
 
   private GooglePhotosExporter googlePhotosExporter;
-  private PersistentPerJobStorage jobStore;
+  private TemporaryPerJobDataStore jobStore;
   private GooglePhotosInterface photosInterface;
 
   private MediaItemSearchResponse mediaItemSearchResponse;
@@ -78,7 +78,7 @@ public class GooglePhotosExporterTest {
   @Before
   public void setup() throws IOException {
     GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
-    jobStore = mock(PersistentPerJobStorage.class);
+    jobStore = mock(TemporaryPerJobDataStore.class);
     photosInterface = mock(GooglePhotosInterface.class);
 
     albumListResponse = mock(AlbumListResponse.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
@@ -15,24 +15,8 @@
  */
 package org.datatransferproject.datatransfer.google.photos;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.ALBUM_TOKEN_PREFIX;
-import static org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.PHOTO_TOKEN_PREFIX;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.json.jackson2.JacksonFactory;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.mediaModels.AlbumListResponse;
@@ -41,14 +25,14 @@ import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaItemSearchResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaMetadata;
 import org.datatransferproject.datatransfer.google.mediaModels.Photo;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
-import org.datatransferproject.types.common.models.IdOnlyContainerResource;
+import org.datatransferproject.spi.transfer.types.TempPhotosData;
 import org.datatransferproject.types.common.PaginationData;
 import org.datatransferproject.types.common.StringPaginationToken;
-import org.datatransferproject.spi.transfer.types.TempPhotosData;
 import org.datatransferproject.types.common.models.ContainerResource;
+import org.datatransferproject.types.common.models.IdOnlyContainerResource;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
@@ -56,6 +40,23 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.ALBUM_TOKEN_PREFIX;
+import static org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.PHOTO_TOKEN_PREFIX;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 public class GooglePhotosExporterTest {
 
@@ -68,7 +69,7 @@ public class GooglePhotosExporterTest {
   private UUID uuid = UUID.randomUUID();
 
   private GooglePhotosExporter googlePhotosExporter;
-  private JobStore jobStore;
+  private PersistentPerJobStorage jobStore;
   private GooglePhotosInterface photosInterface;
 
   private MediaItemSearchResponse mediaItemSearchResponse;
@@ -77,7 +78,7 @@ public class GooglePhotosExporterTest {
   @Before
   public void setup() throws IOException {
     GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
-    jobStore = mock(JobStore.class);
+    jobStore = mock(PersistentPerJobStorage.class);
     photosInterface = mock(GooglePhotosInterface.class);
 
     albumListResponse = mock(AlbumListResponse.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -22,7 +22,7 @@ import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemResult;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
 import org.datatransferproject.transfer.ImageStreamProvider;
@@ -54,7 +54,7 @@ public class GooglePhotosImporterTest {
 
   private GooglePhotosImporter googlePhotosImporter;
   private GooglePhotosInterface googlePhotosInterface;
-  private JobStore jobStore;
+  private PersistentPerJobStorage jobStore;
   private ImageStreamProvider imageStreamProvider;
   private InputStream inputStream;
   private IdempotentImportExecutor executor;

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -22,7 +22,7 @@ import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemResult;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
 import org.datatransferproject.transfer.ImageStreamProvider;
@@ -54,7 +54,7 @@ public class GooglePhotosImporterTest {
 
   private GooglePhotosImporter googlePhotosImporter;
   private GooglePhotosInterface googlePhotosInterface;
-  private PersistentPerJobStorage jobStore;
+  private TemporaryPerJobDataStore jobStore;
   private ImageStreamProvider imageStreamProvider;
   private InputStream inputStream;
   private IdempotentImportExecutor executor;

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
@@ -17,8 +17,12 @@
 package org.datatransferproject.datatransfer.google.videos;
 
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
-import org.datatransferproject.datatransfer.google.mediaModels.*;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.datatransfer.google.mediaModels.AlbumListResponse;
+import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
+import org.datatransferproject.datatransfer.google.mediaModels.MediaItemSearchResponse;
+import org.datatransferproject.datatransfer.google.mediaModels.MediaMetadata;
+import org.datatransferproject.datatransfer.google.mediaModels.Video;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.types.common.StringPaginationToken;
@@ -37,7 +41,10 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 public class GoogleVideosExporterTest {
 
@@ -48,7 +55,7 @@ public class GoogleVideosExporterTest {
   private UUID uuid = UUID.randomUUID();
 
   private GoogleVideosExporter googleVideosExporter;
-  private JobStore jobStore;
+  private PersistentPerJobStorage jobStore;
   private GoogleVideosInterface videosInterface;
 
   private MediaItemSearchResponse mediaItemSearchResponse;
@@ -57,7 +64,7 @@ public class GoogleVideosExporterTest {
   @Before
   public void setup() throws IOException {
     GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
-    jobStore = mock(JobStore.class);
+    jobStore = mock(PersistentPerJobStorage.class);
     videosInterface = mock(GoogleVideosInterface.class);
 
     albumListResponse = mock(AlbumListResponse.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
@@ -22,7 +22,7 @@ import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaItemSearchResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaMetadata;
 import org.datatransferproject.datatransfer.google.mediaModels.Video;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.types.common.StringPaginationToken;
@@ -55,7 +55,7 @@ public class GoogleVideosExporterTest {
   private UUID uuid = UUID.randomUUID();
 
   private GoogleVideosExporter googleVideosExporter;
-  private PersistentPerJobStorage jobStore;
+  private TemporaryPerJobDataStore jobStore;
   private GoogleVideosInterface videosInterface;
 
   private MediaItemSearchResponse mediaItemSearchResponse;
@@ -64,7 +64,7 @@ public class GoogleVideosExporterTest {
   @Before
   public void setup() throws IOException {
     GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
-    jobStore = mock(PersistentPerJobStorage.class);
+    jobStore = mock(TemporaryPerJobDataStore.class);
     videosInterface = mock(GoogleVideosInterface.class);
 
     albumListResponse = mock(AlbumListResponse.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
@@ -16,11 +16,9 @@
 
 package org.datatransferproject.datatransfer.google.videos;
 
-import org.datatransferproject.cloud.local.LocalJobStore;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemResult;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
-import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.videos.VideoObject;
@@ -52,7 +50,6 @@ public class GoogleVideosImporterTest {
   private GoogleVideosImporter googleVideosImporter;
   private GoogleVideosInterface googleVideosInterface;
   private ImageStreamProvider videoStreamProvider;
-  private JobStore jobStore;
   private InputStream inputStream;
 
   @Before
@@ -69,15 +66,13 @@ public class GoogleVideosImporterTest {
             Matchers.eq(NewMediaItemResult.class)))
         .thenReturn(mock(NewMediaItemResult.class));
 
-    jobStore = new LocalJobStore();
-
     inputStream = mock(InputStream.class);
 
     videoStreamProvider = mock(ImageStreamProvider.class);
     when(videoStreamProvider.get(Matchers.anyString())).thenReturn(inputStream);
 
     googleVideosImporter =
-        new GoogleVideosImporter(null, jobStore, googleVideosInterface, videoStreamProvider,null,null);
+        new GoogleVideosImporter(null, googleVideosInterface, videoStreamProvider,null,null);
   }
 
   @Test

--- a/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/ImgurTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/ImgurTransferExtension.java
@@ -25,7 +25,7 @@ import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.imgur.photos.ImgurPhotosExporter;
 import org.datatransferproject.datatransfer.imgur.photos.ImgurPhotosImporter;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -53,7 +53,7 @@ public class ImgurTransferExtension implements TransferExtension {
     ObjectMapper mapper =
         new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     OkHttpClient client = context.getService(OkHttpClient.class);
-    PersistentPerJobStorage jobStore = context.getService(PersistentPerJobStorage.class);
+    TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
 
     exporter = new ImgurPhotosExporter(monitor, client, mapper, jobStore);
     importer = new ImgurPhotosImporter(monitor, client, mapper, jobStore);

--- a/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/ImgurTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/ImgurTransferExtension.java
@@ -16,8 +16,6 @@
 
 package org.datatransferproject.datatransfer.imgur;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -25,12 +23,12 @@ import com.google.common.collect.ImmutableList;
 import okhttp3.OkHttpClient;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.imgur.photos.ImgurPhotosExporter;
 import org.datatransferproject.datatransfer.imgur.photos.ImgurPhotosImporter;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.datatransfer.imgur.photos.ImgurPhotosExporter;
 
 /** Extension for transferring Imgur data */
 public class ImgurTransferExtension implements TransferExtension {
@@ -55,7 +53,7 @@ public class ImgurTransferExtension implements TransferExtension {
     ObjectMapper mapper =
         new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     OkHttpClient client = context.getService(OkHttpClient.class);
-    JobStore jobStore = context.getService(JobStore.class);
+    PersistentPerJobStorage jobStore = context.getService(PersistentPerJobStorage.class);
 
     exporter = new ImgurPhotosExporter(monitor, client, mapper, jobStore);
     importer = new ImgurPhotosImporter(monitor, client, mapper, jobStore);

--- a/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosExporter.java
@@ -24,7 +24,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.imgur.ImgurTransferExtension;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
@@ -41,7 +41,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 import static java.lang.String.format;
 
@@ -62,10 +68,13 @@ public class ImgurPhotosExporter
   private final OkHttpClient client;
   private final ObjectMapper objectMapper;
   private final Monitor monitor;
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
 
   public ImgurPhotosExporter(
-      Monitor monitor, OkHttpClient client, ObjectMapper objectMapper, JobStore jobStore) {
+      Monitor monitor,
+      OkHttpClient client,
+      ObjectMapper objectMapper,
+      PersistentPerJobStorage jobStore) {
     this.client = client;
     this.objectMapper = objectMapper;
     this.monitor = monitor;

--- a/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosExporter.java
@@ -24,7 +24,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.imgur.ImgurTransferExtension;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
@@ -68,13 +68,13 @@ public class ImgurPhotosExporter
   private final OkHttpClient client;
   private final ObjectMapper objectMapper;
   private final Monitor monitor;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
 
   public ImgurPhotosExporter(
       Monitor monitor,
       OkHttpClient client,
       ObjectMapper objectMapper,
-      PersistentPerJobStorage jobStore) {
+      TemporaryPerJobDataStore jobStore) {
     this.client = client;
     this.objectMapper = objectMapper;
     this.monitor = monitor;

--- a/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosImporter.java
@@ -28,7 +28,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.imgur.ImgurTransferExtension;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -50,7 +50,7 @@ public class ImgurPhotosImporter
 
   private final OkHttpClient client;
   private final ObjectMapper objectMapper;
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
   private final Monitor monitor;
   private static final String BASE_URL = ImgurTransferExtension.BASE_URL;
   private static final String CREATE_ALBUM_URL = BASE_URL + "/album";
@@ -58,7 +58,10 @@ public class ImgurPhotosImporter
   private static final String TEMP_PHOTOS_KEY = "tempPhotosData";
 
   public ImgurPhotosImporter(
-      Monitor monitor, OkHttpClient client, ObjectMapper objectMapper, JobStore jobStore) {
+      Monitor monitor,
+      OkHttpClient client,
+      ObjectMapper objectMapper,
+      PersistentPerJobStorage jobStore) {
     this.client = client;
     this.objectMapper = objectMapper;
     this.jobStore = jobStore;

--- a/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosImporter.java
@@ -28,7 +28,7 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.imgur.ImgurTransferExtension;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -50,7 +50,7 @@ public class ImgurPhotosImporter
 
   private final OkHttpClient client;
   private final ObjectMapper objectMapper;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final Monitor monitor;
   private static final String BASE_URL = ImgurTransferExtension.BASE_URL;
   private static final String CREATE_ALBUM_URL = BASE_URL + "/album";
@@ -61,7 +61,7 @@ public class ImgurPhotosImporter
       Monitor monitor,
       OkHttpClient client,
       ObjectMapper objectMapper,
-      PersistentPerJobStorage jobStore) {
+      TemporaryPerJobDataStore jobStore) {
     this.client = client;
     this.objectMapper = objectMapper;
     this.jobStore = jobStore;

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftTransferExtension.java
@@ -5,7 +5,7 @@ import okhttp3.OkHttpClient;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.JobStore;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -33,7 +33,7 @@ public class MicrosoftTransferExtension implements TransferExtension {
 
   private boolean initialized = false;
 
-  private PersistentPerJobStorage jobStore;
+  private TemporaryPerJobDataStore jobStore;
   private Monitor monitor;
 
   // Needed for ServiceLoader to load this class.

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftTransferExtension.java
@@ -5,6 +5,7 @@ import okhttp3.OkHttpClient;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -32,7 +33,7 @@ public class MicrosoftTransferExtension implements TransferExtension {
 
   private boolean initialized = false;
 
-  private JobStore jobStore;
+  private PersistentPerJobStorage jobStore;
   private Monitor monitor;
 
   // Needed for ServiceLoader to load this class.
@@ -84,7 +85,7 @@ public class MicrosoftTransferExtension implements TransferExtension {
     }
     if (transferDataType.equals(CALENDAR)) {
       return new MicrosoftCalendarImporter(
-          BASE_GRAPH_URL, client, mapper, transformerService, jobStore);
+          BASE_GRAPH_URL, client, mapper, transformerService);
     }
 
     if (transferDataType.equals(PHOTOS)) {

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/calendar/MicrosoftCalendarImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/calendar/MicrosoftCalendarImporter.java
@@ -17,7 +17,6 @@ package org.datatransferproject.transfer.microsoft.calendar;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
-import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -54,19 +53,16 @@ public class MicrosoftCalendarImporter
   private final TransformerService transformerService;
 
   private final String baseUrl;
-  private final JobStore jobStore;
 
   public MicrosoftCalendarImporter(
       String baseUrl,
       OkHttpClient client,
       ObjectMapper objectMapper,
-      TransformerService transformerService,
-      JobStore jobStore) {
+      TransformerService transformerService) {
     this.client = client;
     this.objectMapper = objectMapper;
     this.transformerService = transformerService;
     this.baseUrl = baseUrl;
-    this.jobStore = jobStore;
   }
 
   @SuppressWarnings("unchecked")

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosExporter.java
@@ -20,7 +20,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.types.common.ExportInformation;
@@ -55,13 +55,13 @@ public class MicrosoftPhotosExporter implements
 
   private final OkHttpClient client;
   private final ObjectMapper objectMapper;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
 
   public MicrosoftPhotosExporter(
       String baseUrl,
       OkHttpClient client,
       ObjectMapper objectMapper,
-      PersistentPerJobStorage jobStore) {
+      TemporaryPerJobDataStore jobStore) {
     photosRootUrl = baseUrl + "/v1.0/me/drive/special/photos/children";
     photosFolderTemplate = baseUrl + "/v1.0/me/drive/items/%s/children";
     photosContentTemplate = baseUrl + "/v1.0/me/drive/items/%s/content";

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosExporter.java
@@ -16,6 +16,19 @@
 package org.datatransferproject.transfer.microsoft.photos;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.transfer.provider.ExportResult;
+import org.datatransferproject.spi.transfer.provider.Exporter;
+import org.datatransferproject.types.common.ExportInformation;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -26,18 +39,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import org.datatransferproject.spi.cloud.storage.JobStore;
-import org.datatransferproject.spi.transfer.provider.ExportResult;
-import org.datatransferproject.spi.transfer.provider.Exporter;
-import org.datatransferproject.types.common.ExportInformation;
-import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.datatransferproject.types.common.models.photos.PhotoAlbum;
-import org.datatransferproject.types.common.models.photos.PhotoModel;
-import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 
 /**
  * Exports Microsoft OneDrive photos using the Graph API.
@@ -54,10 +55,13 @@ public class MicrosoftPhotosExporter implements
 
   private final OkHttpClient client;
   private final ObjectMapper objectMapper;
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
 
   public MicrosoftPhotosExporter(
-      String baseUrl, OkHttpClient client, ObjectMapper objectMapper, JobStore jobStore) {
+      String baseUrl,
+      OkHttpClient client,
+      ObjectMapper objectMapper,
+      PersistentPerJobStorage jobStore) {
     photosRootUrl = baseUrl + "/v1.0/me/drive/special/photos/children";
     photosFolderTemplate = baseUrl + "/v1.0/me/drive/items/%s/children";
     photosContentTemplate = baseUrl + "/v1.0/me/drive/items/%s/content";

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -28,7 +28,7 @@ import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -57,7 +57,7 @@ public class MicrosoftPhotosImporter implements Importer<TokenAuthData, PhotosCo
 
   private final OkHttpClient client;
   private final ObjectMapper objectMapper;
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
   private final Monitor monitor;
 
   private final String createFolderUrl;
@@ -67,7 +67,7 @@ public class MicrosoftPhotosImporter implements Importer<TokenAuthData, PhotosCo
       String baseUrl,
       OkHttpClient client,
       ObjectMapper objectMapper,
-      JobStore jobStore,
+      PersistentPerJobStorage jobStore,
       Monitor monitor) {
     createFolderUrl = baseUrl + "/v1.0/me/drive/special/photos/children";
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -28,7 +28,7 @@ import okio.BufferedSink;
 import okio.Okio;
 import okio.Source;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -57,7 +57,7 @@ public class MicrosoftPhotosImporter implements Importer<TokenAuthData, PhotosCo
 
   private final OkHttpClient client;
   private final ObjectMapper objectMapper;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final Monitor monitor;
 
   private final String createFolderUrl;
@@ -67,7 +67,7 @@ public class MicrosoftPhotosImporter implements Importer<TokenAuthData, PhotosCo
       String baseUrl,
       OkHttpClient client,
       ObjectMapper objectMapper,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       Monitor monitor) {
     createFolderUrl = baseUrl + "/v1.0/me/drive/special/photos/children";
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/MicrosoftCalendarImportTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/MicrosoftCalendarImportTest.java
@@ -24,7 +24,6 @@ import okhttp3.OkHttpClient;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
 import org.datatransferproject.transfer.microsoft.calendar.MicrosoftCalendarImporter;
-import org.datatransferproject.transfer.microsoft.helper.MockJobStore;
 import org.datatransferproject.transfer.microsoft.transformer.TransformerServiceImpl;
 import org.datatransferproject.types.common.models.calendar.CalendarAttendeeModel;
 import org.datatransferproject.types.common.models.calendar.CalendarContainerResource;
@@ -183,7 +182,6 @@ public class MicrosoftCalendarImportTest {
   private ObjectMapper mapper;
   private TransformerServiceImpl transformerService;
   private TokenAuthData token;
-  private MockJobStore jobStore;
 
   @Test
   @SuppressWarnings("unchecked")
@@ -195,7 +193,7 @@ public class MicrosoftCalendarImportTest {
     HttpUrl baseUrl = server.url("");
     MicrosoftCalendarImporter importer =
         new MicrosoftCalendarImporter(
-            baseUrl.toString(), client, mapper, transformerService, jobStore);
+            baseUrl.toString(), client, mapper, transformerService);
 
     CalendarModel calendarModel = new CalendarModel("OldId1", "name", "name");
     CalendarAttendeeModel attendeeModel =
@@ -300,7 +298,6 @@ public class MicrosoftCalendarImportTest {
     transformerService = new TransformerServiceImpl();
     token = new TokenAuthData("token456");
     server = new MockWebServer();
-    jobStore = new MockJobStore();
   }
 
   @After

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/SmugMugTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/SmugMugTransferExtension.java
@@ -24,7 +24,7 @@ import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.api.launcher.TypeManager;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -80,7 +80,7 @@ public class SmugMugTransferExtension implements TransferExtension {
     }
 
     HttpTransport transport = context.getService(HttpTransport.class);
-    JobStore jobStore = context.getService(JobStore.class);
+    PersistentPerJobStorage jobStore = context.getService(PersistentPerJobStorage.class);
 
     AppCredentials appCredentials;
     try {

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/SmugMugTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/SmugMugTransferExtension.java
@@ -24,7 +24,7 @@ import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.api.launcher.TypeManager;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -80,7 +80,7 @@ public class SmugMugTransferExtension implements TransferExtension {
     }
 
     HttpTransport transport = context.getService(HttpTransport.class);
-    PersistentPerJobStorage jobStore = context.getService(PersistentPerJobStorage.class);
+    TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
 
     AppCredentials appCredentials;
     try {

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosExporter.java
@@ -23,7 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Exporter;
@@ -58,7 +58,7 @@ public class SmugMugPhotosExporter
   private final AppCredentials appCredentials;
   private final HttpTransport transport;
   private final ObjectMapper mapper;
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
   private final Monitor monitor;
 
   private SmugMugInterface smugMugInterface;
@@ -67,7 +67,7 @@ public class SmugMugPhotosExporter
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,
-      JobStore jobStore,
+      PersistentPerJobStorage jobStore,
       Monitor monitor) {
     this(null, transport, appCredentials, mapper, jobStore, monitor);
   }
@@ -78,7 +78,7 @@ public class SmugMugPhotosExporter
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,
-      JobStore jobStore,
+      PersistentPerJobStorage jobStore,
       Monitor monitor) {
     this.transport = transport;
     this.appCredentials = appCredentials;

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosExporter.java
@@ -23,7 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Exporter;
@@ -58,7 +58,7 @@ public class SmugMugPhotosExporter
   private final AppCredentials appCredentials;
   private final HttpTransport transport;
   private final ObjectMapper mapper;
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final Monitor monitor;
 
   private SmugMugInterface smugMugInterface;
@@ -67,7 +67,7 @@ public class SmugMugPhotosExporter
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       Monitor monitor) {
     this(null, transport, appCredentials, mapper, jobStore, monitor);
   }
@@ -78,7 +78,7 @@ public class SmugMugPhotosExporter
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       Monitor monitor) {
     this.transport = transport;
     this.appCredentials = appCredentials;

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
@@ -21,7 +21,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -42,7 +42,7 @@ import static com.google.common.base.Preconditions.checkState;
 public class SmugMugPhotosImporter
     implements Importer<TokenSecretAuthData, PhotosContainerResource> {
 
-  private final JobStore jobStore;
+  private final PersistentPerJobStorage jobStore;
   private final AppCredentials appCredentials;
   private final HttpTransport transport;
   private final ObjectMapper mapper;
@@ -51,7 +51,7 @@ public class SmugMugPhotosImporter
   private SmugMugInterface smugMugInterface;
 
   public SmugMugPhotosImporter(
-      JobStore jobStore,
+      PersistentPerJobStorage jobStore,
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,
@@ -62,7 +62,7 @@ public class SmugMugPhotosImporter
   @VisibleForTesting
   SmugMugPhotosImporter(
       SmugMugInterface smugMugInterface,
-      JobStore jobStore,
+      PersistentPerJobStorage jobStore,
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
@@ -21,7 +21,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.PersistentPerJobStorage;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -42,7 +42,7 @@ import static com.google.common.base.Preconditions.checkState;
 public class SmugMugPhotosImporter
     implements Importer<TokenSecretAuthData, PhotosContainerResource> {
 
-  private final PersistentPerJobStorage jobStore;
+  private final TemporaryPerJobDataStore jobStore;
   private final AppCredentials appCredentials;
   private final HttpTransport transport;
   private final ObjectMapper mapper;
@@ -51,7 +51,7 @@ public class SmugMugPhotosImporter
   private SmugMugInterface smugMugInterface;
 
   public SmugMugPhotosImporter(
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,
@@ -62,7 +62,7 @@ public class SmugMugPhotosImporter
   @VisibleForTesting
   SmugMugPhotosImporter(
       SmugMugInterface smugMugInterface,
-      PersistentPerJobStorage jobStore,
+      TemporaryPerJobDataStore jobStore,
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
@@ -12,7 +12,7 @@ import java.util.UUID;
  * <p>This class is intended to be implemented by extensions that support storage in various
  * back-end services.
  */
-public interface JobStore extends PersistentPerJobStorage {
+public interface JobStore extends TemporaryPerJobDataStore {
 
   interface JobUpdateValidator {
 

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
@@ -1,11 +1,10 @@
 package org.datatransferproject.spi.cloud.storage;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.UUID;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
-import org.datatransferproject.types.common.models.DataModel;
+
+import java.io.IOException;
+import java.util.UUID;
 
 /**
  * A store for {@link PortabilityJob}s.
@@ -13,7 +12,7 @@ import org.datatransferproject.types.common.models.DataModel;
  * <p>This class is intended to be implemented by extensions that support storage in various
  * back-end services.
  */
-public interface JobStore {
+public interface JobStore extends PersistentPerJobStorage {
 
   interface JobUpdateValidator {
 
@@ -73,38 +72,4 @@ public interface JobStore {
    * if none found.
    */
   UUID findFirst(JobAuthorization.State jobState);
-
-  default <T extends DataModel> void create(UUID jobId, String key, T model) throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * Updates the given model instance associated with a job.
-   */
-  default <T extends DataModel> void update(UUID jobId, String key, T model) {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * Returns a model instance for the id of the given type or null if not found.
-   */
-  default <T extends DataModel> T findData(UUID jobId, String key, Class<T> type)
-      throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * Removes the data model instance.
-   */
-  default void removeData(UUID JobId, String key) {
-    throw new UnsupportedOperationException();
-  }
-
-  default void create(UUID jobId, String key, InputStream stream) throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
-  default InputStream getStream(UUID jobId, String key) throws IOException {
-    throw new UnsupportedOperationException();
-  }
 }

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/PersistentPerJobStorage.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/PersistentPerJobStorage.java
@@ -1,0 +1,49 @@
+package org.datatransferproject.spi.cloud.storage;
+
+import org.datatransferproject.types.common.models.DataModel;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+/**
+ * A store for data that will be persisted for the life of a backup job.
+ *
+ * <p>This class is intended to be implemented by extensions that support storage in various
+ * back-end services.
+ */
+public interface PersistentPerJobStorage {
+  default <T extends DataModel> void create(UUID jobId, String key, T model) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Updates the given model instance associated with a job.
+   */
+  default <T extends DataModel> void update(UUID jobId, String key, T model) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns a model instance for the id of the given type or null if not found.
+   */
+  default <T extends DataModel> T findData(UUID jobId, String key, Class<T> type)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Removes the data model instance.
+   */
+  default void removeData(UUID JobId, String key) {
+    throw new UnsupportedOperationException();
+  }
+
+  default void create(UUID jobId, String key, InputStream stream) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  default InputStream getStream(UUID jobId, String key) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/TemporaryPerJobDataStore.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/TemporaryPerJobDataStore.java
@@ -12,7 +12,7 @@ import java.util.UUID;
  * <p>This class is intended to be implemented by extensions that support storage in various
  * back-end services.
  */
-public interface PersistentPerJobStorage {
+public interface TemporaryPerJobDataStore {
   default <T extends DataModel> void create(UUID jobId, String key, T model) throws IOException {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
As per #623 JobStore is really 2 distinct things:
1) a job management interface that is only used by DTP internals
2) a Temp data store for integrations.

This pulls use case 2 into a seperate interface: TemporaryPerJobDataStore.  I am not sold on the name, so any suggestions would be appreciated.

For now JobStore inherits from TemporaryPerJobDataStore, but in future changes that will break.

Also TemporaryPerJobDataStore will should no longer require the JobId for jobs, but that again will come in a latter PR.