### PR TITLE
Make the DTP framework call the appropriate metric hooks

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleDtpInternalMetricRecorder.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleDtpInternalMetricRecorder.java
@@ -69,16 +69,6 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void exportFinished(String dataType, String service, boolean success, Duration duration) {
-    monitor.debug(
-        () -> "Metric: exportFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
-  }
-
-  @Override
   public void importPageAttemptFinished(
       String dataType,
       String service,
@@ -101,16 +91,6 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
       Duration duration) {
     monitor.debug(
         () -> "Metric: importPageFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
-  }
-
-  @Override
-  public void importFinished(String dataType, String service, boolean success, Duration duration) {
-    monitor.debug(
-        () -> "Metric: importFinished, data type: %s, service: %s, success: %s, duration: %s",
         dataType,
         service,
         success,

--- a/extensions/cloud/portability-cloud-local/src/main/java/org/datatransferproject/cloud/local/LoggingDtpInternalMetricRecorder.java
+++ b/extensions/cloud/portability-cloud-local/src/main/java/org/datatransferproject/cloud/local/LoggingDtpInternalMetricRecorder.java
@@ -67,16 +67,6 @@ class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void exportFinished(String dataType, String service, boolean success, Duration duration) {
-    monitor.debug(
-        () -> "Metric: exportFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
-  }
-
-  @Override
   public void importPageAttemptFinished(
       String dataType,
       String service,
@@ -99,16 +89,6 @@ class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
       Duration duration) {
     monitor.debug(
         () -> "Metric: importPageFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
-  }
-
-  @Override
-  public void importFinished(String dataType, String service, boolean success, Duration duration) {
-    monitor.debug(
-        () -> "Metric: importFinished, data type: %s, service: %s, success: %s, duration: %s",
         dataType,
         service,
         success,

--- a/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureDtpInternalMetricRecorder.java
+++ b/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureDtpInternalMetricRecorder.java
@@ -68,16 +68,6 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void exportFinished(String dataType, String service, boolean success, Duration duration) {
-    monitor.debug(
-        () -> "Metric: exportFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
-  }
-
-  @Override
   public void importPageAttemptFinished(
       String dataType,
       String service,
@@ -100,16 +90,6 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
       Duration duration) {
     monitor.debug(
         () -> "Metric: importPageFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
-  }
-
-  @Override
-  public void importFinished(String dataType, String service, boolean success, Duration duration) {
-    monitor.debug(
-        () -> "Metric: importFinished, data type: %s, service: %s, success: %s, duration: %s",
         dataType,
         service,
         success,

--- a/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/DtpInternalMetricRecorder.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/DtpInternalMetricRecorder.java
@@ -49,9 +49,6 @@ public interface DtpInternalMetricRecorder {
   /** An attempt to export a page of data finished including all retires. **/
   void exportPageFinished(String dataType, String service, boolean success, Duration duration);
 
-  /** The export of all data from a service finished. **/
-  void exportFinished(String dataType, String service, boolean success, Duration duration);
-
   /** An single attempt to import a page of data finished. **/
   void importPageAttemptFinished(
       String dataType,
@@ -61,9 +58,6 @@ public interface DtpInternalMetricRecorder {
 
   /** An attempt to import a page of data finished including all retires. **/
   void importPageFinished(String dataType, String service, boolean success, Duration duration);
-
-  /** The import of all data from a service finished. **/
-  void importFinished(String dataType, String service, boolean success, Duration duration);
 
   // Metrics from {@link MetricRecorder}
   void recordGenericMetric(String dataType, String service, String tag);

--- a/portability-api/src/main/java/org/datatransferproject/api/ApiServicesModule.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/ApiServicesModule.java
@@ -15,6 +15,7 @@ import org.datatransferproject.api.action.transfer.GetTransferServicesAction;
 import org.datatransferproject.api.action.transfer.ReserveWorkerAction;
 import org.datatransferproject.api.action.transfer.StartTransferJobAction;
 import org.datatransferproject.api.auth.PortabilityAuthServiceProviderRegistry;
+import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.api.launcher.TypeManager;
@@ -87,6 +88,8 @@ public class ApiServicesModule extends FlagBindingModule {
     bind(TypeManager.class).toInstance(typeManager);
     bind(JobStore.class).toInstance(jobStore);
     bind(TokenManager.class).toInstance(tokenManager);
+    bind(DtpInternalMetricRecorder.class)
+        .toInstance(context.getService(DtpInternalMetricRecorder.class));
 
     if (trustManagerFactory != null) {
       bind(TrustManagerFactory.class).toInstance(trustManagerFactory);

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
@@ -107,6 +107,8 @@ final class WorkerModule extends FlagBindingModule {
     bind(AsymmetricKeyGenerator.class).toInstance(asymmetricKeyGenerator);
     bind(InMemoryDataCopier.class).to(PortabilityInMemoryDataCopier.class);
     bind(ObjectMapper.class).toInstance(context.getTypeManager().getMapper());
+    bind(DtpInternalMetricRecorder.class)
+        .toInstance(context.getService(DtpInternalMetricRecorder.class));
   }
 
   @Provides


### PR DESCRIPTION
Removes importFinished and exportFinished as because we interleave the processing they don't make sense.

This addresses issue #41.