### PR TITLE
Insert missing uses of String.format

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/StackdriverMonitor.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/StackdriverMonitor.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 
 class StackdriverMonitor implements JobAwareMonitor {
 
@@ -62,13 +63,13 @@ class StackdriverMonitor implements JobAwareMonitor {
       for (Object datum : data) {
         if (datum instanceof Throwable) {
           logMessage.append(
-              String.format("\n%s", Throwables.getStackTraceAsString(((Throwable) datum))));
+              format("\n%s", Throwables.getStackTraceAsString(((Throwable) datum))));
         } else if (datum instanceof UUID) {
-          logMessage.append(String.format("\nJobId: %s", ((UUID) datum)));
+          logMessage.append(format("\nJobId: %s", ((UUID) datum)));
         } else if (datum instanceof EventCode) {
-          logMessage.append(String.format("\nEventCode: %s", (EventCode) datum));
+          logMessage.append(format("\nEventCode: %s", (EventCode) datum));
         } else if (datum != null) {
-          logMessage.append(String.format("\n%s", datum));
+          logMessage.append(format("\n%s", datum));
         }
       }
     }
@@ -100,6 +101,6 @@ class StackdriverMonitor implements JobAwareMonitor {
   public void setJobId(String jobId) {
     checkState(this.jobId == null, "JobId can only be set once.");
     this.jobId = jobId;
-    debug(() -> "Set job id to: %s", jobId);
+    debug(() -> format("Set job id to: %s", jobId));
   }
 }

--- a/extensions/cloud/portability-cloud-local/src/main/java/org/datatransferproject/cloud/local/LocalJobStore.java
+++ b/extensions/cloud/portability-cloud-local/src/main/java/org/datatransferproject/cloud/local/LocalJobStore.java
@@ -117,7 +117,8 @@ public final class LocalJobStore implements JobStore {
     // This is a no-op currently as nothing in DTP reads the errors currently.
     if (errors != null && !errors.isEmpty()) {
       for (ErrorDetail error : errors) {
-        monitor.info(() -> "Added error: %s", OBJECT_MAPPER.writeValueAsString(error));
+        String errorString = OBJECT_MAPPER.writeValueAsString(error);
+        monitor.info(() -> "Added error: " + errorString);
       }
     }
   }

--- a/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureDtpInternalMetricRecorder.java
+++ b/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureDtpInternalMetricRecorder.java
@@ -15,6 +15,8 @@
  */
 package org.datatransferproject.cloud.microsoft.cosmos;
 
+import static java.lang.String.format;
+
 import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
 import org.datatransferproject.api.launcher.Monitor;
 
@@ -34,8 +36,11 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void startedJob(String dataType, String exportService, String importService) {
-    monitor.debug(() -> "Metric: StartedJob, data type: %s, from: %s, to: %s",
-        dataType, exportService, importService);
+    monitor.debug(
+        () ->
+            format(
+                "Metric: StartedJob, data type: %s, from: %s, to: %s",
+                dataType, exportService, importService));
   }
 
   @Override
@@ -45,12 +50,11 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: exportPageAttemptFinished, data type: %s, service: %s, "
-            + "success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: exportPageAttemptFinished, data type: %s, service: %s, "
+                    + "success: %s, duration: %s",
+                dataType, service, success, duration));
   }
 
   @Override
@@ -60,11 +64,10 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: exportPageFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: exportPageFinished, data type: %s, service: %s, success: %s, duration: %s",
+                dataType, service, success, duration));
   }
 
   @Override
@@ -74,12 +77,11 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: importPageAttemptFinished, data type: %s, service: %s,"
-            + "success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: importPageAttemptFinished, data type: %s, service: %s,"
+                    + "success: %s, duration: %s",
+                dataType, service, success, duration));
   }
 
   @Override
@@ -89,11 +91,10 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: importPageFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: importPageFinished, data type: %s, service: %s, success: %s, duration: %s",
+                dataType, service, success, duration));
   }
 
   @Override
@@ -104,35 +105,43 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: finishedJob, data type: %s, from: %s, to: %s, success: %s, duration: %s",
-        dataType,
-        exportService,
-        importService,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: finishedJob, data type: %s, from: %s, to: %s, success: %s, duration: %s",
+                dataType, exportService, importService, success, duration));
   }
 
   @Override
   public void recordGenericMetric(String dataType, String service, String tag) {
-    monitor.debug(() -> "Metric: Generic, data type: %s, service: %s, tag: %s",
-        dataType, service, tag);
+    monitor.debug(
+        () ->
+            format("Metric: Generic, data type: %s, service: %s, tag: %s", dataType, service, tag));
   }
 
   @Override
   public void recordGenericMetric(String dataType, String service, String tag, boolean bool) {
-    monitor.debug(() -> "Metric: Generic, data type: %s, service: %s, tag: %s, value: %s",
-        dataType, service, tag, bool);
+    monitor.debug(
+        () ->
+            format(
+                "Metric: Generic, data type: %s, service: %s, tag: %s, value: %s",
+                dataType, service, tag, bool));
   }
 
   @Override
   public void recordGenericMetric(String dataType, String service, String tag, Duration duration) {
-    monitor.debug(() -> "Metric: Generic, data type: %s, service: %s, tag: %s, duration: %s",
-        dataType, service, tag, duration);
+    monitor.debug(
+        () ->
+            format(
+                "Metric: Generic, data type: %s, service: %s, tag: %s, duration: %s",
+                dataType, service, tag, duration));
   }
 
   @Override
   public void recordGenericMetric(String dataType, String service, String tag, int value) {
-    monitor.debug(() -> "Metric: Generic, data type: %s, service: %s, tag: %s, value: %s",
-        dataType, service, tag, value);
+    monitor.debug(
+        () ->
+            format(
+                "Metric: Generic, data type: %s, service: %s, tag: %s, value: %s",
+                dataType, service, tag, value));
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-deezer/src/main/java/org/datatransferproject/transfer/deezer/playlists/DeezerPlaylistExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-deezer/src/main/java/org/datatransferproject/transfer/deezer/playlists/DeezerPlaylistExporter.java
@@ -17,6 +17,8 @@
 package org.datatransferproject.transfer.deezer.playlists;
 
 
+import static java.lang.String.format;
+
 import com.google.api.client.http.HttpTransport;
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.Monitor;
@@ -88,7 +90,7 @@ public class DeezerPlaylistExporter implements
 
     ImmutableList.Builder<MusicRecording> results = new ImmutableList.Builder<>();
 
-      monitor.debug(() -> "Fetching playlist's %s tracks", playlistId);
+      monitor.debug(() -> format("Fetching playlist's %s tracks", playlistId));
       PlaylistDetails playlistDetails = api.getPlaylistDetails(playlistId);
       for (Track track : playlistDetails.getTrackCollection().getTracks()) {
         results.add(convertTrack(api, track.getId()));

--- a/extensions/data-transfer/portability-data-transfer-deezer/src/main/java/org/datatransferproject/transfer/deezer/playlists/DeezerPlaylistImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-deezer/src/main/java/org/datatransferproject/transfer/deezer/playlists/DeezerPlaylistImporter.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
 
 /**
  * Imports playlists into Deezer.
@@ -84,7 +85,7 @@ public class DeezerPlaylistImporter
         playlist.getHeadline(),
         () -> createPlaylist(api, playlist));
     if (null == newPlaylistId) {
-      monitor.severe(() ->"Couldn't create playlist: %s", playlist);
+      monitor.severe(() -> format("Couldn't create playlist: %s", playlist));
       // Playlist couldn't be created error will be reported to user.
       return;
     }

--- a/extensions/data-transfer/portability-data-transfer-spotify/src/main/java/org/datatransferproject/transfer/spotify/playlists/SpotifyPlaylistExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-spotify/src/main/java/org/datatransferproject/transfer/spotify/playlists/SpotifyPlaylistExporter.java
@@ -17,6 +17,8 @@
 package org.datatransferproject.transfer.spotify.playlists;
 
 
+import static java.lang.String.format;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.wrapper.spotify.SpotifyApi;
@@ -78,14 +80,18 @@ public class SpotifyPlaylistExporter implements
     int offset = 0;
     Paging<PlaylistSimplified> playlists;
     do {
-      monitor.debug(() -> "Fetching playlists with offset %s", offset);
+      int finalOffset = offset;
+      monitor.debug(() -> format("Fetching playlists with offset %s", finalOffset));
       playlists = spotifyApi.getListOfUsersPlaylists(userId)
           .offset(offset)
           .build()
           .execute();
       for (PlaylistSimplified playlist : playlists.getItems()) {
-        monitor.debug(() -> "Got playlist %s: %s (id: %s)",
-            playlist.getId(), playlist.getName(), playlist.getHref());
+        monitor.debug(
+            () ->
+                format(
+                    "Got playlist %s: %s (id: %s)",
+                    playlist.getId(), playlist.getName(), playlist.getHref()));
         results.add(new MusicPlaylist(
             playlist.getHref(),
             playlist.getName(),
@@ -102,8 +108,12 @@ public class SpotifyPlaylistExporter implements
     Paging<PlaylistTrack> playlistTrackResults;
     ImmutableList.Builder<MusicRecording> results = new ImmutableList.Builder<>(); 
     do {
-      monitor.debug(() -> "Fetching playlist's %s tracks with offset %s, next: %s",
-          playlistId, offset);
+      int finalOffset = offset;
+      monitor.debug(
+          () ->
+              format(
+                  "Fetching playlist's %s tracks with offset %s, next: %s",
+                  playlistId, finalOffset));
       playlistTrackResults = spotifyApi.getPlaylistsTracks(playlistId)
           .offset(offset)
           .build()
@@ -119,7 +129,7 @@ public class SpotifyPlaylistExporter implements
 
   private MusicRecording convertTrack(PlaylistTrack playlistTrack) {
     Track track = playlistTrack.getTrack();
-    monitor.debug(() -> "Converting: %s", track);
+    monitor.debug(() -> format("Converting: %s", track));
     return new MusicRecording(
         track.getHref(),
         track.getName(),

--- a/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/DelegatingExtensionContext.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/DelegatingExtensionContext.java
@@ -15,6 +15,8 @@
  */
 package org.datatransferproject.api.launcher;
 
+import static java.lang.String.format;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -69,11 +71,12 @@ public class DelegatingExtensionContext implements ExtensionContext {
 
   public <T> void registerOverrideService(Class<T> type, T service) {
     if (overriddenRegisteredClasses.containsKey(type)) {
-      getMonitor().info(
-          () -> "Re-overriding type %s from %s to %s",
-          type,
-          overriddenRegisteredClasses.get(type),
-          service);
+      getMonitor()
+          .info(
+              () ->
+                  format(
+                      "Re-overriding type %s from %s to %s",
+                      type, overriddenRegisteredClasses.get(type), service));
     }
     overriddenRegisteredClasses.put(type, service);
   }

--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/metrics/LoggingDtpInternalMetricRecorder.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/metrics/LoggingDtpInternalMetricRecorder.java
@@ -15,6 +15,8 @@
  */
 package org.datatransferproject.launcher.metrics;
 
+import static java.lang.String.format;
+
 import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
@@ -46,8 +48,11 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
 
   @Override
   public void startedJob(String dataType, String exportService, String importService) {
-    monitor.debug(() -> "Metric: StartedJob, data type: %s, from: %s, to: %s",
-        dataType, exportService, importService);
+    monitor.debug(
+        () ->
+            format(
+                "Metric: StartedJob, data type: %s, from: %s, to: %s",
+                dataType, exportService, importService));
   }
 
   @Override
@@ -57,12 +62,11 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: exportPageAttemptFinished, data type: %s, service: %s, "
-            + "success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: exportPageAttemptFinished, data type: %s, service: %s, "
+                    + "success: %s, duration: %s",
+                dataType, service, success, duration));
   }
 
   @Override
@@ -72,11 +76,10 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: exportPageFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: exportPageFinished, data type: %s, service: %s, success: %s, duration: %s",
+                dataType, service, success, duration));
   }
 
   @Override
@@ -86,12 +89,11 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: importPageAttemptFinished, data type: %s, service: %s,"
-            + "success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: importPageAttemptFinished, data type: %s, service: %s,"
+                    + "success: %s, duration: %s",
+                dataType, service, success, duration));
   }
 
   @Override
@@ -101,11 +103,10 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: importPageFinished, data type: %s, service: %s, success: %s, duration: %s",
-        dataType,
-        service,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: importPageFinished, data type: %s, service: %s, success: %s, duration: %s",
+                dataType, service, success, duration));
   }
 
   @Override
@@ -116,35 +117,43 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
       boolean success,
       Duration duration) {
     monitor.debug(
-        () -> "Metric: finishedJob, data type: %s, from: %s, to: %s, success: %s, duration: %s",
-        dataType,
-        exportService,
-        importService,
-        success,
-        duration);
+        () ->
+            format(
+                "Metric: finishedJob, data type: %s, from: %s, to: %s, success: %s, duration: %s",
+                dataType, exportService, importService, success, duration));
   }
 
   @Override
   public void recordGenericMetric(String dataType, String service, String tag) {
-    monitor.debug(() -> "Metric: Generic, data type: %s, service: %s, tag: %s",
-        dataType, service, tag);
+    monitor.debug(
+        () ->
+            format("Metric: Generic, data type: %s, service: %s, tag: %s", dataType, service, tag));
   }
 
   @Override
   public void recordGenericMetric(String dataType, String service, String tag, boolean bool) {
-    monitor.debug(() -> "Metric: Generic, data type: %s, service: %s, tag: %s, value: %s",
-        dataType, service, tag, bool);
+    monitor.debug(
+        () ->
+            format(
+                "Metric: Generic, data type: %s, service: %s, tag: %s, value: %s",
+                dataType, service, tag, bool));
   }
 
   @Override
   public void recordGenericMetric(String dataType, String service, String tag, Duration duration) {
-    monitor.debug(() -> "Metric: Generic, data type: %s, service: %s, tag: %s, duration: %s",
-        dataType, service, tag, duration);
+    monitor.debug(
+        () ->
+            format(
+                "Metric: Generic, data type: %s, service: %s, tag: %s, duration: %s",
+                dataType, service, tag, duration));
   }
 
   @Override
   public void recordGenericMetric(String dataType, String service, String tag, int value) {
-    monitor.debug(() -> "Metric: Generic, data type: %s, service: %s, tag: %s, value: %s",
-        dataType, service, tag, value);
+    monitor.debug(
+        () ->
+            format(
+                "Metric: Generic, data type: %s, service: %s, tag: %s, value: %s",
+                dataType, service, tag, value));
   }
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/InMemoryIdempotentImportExecutor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/InMemoryIdempotentImportExecutor.java
@@ -16,6 +16,8 @@
 
 package org.datatransferproject.transfer;
 
+import static java.lang.String.format;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -59,13 +61,13 @@ public class InMemoryIdempotentImportExecutor implements IdempotentImportExecuto
   public <T extends Serializable> T executeOrThrowException(
       String idempotentId, String itemName, Callable<T> callable) throws IOException {
     if (knownValues.containsKey(idempotentId)) {
-      monitor.debug(() -> "Using cached key %s from cache for %s", idempotentId, itemName);
+      monitor.debug(() -> format("Using cached key %s from cache for %s", idempotentId, itemName));
       return (T) knownValues.get(idempotentId);
     }
     try {
       T result = callable.call();
       knownValues.put(idempotentId, result);
-      monitor.debug(() -> "Storing key %s in cache for %s", idempotentId, itemName);
+      monitor.debug(() -> format("Storing key %s in cache for %s", idempotentId, itemName));
       errors.remove(idempotentId);
       return result;
     } catch (Exception e) {

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -127,7 +127,7 @@ class JobPollingService extends AbstractScheduledService {
     UUID jobId = store.findFirst(JobAuthorization.State.CREDS_AVAILABLE);
     monitor.debug(() -> "Polling for a job in state CREDS_AVAILABLE");
     if (jobId == null) {
-      monitor.debug(() -> format("Did not find job after polling"));
+      monitor.debug(() -> "Did not find job after polling");
       return;
     }
     monitor.debug(() -> format("Found job %s", jobId));

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -155,7 +155,7 @@ final class JobProcessor {
       store.addErrorsToJob(jobId, errors);
     } catch (IOException | RuntimeException e) {
       success = false;
-      monitor.severe(() -> "Problem adding errors to JobStore: %s", e);
+      monitor.severe(() -> format("Problem adding errors to JobStore: %s", e), e);
     }
     State state = success ? State.COMPLETE : State.ERROR;
     updateJobState(jobId, state, State.IN_PROGRESS, JobAuthorization.State.CREDS_STORED);

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
@@ -15,6 +15,8 @@
  */
 package org.datatransferproject.transfer;
 
+import static java.lang.String.format;
+
 import com.google.common.base.Stopwatch;
 import com.google.inject.Provider;
 import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
@@ -156,7 +158,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
         ImportResult importResult = retryingImporter.call();
         importSuccess = importResult.getType() == ImportResult.ResultType.OK;
       } catch (RetryException | RuntimeException e) {
-        monitor.severe(() -> "Got error importing data: %s", e);
+        monitor.severe(() -> format("Got error importing data: %s", e), e);
       } finally{
         metricRecorder.importPageFinished(
             JobMetadata.getDataType(),

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
@@ -16,6 +16,7 @@
 package org.datatransferproject.transfer;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static java.lang.String.format;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -227,10 +228,11 @@ final class WorkerModule extends FlagBindingModule {
   private TransferServiceConfig getTransferServiceConfig(TransferExtension ext) {
     String configFileName = "config/" + ext.getServiceId().toLowerCase() + ".yaml";
     InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(configFileName);
-    getMonitor().info(
-        () -> "Service %s has a config file: %s",
-        ext.getServiceId(),
-        (inputStream != null));
+    getMonitor()
+        .info(
+            () ->
+                format(
+                    "Service %s has a config file: %s", ext.getServiceId(), (inputStream != null)));
     if (inputStream == null) {
       return TransferServiceConfig.getDefaultInstance();
     } else {


### PR DESCRIPTION
Fix calls to Monitor where format was not being applied to strings with obvious String format expressions in them (e.g. %s)