### PR TITLE
Catch HttpResponseExceptions in the GooglePhotosInterface

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -156,15 +156,11 @@ public class GooglePhotosInterface {
             .execute();
       } else {
         // something else is wrong, bubble up the error
-        throw e;
+        throw new IOException(
+            "Bad status code: " + e.getStatusCode() + " error: " + e.getStatusMessage());
       }
     }
 
-    int statusCode = response.getStatusCode();
-    if (statusCode != 200) {
-      throw new IOException(
-          "Bad status code: " + statusCode + " error: " + response.getStatusMessage());
-    }
     String result = CharStreams
         .toString(new InputStreamReader(response.getContent(), Charsets.UTF_8));
     return objectMapper.readValue(result, clazz);
@@ -191,15 +187,11 @@ public class GooglePhotosInterface {
                 httpContent).execute();
       } else {
         // something else is wrong, bubble up the error
-        throw e;
+        throw new IOException(
+            "Bad status code: " + e.getStatusCode() + " error: " + e.getStatusMessage());
       }
     }
 
-    int statusCode = response.getStatusCode();
-    if (statusCode != 200) {
-      throw new IOException(
-          "Bad status code: " + statusCode + " error: " + response.getStatusMessage());
-    }
     String result = CharStreams
         .toString(new InputStreamReader(response.getContent(), Charsets.UTF_8));
     if (clazz.isAssignableFrom(String.class)) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -161,6 +161,7 @@ public class GooglePhotosInterface {
       }
     }
 
+    Preconditions.checkState(response.getStatusCode() == 200);
     String result = CharStreams
         .toString(new InputStreamReader(response.getContent(), Charsets.UTF_8));
     return objectMapper.readValue(result, clazz);
@@ -192,6 +193,7 @@ public class GooglePhotosInterface {
       }
     }
 
+    Preconditions.checkState(response.getStatusCode() == 200);
     String result = CharStreams
         .toString(new InputStreamReader(response.getContent(), Charsets.UTF_8));
     if (clazz.isAssignableFrom(String.class)) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -207,11 +207,6 @@ public class GooglePhotosInterface {
       updatedParams.putAll(params.get());
     }
 
-    // getAccessToken will return null when the token needs to be refreshed
-    if (credential.getAccessToken() == null) {
-      credential.refreshToken();
-    }
-
     updatedParams.put(ACCESS_TOKEN_KEY, Preconditions.checkNotNull(credential.getAccessToken()));
 
     List<String> orderedKeys = updatedParams.keySet().stream().collect(Collectors.toList());


### PR DESCRIPTION
HttpRequest.execute() throws errors if the response is not 200, so when the refresh token expires, this exception gets thrown: 

```
Caught exception com.google.api.client.http.HttpResponseException: 401 Unauthorized 
at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1072) 
at org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface.makePostRequest(GooglePhotosInterface.java:163) 
at org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface.listMediaItems(GooglePhotosInterface.java:108) 
at org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.exportPhotos(GooglePhotosExporter.java:201) 
at org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.export(GooglePhotosExporter.java:129) 
at org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.export(GooglePhotosExporter.java:58) 
at org.datatransferproject.transfer.CallableExporter.call(CallableExporter.java:62) 
at org.datatransferproject.transfer.CallableExporter.call(CallableExporter.java:36) 
at org.datatransferproject.types.transfer.retry.RetryingCallable.call(RetryingCallable.java:66) 
at org.datatransferproject.transfer.PortabilityInMemoryDataCopier.copyHelper(PortabilityInMemoryDataCopier.java:129) 
at ... 
```

When we get that exception with 401, we need to refresh the token and try again. We can't detect the token refresh by relying on `credential.getAccessToken == null` since this library is primarily meant to be used as a request interceptor and the only way the accesstoken gets updated is if one of the requests it intercepts is a 401. This would be fixed if we just used the java client library for google photos, but that is a fair bit of work.

 