### PR TITLE
Mark a job as failed if any errors are returned from the copier

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -124,8 +124,10 @@ final class JobProcessor {
           importAuthData,
           jobId,
           exportInfo);
-      monitor.debug(() -> "Finished copy for jobId: " + jobId);
-      success = true;
+      final int numErrors = errors.size();
+      monitor.debug(
+          () -> format("Finished copy for jobId: %s with %d error(s).", jobId, numErrors));
+      success = errors.isEmpty();
     } catch (IOException | CopyException | RuntimeException e) {
       monitor.severe(() -> "Error processing jobId: " + jobId, e, EventCode.WORKER_JOB_ERRORED);
     } finally {


### PR DESCRIPTION
Because most exceptions are caught by the IdepotentExecutor it has been possible for a job to have a bunch of errors, to the point that no photos were transferred, but it could still be marked as complete. This change aims to mark a job as failed if there are any errors left when a copy finishes. (If an import is retried for an item that had previously failed then that error will already be removed on a successful retry)