### PR TITLE
Refactor JobStore

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleJobStore.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleJobStore.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.JobStoreWithValidator;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.types.common.models.DataModel;
@@ -59,7 +60,7 @@ import java.util.UUID;
  * A {@link JobStore} implementation based on Google Cloud Platform's Datastore.
  */
 @Singleton
-public final class GoogleJobStore implements JobStore {
+public final class GoogleJobStore extends JobStoreWithValidator {
 
   private static final String JOB_KIND = "persistentKey";
   private static final String ERROR_KIND = "error";
@@ -165,7 +166,7 @@ public final class GoogleJobStore implements JobStore {
    * updating it @throws IllegalStateException if validator.validate() failed
    */
   @Override
-  public void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
+  protected void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
       throws IOException {
     Preconditions.checkNotNull(jobId);
     Transaction transaction = datastore.newTransaction();

--- a/extensions/cloud/portability-cloud-local/src/main/java/org/datatransferproject/cloud/local/LocalJobStore.java
+++ b/extensions/cloud/portability-cloud-local/src/main/java/org/datatransferproject/cloud/local/LocalJobStore.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.JobStoreWithValidator;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.JobAuthorization.State;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
@@ -37,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static java.lang.String.format;
 
 /** An in-memory {@link JobStore} implementation that uses a concurrent map as its store. */
-public final class LocalJobStore implements JobStore {
+public final class LocalJobStore extends JobStoreWithValidator {
   private static ConcurrentHashMap<UUID, Map<String, Object>> JOB_MAP = new ConcurrentHashMap<>();
   private static ConcurrentHashMap<String, Map<Class<? extends DataModel>, DataModel>> DATA_MAP =
       new ConcurrentHashMap<>();
@@ -95,7 +96,7 @@ public final class LocalJobStore implements JobStore {
    * @throws IllegalStateException if validator.validate() failed
    */
   @Override
-  public synchronized void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
+  protected synchronized void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
       throws IOException {
     Preconditions.checkNotNull(jobId);
     try {

--- a/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureTableStore.java
+++ b/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureTableStore.java
@@ -13,7 +13,7 @@ import com.microsoft.azure.storage.table.CloudTableClient;
 import com.microsoft.azure.storage.table.TableOperation;
 import com.microsoft.azure.storage.table.TableQuery;
 import com.microsoft.azure.storage.table.TableResult;
-import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.JobStoreWithValidator;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.types.common.models.DataModel;
@@ -30,7 +30,7 @@ import java.util.UUID;
 import static com.microsoft.azure.storage.table.TableQuery.generateFilterCondition;
 
 /** Uses the Azure Cosmos DB Table Storage API to persist job data. */
-public class AzureTableStore implements JobStore {
+public class AzureTableStore extends JobStoreWithValidator {
   private static final String COSMOS_CONNECTION_TEMPLATE =
       "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;TableEndpoint=%s;";
   private static final String ENDPOINT_TEMPLATE = "https://%s.table.cosmosdb.azure.com:443/";
@@ -106,7 +106,7 @@ public class AzureTableStore implements JobStore {
   }
 
   @Override
-  public void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
+  protected void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
       throws IOException {
 
     Preconditions.checkNotNull(jobId, "Job is null");

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/helper/MockJobStore.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/helper/MockJobStore.java
@@ -18,6 +18,7 @@ package org.datatransferproject.transfer.microsoft.helper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.JobStoreWithValidator;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.types.common.models.DataModel;
@@ -31,7 +32,7 @@ import java.util.Map;
 import java.util.UUID;
 
 /** An implementation for testing. */
-public class MockJobStore implements JobStore {
+public class MockJobStore extends JobStoreWithValidator {
   private final Map<String, DataModel> testData = new HashMap<>();
   private final Map<String, InputStream> keyedData = new HashMap<>();
 
@@ -47,7 +48,7 @@ public class MockJobStore implements JobStore {
   public void updateJob(UUID jobId, PortabilityJob job) throws IOException {}
 
   @Override
-  public void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
+  protected void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
       throws IOException {}
 
   @Override

--- a/portability-api/src/main/java/org/datatransferproject/api/action/ActionUtils.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/ActionUtils.java
@@ -36,16 +36,6 @@ public final class ActionUtils {
         Charsets.UTF_8));
   }
 
-  /** Determines whether the current service is a valid service for export. */
-  public static boolean isValidExportService(String serviceName) {
-    return !Strings.isNullOrEmpty(serviceName);
-  }
-
-  /** Determines whether the current service is a valid service for import. */
-  public static boolean isValidImportService(String serviceName) {
-    return !Strings.isNullOrEmpty(serviceName);
-  }
-
   /** Determines whether the current service is a valid service for import. */
   public static boolean isValidTransferDataType(String transferDataType) {
     return !Strings.isNullOrEmpty(transferDataType);

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/ReserveWorkerAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/ReserveWorkerAction.java
@@ -1,15 +1,11 @@
 package org.datatransferproject.api.action.transfer;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import org.datatransferproject.api.action.Action;
-import org.datatransferproject.api.action.ActionUtils;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.launcher.monitor.events.EventCode;
 import org.datatransferproject.spi.cloud.storage.JobStore;
-import org.datatransferproject.spi.cloud.types.JobAuthorization;
-import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.types.client.transfer.ReserveWorker;
 import org.datatransferproject.types.client.transfer.ReservedWorker;
 
@@ -18,7 +14,6 @@ import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.datatransferproject.api.action.ActionUtils.decodeJobId;
-import static org.datatransferproject.spi.cloud.types.JobAuthorization.State.CREDS_AVAILABLE;
 
 /** Reserves a worker to process a transfer job. */
 public class ReserveWorkerAction implements Action<ReserveWorker, ReservedWorker> {
@@ -50,48 +45,13 @@ public class ReserveWorkerAction implements Action<ReserveWorker, ReservedWorker
     return new ReservedWorker("");
   }
 
-  /**
-   * Update the job to state to {@code State.CREDS_AVAILABLE} in the store. This indicates to the
-   * pool of workers that this job is available for processing.
-   */
   private void updateStateToCredsAvailable(UUID jobId) {
-    PortabilityJob job = jobStore.findJob(jobId);
-    validateJob(job);
-    // Set update job auth data
-    JobAuthorization jobAuthorization =
-        job.jobAuthorization().toBuilder().setState(CREDS_AVAILABLE).build();
-    job = job.toBuilder().setAndValidateJobAuthorization(jobAuthorization).build();
     try {
-      jobStore.updateJob(
-          jobId,
-          job,
-          (previous, updated) ->
-              Preconditions.checkState(
-                  previous.jobAuthorization().state() == JobAuthorization.State.INITIAL));
+      jobStore.updateJobAuthStateToCredsAvailable(jobId);
       monitor.debug(() -> format("Updated job %s to CREDS_AVAILABLE", jobId), jobId,
           EventCode.API_JOB_CREDS_AVAILABLE);
     } catch (IOException e) {
       throw new RuntimeException("Unable to update job", e);
     }
-  }
-
-  // TODO: Consolidate validation with the internal PortabilityJob validation
-  private void validateJob(PortabilityJob job) {
-    // Validate
-    String dataType = job.transferDataType();
-    Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(dataType), "Missing valid dataTypeParam: %s", dataType);
-
-    String exportService = job.exportService();
-    Preconditions.checkArgument(
-        ActionUtils.isValidExportService(exportService),
-        "Missing valid exportService: %s",
-        exportService);
-
-    String importService = job.importService();
-    Preconditions.checkArgument(
-        ActionUtils.isValidImportService(importService),
-        "Missing valid importService: %s",
-        importService);
   }
 }

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/StartTransferJobAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/StartTransferJobAction.java
@@ -79,7 +79,7 @@ public class StartTransferJobAction implements Action<StartTransferJob, Transfer
         () -> format("Updating job %s from CREDS_ENCRYPTION_KEY_GENERATED to CREDS_STORED", jobId),
         jobId);
     try {
-      jobStore.updateJob(jobId, job);
+      jobStore.updateJobWithCredentials(jobId, job);
       monitor.debug(() -> format("Updated job %s to CREDS_STORED", jobId), jobId,
           EventCode.API_JOB_CREDS_STORED);
     } catch (IOException e) {

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStoreWithValidator.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStoreWithValidator.java
@@ -1,0 +1,87 @@
+package org.datatransferproject.spi.cloud.storage;
+
+import static org.datatransferproject.spi.cloud.types.JobAuthorization.State.CREDS_AVAILABLE;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import java.io.IOException;
+import java.util.UUID;
+import org.datatransferproject.spi.cloud.types.JobAuthorization;
+import org.datatransferproject.spi.cloud.types.PortabilityJob;
+import org.datatransferproject.spi.cloud.types.PortabilityJob.State;
+
+public abstract class JobStoreWithValidator implements JobStore {
+
+  public interface JobUpdateValidator {
+
+    /**
+     * Validation to do as part of an atomic update. Implementers should throw an {@code
+     * IllegalStateException} if the validation fails.
+     */
+    void validate(PortabilityJob previous, PortabilityJob updated);
+  }
+
+  /**
+   * Verifies a {@code PortabilityJob} already exists for {@code jobId}, and updates the entry to
+   * {@code job}. If {@code validator} is non-null, validator.validate() is called first, as part of
+   * the atomic update.
+   *
+   * @throws IOException if a job didn't already exist for {@code jobId} or there was a problem
+   * updating it
+   * @throws IllegalStateException if validator.validate() failed
+   */
+  protected abstract void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
+      throws IOException;
+
+  @Override
+  public void claimJob(UUID jobId, PortabilityJob job) throws IOException {
+    updateJob(jobId, job, (previous, updated) ->
+        Preconditions.checkState(
+            previous.jobAuthorization().state() == JobAuthorization.State.CREDS_AVAILABLE));
+  }
+
+  @Override
+  public void updateJobState(
+      UUID jobId, State state, State prevState, JobAuthorization.State prevAuthState)
+      throws IOException {
+    PortabilityJob existingJob = findJob(jobId);
+    PortabilityJob updatedJob = existingJob.toBuilder().setState(state).build();
+
+    updateJob(
+        jobId,
+        updatedJob,
+        ((previous, updated) -> {
+          Preconditions.checkState(previous.state() == prevState);
+          Preconditions.checkState(previous.jobAuthorization().state() == prevAuthState);
+        }));
+  }
+
+  @Override
+  public void updateJobAuthStateToCredsAvailable(UUID jobId) throws IOException {
+    PortabilityJob job = findJob(jobId);
+    // Set update job auth data
+    JobAuthorization jobAuthorization =
+        job.jobAuthorization().toBuilder().setState(CREDS_AVAILABLE).build();
+    job = job.toBuilder().setAndValidateJobAuthorization(jobAuthorization).build();
+    updateJob(
+        jobId,
+        job,
+        (previous, updated) -> validateForUpdateStateToCredsAvailable(previous));
+  }
+
+
+  private static void validateForUpdateStateToCredsAvailable(PortabilityJob job) {
+    String dataType = job.transferDataType();
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(dataType), "Missing valid dataTypeParam: %s", dataType);
+
+    String exportService = job.exportService();
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(exportService), "Missing valid exportService: %s", exportService);
+
+    String importService = job.importService();
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(importService), "Missing valid importService: %s", importService);
+    Preconditions.checkState(job.jobAuthorization().state() == JobAuthorization.State.INITIAL);
+  }
+}

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStoreWithValidator.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStoreWithValidator.java
@@ -1,6 +1,8 @@
 package org.datatransferproject.spi.cloud.storage;
 
 import static org.datatransferproject.spi.cloud.types.JobAuthorization.State.CREDS_AVAILABLE;
+import static org.datatransferproject.spi.cloud.types.JobAuthorization.State.CREDS_ENCRYPTION_KEY_GENERATED;
+import static org.datatransferproject.spi.cloud.types.JobAuthorization.State.CREDS_STORED;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -12,48 +14,11 @@ import org.datatransferproject.spi.cloud.types.PortabilityJob.State;
 
 public abstract class JobStoreWithValidator implements JobStore {
 
-  public interface JobUpdateValidator {
-
-    /**
-     * Validation to do as part of an atomic update. Implementers should throw an {@code
-     * IllegalStateException} if the validation fails.
-     */
-    void validate(PortabilityJob previous, PortabilityJob updated);
-  }
-
-  /**
-   * Verifies a {@code PortabilityJob} already exists for {@code jobId}, and updates the entry to
-   * {@code job}. If {@code validator} is non-null, validator.validate() is called first, as part of
-   * the atomic update.
-   *
-   * @throws IOException if a job didn't already exist for {@code jobId} or there was a problem
-   * updating it
-   * @throws IllegalStateException if validator.validate() failed
-   */
-  protected abstract void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
-      throws IOException;
-
   @Override
   public void claimJob(UUID jobId, PortabilityJob job) throws IOException {
     updateJob(jobId, job, (previous, updated) ->
         Preconditions.checkState(
             previous.jobAuthorization().state() == JobAuthorization.State.CREDS_AVAILABLE));
-  }
-
-  @Override
-  public void updateJobState(
-      UUID jobId, State state, State prevState, JobAuthorization.State prevAuthState)
-      throws IOException {
-    PortabilityJob existingJob = findJob(jobId);
-    PortabilityJob updatedJob = existingJob.toBuilder().setState(state).build();
-
-    updateJob(
-        jobId,
-        updatedJob,
-        ((previous, updated) -> {
-          Preconditions.checkState(previous.state() == prevState);
-          Preconditions.checkState(previous.jobAuthorization().state() == prevAuthState);
-        }));
   }
 
   @Override
@@ -69,7 +34,6 @@ public abstract class JobStoreWithValidator implements JobStore {
         (previous, updated) -> validateForUpdateStateToCredsAvailable(previous));
   }
 
-
   private static void validateForUpdateStateToCredsAvailable(PortabilityJob job) {
     String dataType = job.transferDataType();
     Preconditions.checkArgument(
@@ -83,5 +47,88 @@ public abstract class JobStoreWithValidator implements JobStore {
     Preconditions.checkArgument(
         !Strings.isNullOrEmpty(importService), "Missing valid importService: %s", importService);
     Preconditions.checkState(job.jobAuthorization().state() == JobAuthorization.State.INITIAL);
+  }
+
+  @Override
+  public void updateJobWithCredentials(UUID jobId, PortabilityJob job) throws IOException {
+    updateJob(
+        jobId,
+        job,
+        ((previous, updated) -> {
+          Preconditions.checkState(
+              previous.jobAuthorization().state() == CREDS_ENCRYPTION_KEY_GENERATED);
+          Preconditions.checkState(updated.jobAuthorization().state() == CREDS_STORED);
+        }));
+  }
+
+  @Override
+  public void markJobAsFinished(UUID jobId, State state) throws IOException {
+    Preconditions.checkState(state == State.ERROR || state == State.COMPLETE);
+    updateJobState(jobId, state, State.IN_PROGRESS, JobAuthorization.State.CREDS_STORED);
+  }
+
+  @Override
+  public void markJobAsStarted(UUID jobId) throws IOException {
+    updateJobState(jobId, State.IN_PROGRESS, State.NEW, JobAuthorization.State.CREDS_STORED);
+  }
+
+  @Override
+  public void markJobAsTimedOut(UUID jobId) throws IOException {
+    PortabilityJob job = findJob(jobId);
+    updateJob(
+        jobId,
+        job.toBuilder()
+            .setState(PortabilityJob.State.ERROR)
+            .setAndValidateJobAuthorization(
+                job.jobAuthorization()
+                    .toBuilder()
+                    .setState(JobAuthorization.State.TIMED_OUT)
+                    .build())
+            .build());
+  }
+
+  /**
+   * Verifies a {@code PortabilityJob} already exists for {@code jobId}, and updates the entry to
+   * {@code job}.
+   *
+   * @throws IOException if a job didn't already exist for {@code jobId} or there was a problem
+   * updating it
+   */
+  protected abstract void updateJob(UUID jobId, PortabilityJob job) throws IOException;
+
+  /**
+   * Verifies a {@code PortabilityJob} already exists for {@code jobId}, and updates the entry to
+   * {@code job}. If {@code validator} is non-null, validator.validate() is called first, as part of
+   * the atomic update.
+   *
+   * @throws IOException if a job didn't already exist for {@code jobId} or there was a problem
+   * updating it
+   * @throws IllegalStateException if validator.validate() failed
+   */
+  protected abstract void updateJob(UUID jobId, PortabilityJob job, JobUpdateValidator validator)
+      throws IOException;
+
+  private void updateJobState(
+      UUID jobId, State state, State prevState, JobAuthorization.State prevAuthState)
+      throws IOException {
+    PortabilityJob existingJob = findJob(jobId);
+    PortabilityJob updatedJob = existingJob.toBuilder().setState(state).build();
+
+    updateJob(
+        jobId,
+        updatedJob,
+        ((previous, updated) -> {
+          Preconditions.checkState(previous.state() == prevState);
+          Preconditions.checkState(previous.jobAuthorization().state() == prevAuthState);
+        }));
+  }
+
+  public interface JobUpdateValidator {
+
+    /**
+     * Validation to do as part of an atomic update. Implementers should throw an {@code
+     * IllegalStateException} if the validation fails.
+     */
+    void validate(PortabilityJob previous, PortabilityJob updated);
   }
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -92,18 +92,8 @@ class JobPollingService extends AbstractScheduledService {
   }
 
   private void markJobTimedOut(UUID jobId) {
-    PortabilityJob job = store.findJob(jobId);
     try {
-      store.updateJob(
-          jobId,
-          job.toBuilder()
-              .setState(PortabilityJob.State.ERROR)
-              .setAndValidateJobAuthorization(
-                  job.jobAuthorization()
-                      .toBuilder()
-                      .setState(JobAuthorization.State.TIMED_OUT)
-                      .build())
-              .build());
+      store.markJobAsTimedOut(jobId);
     } catch (IOException e) {
       // Suppress exception so we still pass out the original exception
       monitor.severe(

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -194,12 +194,9 @@ class JobPollingService extends AbstractScheduledService {
     // instance polled the same job, and already claimed it, it will have updated the job's state
     // to CREDS_ENCRYPTION_KEY_GENERATED.
     try {
-      store.updateJob(
+      store.claimJob(
           jobId,
-          updatedJob,
-          (previous, updated) ->
-              Preconditions.checkState(
-                  previous.jobAuthorization().state() == JobAuthorization.State.CREDS_AVAILABLE));
+          updatedJob);
 
       monitor.debug(() -> format("Stored updated job: tryToClaimJob: jobId: %s", existingJob));
     } catch (IllegalStateException | IOException e) {

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -18,11 +18,9 @@ package org.datatransferproject.transfer;
 import static java.lang.String.format;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.inject.Inject;
 import java.io.IOException;
-import java.security.PrivateKey;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
@@ -160,26 +158,18 @@ final class JobProcessor {
       monitor.severe(() -> format("Problem adding errors to JobStore: %s", e), e);
     }
     State state = success ? State.COMPLETE : State.ERROR;
-    updateJobState(jobId, state, State.IN_PROGRESS, JobAuthorization.State.CREDS_STORED);
+    try {
+      store.updateJobState(jobId, state, State.IN_PROGRESS, JobAuthorization.State.CREDS_STORED);
+    } catch (IOException e) {
+      monitor.severe(() -> format("Could not mark job %s as finished.", jobId));
+    }
   }
 
   private void markJobStarted(UUID jobId) {
-    updateJobState(jobId, State.IN_PROGRESS, State.NEW, JobAuthorization.State.CREDS_STORED);
-  }
-
-  private void updateJobState(UUID jobId, State state, State prevState,
-      JobAuthorization.State prevAuthState) {
-    PortabilityJob existingJob = store.findJob(jobId);
-    PortabilityJob updatedJob = existingJob.toBuilder().setState(state).build();
-
     try {
-      store.updateJob(jobId, updatedJob,
-          ((previous, updated) -> {
-            Preconditions.checkState(previous.state() == prevState);
-            Preconditions.checkState(previous.jobAuthorization().state() == prevAuthState);
-          }));
+      store.updateJobState(jobId, State.IN_PROGRESS, State.NEW, JobAuthorization.State.CREDS_STORED);
     } catch (IOException e) {
-      monitor.debug(() -> format("Could not mark job %s as %s, %s", jobId, state, e));
+      monitor.severe(() -> format("Could not mark job %s as %s, %s", jobId, State.IN_PROGRESS, e));
     }
   }
 }

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
@@ -140,7 +140,7 @@ public class JobPollingServiceTest {
             .setAndValidateJobAuthorization(
                 job.jobAuthorization().toBuilder().setState(State.CREDS_AVAILABLE).build())
             .build();
-    store.updateJob(TEST_ID, job);
+    store.updateJobAuthStateToCredsAvailable(TEST_ID);
 
     // Verify 'creds available' state
     job = store.findJob(TEST_ID);
@@ -169,7 +169,7 @@ public class JobPollingServiceTest {
                     .setState(State.CREDS_STORED)
                     .build())
             .build();
-    store.updateJob(TEST_ID, job);
+    store.updateJobWithCredentials(TEST_ID, job);
 
     // Run another iteration of the polling service
     // Worker should pick up encrypted data and update job


### PR DESCRIPTION
This makes sure the JobStore interface only depends on Plain Old Java Objects and does not receive logic dynamically via its arguments. This means we can significantly optimise our JobStore implementation.

Once I removed the concept of passed in validation it meant a mix of specific state transitions and generic updates. To improve validation it seemed like a logical step to make every call on the JobStore a specific state change. This changes the philosophy of the JobStore and is fairly opinionated. I'm happy to discuss/explain this more as it is significant change in that respect (event though actual behaviour should not change).