### PR TITLE
update autovalue version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 projectGroup=org.datatransferproject
 projectVersion=0.1
 annotationApiVersion=1.2
-autoValueVersion=1.5.3
+autoValueVersion=1.6.2
 commonsLangVersion=3.4
 ezVcardVersion=0.10.3
 flickrVersion=2.16

--- a/portability-types-common/build.gradle
+++ b/portability-types-common/build.gradle
@@ -21,6 +21,7 @@ plugins {
 }
 dependencies {
     compile("com.google.auto.value:auto-value:${autoValueVersion}")
+    compile("com.google.auto.value:auto-value-annotations:${autoValueVersion}")
 
     compile fileTree(include: ['*.jar'], dir: 'lib')
 


### PR DESCRIPTION
Update AutoValue version and add recently broken out maven package for the Auto value annotations, used in portability-types-common sub project.