### PR TITLE
Change ImporterExecutor to only swallow IO exceptions

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-deezer/src/main/java/org/datatransferproject/transfer/deezer/playlists/DeezerPlaylistImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-deezer/src/main/java/org/datatransferproject/transfer/deezer/playlists/DeezerPlaylistImporter.java
@@ -64,7 +64,7 @@ public class DeezerPlaylistImporter
       UUID jobId,
       IdempotentImportExecutor idempotentExecutor,
       TokensAndUrlAuthData authData,
-      PlaylistContainerResource data) throws IOException {
+      PlaylistContainerResource data) throws Exception {
     DeezerApi api = new DeezerApi(
         authData.getAccessToken(),
         httpTransport,
@@ -79,8 +79,8 @@ public class DeezerPlaylistImporter
       IdempotentImportExecutor idempotentExecutor,
       DeezerApi api,
       MusicPlaylist playlist)
-      throws IOException {
-    Long newPlaylistId = idempotentExecutor.executeAndSwallowExceptions(
+      throws Exception {
+    Long newPlaylistId = idempotentExecutor.executeAndSwallowIOExceptions(
         playlist.getIdentifier(),
         playlist.getHeadline(),
         () -> createPlaylist(api, playlist));
@@ -91,13 +91,13 @@ public class DeezerPlaylistImporter
     }
     List<Long> ids = new ArrayList<>();
     for (MusicRecording track : playlist.getTrack()) {
-      Long newSongId = idempotentExecutor.executeAndSwallowExceptions(
+      Long newSongId = idempotentExecutor.executeAndSwallowIOExceptions(
           newPlaylistId + "-" + track.hashCode(),
           "Track: " + track + " in " + playlist.getHeadline(),
           () -> lookupTrack(api, track));
       ids.add(newSongId);
     }
-    idempotentExecutor.executeAndSwallowExceptions(
+    idempotentExecutor.executeAndSwallowIOExceptions(
         newPlaylistId + "-tracks",
         "Playlist: " + playlist.getHeadline(),
         () -> {

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -100,7 +100,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
       IdempotentImportExecutor idempotentExecutor,
       AuthData authData,
       PhotosContainerResource data)
-      throws IOException {
+      throws Exception, IOException {
     Auth auth;
     try {
       auth = FlickrUtils.getAuth(authData, flickr);
@@ -145,8 +145,8 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
 
   private void importSinglePhoto(IdempotentImportExecutor idempotentExecutor,
       UUID id,
-      PhotoModel photo) throws FlickrException, IOException {
-    String photoId = idempotentExecutor.executeAndSwallowExceptions(
+      PhotoModel photo) throws Exception {
+    String photoId = idempotentExecutor.executeAndSwallowIOExceptions(
         photo.getAlbumId() + "-" + photo.getDataId(),
         photo.getTitle(),
         () -> uploadPhoto(photo, id));
@@ -171,7 +171,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
       IdempotentImportExecutor idempotentExecutor,
       UUID jobId,
       String oldAlbumId,
-      String photoId) throws IOException, FlickrException {
+      String photoId) throws Exception {
     if (idempotentExecutor.isKeyCached(oldAlbumId)) {
       String newAlbumId = idempotentExecutor.getCachedValue(oldAlbumId);
       // We've already created the album this photo belongs in, simply add it to the new album
@@ -185,7 +185,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
       IdempotentImportExecutor idempotentExecutor,
       UUID jobId,
       String oldAlbumId,
-      String firstPhotoId) throws IOException {
+      String firstPhotoId) throws Exception {
     // This means that we havent created the new album yet, create the photoset
     FlickrTempPhotoData album = jobStore.findData(
         jobId,
@@ -197,7 +197,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
     // with these (in case the album exists later).
     Preconditions.checkNotNull(album, "Album not found: " + oldAlbumId);
 
-    idempotentExecutor.executeAndSwallowExceptions(
+    idempotentExecutor.executeAndSwallowIOExceptions(
         oldAlbumId,
         album.getName(),
         () -> {

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
@@ -86,7 +86,7 @@ public class FlickrPhotosImporterTest {
   private Monitor monitor = mock(Monitor.class);
 
   @Test
-  public void importStoresAlbumInJobStore() throws FlickrException, IOException {
+  public void importStoresAlbumInJobStore() throws FlickrException, Exception {
     UUID jobId = UUID.randomUUID();
 
     PhotosContainerResource photosContainerResource =

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/blogger/GoogleBloggerImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/blogger/GoogleBloggerImporter.java
@@ -104,7 +104,7 @@ public class GoogleBloggerImporter
       ASObject asObject,
       String blogId,
       TokensAndUrlAuthData authData)
-      throws IOException {
+      throws Exception {
     String content = asObject.content() == null ? "" : asObject.contentString();
 
     if (content == null) {
@@ -130,7 +130,7 @@ public class GoogleBloggerImporter
       for (LinkValue image : asObject.image()) {
         try {
           String newImgSrc =
-              idempotentExecutor.executeAndSwallowExceptions(
+              idempotentExecutor.executeAndSwallowIOExceptions(
                   image.toString(),
                   "Image",
                   () -> uploadImage((ASObject) image, driveInterface, folderId));
@@ -174,7 +174,7 @@ public class GoogleBloggerImporter
       post.setPublished(new DateTime(asObject.published().getMillis()));
     }
 
-    idempotentExecutor.executeAndSwallowExceptions(
+    idempotentExecutor.executeAndSwallowIOExceptions(
         title,
         title,
         () -> getOrCreateBloggerService(authData).posts()

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarImporter.java
@@ -95,15 +95,15 @@ public class GoogleCalendarImporter implements
   public ImportResult importItem(UUID jobId,
       IdempotentImportExecutor idempotentExecutor,
       TokensAndUrlAuthData authData,
-      CalendarContainerResource data) throws IOException {
+      CalendarContainerResource data) throws Exception {
     for (CalendarModel calendarModel : data.getCalendars()) {
-      idempotentExecutor.executeAndSwallowExceptions(
+      idempotentExecutor.executeAndSwallowIOExceptions(
           calendarModel.getId(),
           calendarModel.getName(),
           () -> importSingleCalendar(authData, calendarModel));
     }
     for (CalendarEventModel eventModel : data.getEvents()) {
-      idempotentExecutor.executeAndSwallowExceptions(
+      idempotentExecutor.executeAndSwallowIOExceptions(
           Integer.toString(eventModel.hashCode()),
           eventModel.getNotes(),
           () -> importSingleEvent(idempotentExecutor, authData, eventModel));

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsImporter.java
@@ -204,7 +204,7 @@ public class GoogleContactsImporter implements Importer<TokensAndUrlAuthData, Co
   @Override
   public ImportResult importItem(UUID jobId,
       IdempotentImportExecutor idempotentExecutor,
-      TokensAndUrlAuthData authData, ContactsModelWrapper data) {
+      TokensAndUrlAuthData authData, ContactsModelWrapper data) throws Exception{
     JCardReader reader = new JCardReader(data.getVCards());
     try {
       // TODO(olsona): address any other problems that might arise in conversion
@@ -212,7 +212,7 @@ public class GoogleContactsImporter implements Importer<TokensAndUrlAuthData, Co
       PeopleService.People peopleService = getOrCreatePeopleService(authData).people();
       for (VCard vCard : vCardList) {
         Person person = convert(vCard);
-        idempotentExecutor.executeAndSwallowExceptions(
+        idempotentExecutor.executeAndSwallowIOExceptions(
             vCard.toString(),
             vCard.getFormattedName().toString(),
             () -> peopleService.createContact(person).execute().toPrettyString());

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveImporter.java
@@ -71,7 +71,7 @@ public final class DriveImporter implements
     // Uploads album metadata
     if (data.getFolders() != null && data.getFolders().size() > 0) {
       for (BlobbyStorageContainerResource folder : data.getFolders()) {
-        idempotentExecutor.executeAndSwallowExceptions(
+        idempotentExecutor.executeAndSwallowIOExceptions(
             folder.getId(),
             folder.getName(),
             () -> importSingleFolder(
@@ -84,7 +84,7 @@ public final class DriveImporter implements
     // Uploads photos
     if (data.getFiles() != null && data.getFiles().size() > 0) {
       for (DigitalDocumentWrapper file : data.getFiles()) {
-        idempotentExecutor.executeAndSwallowExceptions(
+        idempotentExecutor.executeAndSwallowIOExceptions(
             Integer.toString(file.hashCode()),
             file.getDtpDigitalDocument().getName(),
             () -> importSingleFile(jobId, driveInterface, file, parentId));

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mail/GoogleMailImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mail/GoogleMailImporter.java
@@ -72,7 +72,7 @@ public class GoogleMailImporter implements Importer<TokensAndUrlAuthData, MailCo
       UUID id,
       IdempotentImportExecutor idempotentExecutor,
       TokensAndUrlAuthData authData,
-      MailContainerResource data) throws IOException {
+      MailContainerResource data) throws Exception {
 
     // Lazy init the request for all labels in the destination account, since it may not be needed
     // Mapping of labelName -> destination label id
@@ -101,11 +101,11 @@ public class GoogleMailImporter implements Importer<TokensAndUrlAuthData, MailCo
       TokensAndUrlAuthData authData,
       IdempotentImportExecutor idempotentExecutor,
       Supplier<Map<String, String>> allDestinationLabels,
-      Collection<MailContainerModel> folders) throws IOException {
+      Collection<MailContainerModel> folders) throws Exception {
     for (MailContainerModel mailContainerModel : folders) {
       Preconditions.checkArgument(!Strings.isNullOrEmpty(mailContainerModel.getName()));
       String exportedLabelName = mailContainerModel.getName();
-      idempotentExecutor.executeAndSwallowExceptions(
+      idempotentExecutor.executeAndSwallowIOExceptions(
           exportedLabelName,
           "Label - " + exportedLabelName,
           () -> {
@@ -122,8 +122,8 @@ public class GoogleMailImporter implements Importer<TokensAndUrlAuthData, MailCo
   private void importDTPLabel(
       TokensAndUrlAuthData authData,
       IdempotentImportExecutor idempotentExecutor,
-      Supplier<Map<String, String>> allDestinationLabels) throws IOException {
-    idempotentExecutor.executeAndSwallowExceptions(
+      Supplier<Map<String, String>> allDestinationLabels) throws Exception {
+    idempotentExecutor.executeAndSwallowIOExceptions(
         LABEL,
         LABEL,
         () -> {
@@ -143,11 +143,11 @@ public class GoogleMailImporter implements Importer<TokensAndUrlAuthData, MailCo
       TokensAndUrlAuthData authData,
       IdempotentImportExecutor idempotentExecutor,
       Supplier<Map<String, String>> allDestinationLabels,
-      Collection<MailMessageModel> messages) throws IOException {
+      Collection<MailMessageModel> messages) throws Exception {
     for (MailMessageModel mailMessageModel : messages) {
       // Get or create label ids associated with this message
       for (String exportedLabelName : mailMessageModel.getContainerIds()) {
-        idempotentExecutor.executeAndSwallowExceptions(
+        idempotentExecutor.executeAndSwallowIOExceptions(
             exportedLabelName,
             exportedLabelName,
             () -> {
@@ -168,9 +168,9 @@ public class GoogleMailImporter implements Importer<TokensAndUrlAuthData, MailCo
   private void importMessages(
       TokensAndUrlAuthData authData,
       IdempotentImportExecutor idempotentExecutor,
-      Collection<MailMessageModel> messages) throws IOException {
+      Collection<MailMessageModel> messages) throws Exception {
     for (MailMessageModel mailMessageModel : messages) {
-      idempotentExecutor.executeAndSwallowExceptions(
+      idempotentExecutor.executeAndSwallowIOExceptions(
           mailMessageModel.toString(),
           // Trim the full mail message to try to give some context to the user but not overwhelm
           // them.

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -76,7 +76,7 @@ public class GooglePhotosImporter
       UUID jobId,
       IdempotentImportExecutor idempotentImportExecutor,
       TokensAndUrlAuthData authData,
-      PhotosContainerResource data) throws IOException {
+      PhotosContainerResource data) throws Exception {
     if (data == null) {
       // Nothing to do
       return ImportResult.OK;
@@ -85,7 +85,7 @@ public class GooglePhotosImporter
     // Uploads album metadata
     if (data.getAlbums() != null && data.getAlbums().size() > 0) {
       for (PhotoAlbum album : data.getAlbums()) {
-        idempotentImportExecutor.executeAndSwallowExceptions(
+        idempotentImportExecutor.executeAndSwallowIOExceptions(
             album.getId(),
             album.getName(),
             () -> importSingleAlbum(authData, album)
@@ -96,7 +96,7 @@ public class GooglePhotosImporter
     // Uploads photos
     if (data.getPhotos() != null && data.getPhotos().size() > 0) {
       for (PhotoModel photo : data.getPhotos()) {
-        idempotentImportExecutor.executeAndSwallowExceptions(
+        idempotentImportExecutor.executeAndSwallowIOExceptions(
             photo.getDataId(),
             photo.getTitle(),
             () -> importSinglePhoto(jobId, authData, photo, idempotentImportExecutor));

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/tasks/GoogleTasksImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/tasks/GoogleTasksImporter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.datatransferproject.datatransfer.google.tasks;
 
 import com.google.api.client.auth.oauth2.Credential;
@@ -58,12 +57,12 @@ public class GoogleTasksImporter implements Importer<TokensAndUrlAuthData, TaskC
       UUID jobId,
       IdempotentImportExecutor idempotentImportExecutor,
       TokensAndUrlAuthData authData,
-      TaskContainerResource data) throws IOException {
+      TaskContainerResource data) throws Exception {
     Tasks tasksService = getOrCreateTasksService(authData);
 
     for (TaskListModel oldTasksList : data.getLists()) {
       TaskList newTaskList = new TaskList().setTitle("Imported copy - " + oldTasksList.getName());
-      idempotentImportExecutor.executeAndSwallowExceptions(
+      idempotentImportExecutor.executeAndSwallowIOExceptions(
           oldTasksList.getId(),
           oldTasksList.getName(),
           () -> tasksService.tasklists().insert(newTaskList).execute().getId());
@@ -80,7 +79,7 @@ public class GoogleTasksImporter implements Importer<TokensAndUrlAuthData, TaskC
       // If its not cached that means the task list create failed.
       if (idempotentImportExecutor.isKeyCached(oldTask.getTaskListId())) {
         String newTaskListId = idempotentImportExecutor.getCachedValue(oldTask.getTaskListId());
-        idempotentImportExecutor.executeAndSwallowExceptions(
+        idempotentImportExecutor.executeAndSwallowIOExceptions(
             oldTask.getTaskListId() + oldTask.getText(),
             oldTask.getText(),
             () -> tasksService.tasks().insert(newTaskListId, newTask).execute().getId());

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -87,7 +87,7 @@ public class GoogleVideosImporter
           UUID jobId,
           IdempotentImportExecutor executor,
           TokensAndUrlAuthData authData,
-          VideosContainerResource data) throws IOException {
+          VideosContainerResource data) throws Exception {
     if (data == null) {
       // Nothing to do
       return ImportResult.OK;
@@ -106,7 +106,7 @@ public class GoogleVideosImporter
           TokensAndUrlAuthData authData,
           VideoObject inputVideo,
           IdempotentImportExecutor executor)
-          throws IOException {
+          throws Exception {
 
     // download video and create input stream
     InputStream inputStream;
@@ -116,7 +116,7 @@ public class GoogleVideosImporter
                       "Content Url is empty. Make sure that you provide a valid content Url.");
       return;
     }
-    
+
     inputStream = this.videoStreamProvider.get(inputVideo.getContentUrl().toString());
 
     String filename;
@@ -134,7 +134,7 @@ public class GoogleVideosImporter
     NewMediaItemUpload uploadItem =
             new NewMediaItemUpload(null, Collections.singletonList(newMediaItem));
 
-    executor.executeAndSwallowExceptions(
+    executor.executeAndSwallowIOExceptions(
             inputVideo.getDataId(),
             inputVideo.getName(),
             () -> getOrCreateVideosInterface(authData).createVideo(uploadItem));

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarImporterTest.java
@@ -67,7 +67,7 @@ public class GoogleCalendarImporterTest {
   }
 
   @Test
-  public void importCalendarAndEvent() throws IOException {
+  public void importCalendarAndEvent() throws Exception {
     String modelCalendarId = "modelCalendarId";
     String googleCalendarId = "googleCalendarId";
     UUID jobId = UUID.randomUUID();

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsImporterTest.java
@@ -66,7 +66,7 @@ public class GoogleContactsImporterTest {
   }
 
   @Test
-  public void importFirstResources() throws IOException {
+  public void importFirstResources() throws Exception {
     // Set up: small number of VCards to be imported
     int numberOfVCards = 5;
     List<VCard> vCardList = new LinkedList<>();

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mail/GoogleMailImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mail/GoogleMailImporterTest.java
@@ -102,7 +102,7 @@ public class GoogleMailImporterTest {
   }
 
   @Test
-  public void importMessage() throws IOException {
+  public void importMessage() throws Exception {
     MailContainerResource resource =
         new MailContainerResource(null, Collections.singletonList(MESSAGE_MODEL));
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -83,7 +83,7 @@ public class GooglePhotosImporterTest {
   }
 
   @Test
-  public void exportAlbum() throws IOException {
+  public void exportAlbum() throws Exception {
     // Set up
     String albumName = "Album Name";
     String albumDescription = "Album description";
@@ -105,7 +105,7 @@ public class GooglePhotosImporterTest {
   }
 
   @Test
-  public void exportPhoto() throws IOException {
+  public void exportPhoto() throws Exception {
     // Set up
     PhotoModel photoModel = new PhotoModel(PHOTO_TITLE, IMG_URI, PHOTO_DESCRIPTION, JPEG_MEDIA_TYPE,
         "oldPhotoID", OLD_ALBUM_ID, false);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
@@ -53,7 +53,7 @@ public class GoogleVideosImporterTest {
   private InputStream inputStream;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws Exception {
     googleVideosInterface = mock(GoogleVideosInterface.class);
 
     when(googleVideosInterface.uploadVideoContent(
@@ -76,7 +76,7 @@ public class GoogleVideosImporterTest {
   }
 
   @Test
-  public void exportVideo() throws IOException {
+  public void exportVideo() throws Exception {
     // Set up
     VideoObject videoModel =
         new VideoObject(

--- a/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/photos/ImgurPhotosImporter.java
@@ -80,14 +80,14 @@ public class ImgurPhotosImporter
 
     // Import albums
     for (PhotoAlbum album : resource.getAlbums()) {
-      executor.executeAndSwallowExceptions(
+      executor.executeAndSwallowIOExceptions(
           album.getId(),
           album.getName(),
           () -> importAlbum(album, authData));
     }
     // Import photos
     for (PhotoModel photo : resource.getPhotos()) {
-      executor.executeAndSwallowExceptions(
+      executor.executeAndSwallowIOExceptions(
           photo.getDataId(),
           photo.getTitle(),
           () -> {

--- a/extensions/data-transfer/portability-data-transfer-mastodon/src/main/java/org/datatransferproject/transfer/mastodon/social/MastodonActivityImport.java
+++ b/extensions/data-transfer/portability-data-transfer-mastodon/src/main/java/org/datatransferproject/transfer/mastodon/social/MastodonActivityImport.java
@@ -60,7 +60,7 @@ public class MastodonActivityImport
         checkState(object instanceof ASObject, "%s isn't of expected type", object);
         ASObject asObject = (ASObject) object;
         if (asObject.objectTypeString().equals("note")) {
-          idempotentImportExecutor.executeAndSwallowExceptions(
+          idempotentImportExecutor.executeAndSwallowIOExceptions(
               asObject.id(),
               asObject.contentString(),
               () -> {

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/calendar/MicrosoftCalendarImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/calendar/MicrosoftCalendarImporter.java
@@ -71,10 +71,10 @@ public class MicrosoftCalendarImporter
       UUID jobId,
       IdempotentImportExecutor idempotentImportExecutor,
       TokenAuthData authData,
-      CalendarContainerResource data) throws IOException {
+      CalendarContainerResource data) throws Exception {
 
     for (CalendarModel calendar : data.getCalendars()) {
-      idempotentImportExecutor.executeAndSwallowExceptions(calendar.getId(),
+      idempotentImportExecutor.executeAndSwallowIOExceptions(calendar.getId(),
           calendar.getName(),
           () -> importCalendar(authData, calendar));
     }
@@ -103,7 +103,7 @@ public class MicrosoftCalendarImporter
   }
 
   private String importCalendar(TokenAuthData authData,
-      CalendarModel calendar) throws IOException {
+      CalendarModel calendar) throws Exception {
     List<Map<String, Object>> calendarRequests = new ArrayList<>();
 
     Map<String, Object> request = createRequestItem(calendar, 1, CALENDAR_SUBPATH);
@@ -122,7 +122,7 @@ public class MicrosoftCalendarImporter
   }
 
   private Map<String, Object> createRequestItem(
-      Object item, int id, String url) throws IOException {
+      Object item, int id, String url) throws Exception {
     TransformResult<LinkedHashMap> result = transformerService.transform(LinkedHashMap.class, item);
     if (result.getProblems() != null && !result.getProblems().isEmpty()) {
       throw new IOException("Problem transforming request: " + result.getProblems().get(0));

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -92,17 +92,17 @@ public class MicrosoftPhotosImporter implements Importer<TokensAndUrlAuthData, P
       IdempotentImportExecutor idempotentImportExecutor,
       TokensAndUrlAuthData authData,
       PhotosContainerResource resource)
-      throws IOException {
+      throws Exception {
 
     for (PhotoAlbum album : resource.getAlbums()) {
       // Create a OneDrive folder and then save the id with the mapping data
-      idempotentImportExecutor.executeAndSwallowExceptions(
+      idempotentImportExecutor.executeAndSwallowIOExceptions(
           album.getId(), album.getName(), () -> createOneDriveFolder(album, authData));
     }
 
     for (PhotoModel photoModel : resource.getPhotos()) {
 
-      idempotentImportExecutor.executeAndSwallowExceptions(
+      idempotentImportExecutor.executeAndSwallowIOExceptions(
           Integer.toString(photoModel.hashCode()),
           photoModel.getTitle(),
           () -> {

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/tasks/RememberTheMilkTasksImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/tasks/RememberTheMilkTasksImporter.java
@@ -63,7 +63,7 @@ public class RememberTheMilkTasksImporter implements Importer<AuthData, TaskCont
       timeline = service.createTimeline();
 
       for (TaskListModel taskList : data.getLists()) {
-        idempotentExecutor.executeAndSwallowExceptions(
+        idempotentExecutor.executeAndSwallowIOExceptions(
             taskList.getId(),
             taskList.getName(),
             () -> service.createTaskList(taskList.getName(), timeline).id
@@ -73,7 +73,7 @@ public class RememberTheMilkTasksImporter implements Importer<AuthData, TaskCont
       for (TaskModel task : data.getTasks()) {
         // Empty or blank tasks aren't valid in RTM
         if (!Strings.isNullOrEmpty(task.getText())) {
-          idempotentExecutor.executeAndSwallowExceptions(
+          idempotentExecutor.executeAndSwallowIOExceptions(
               Integer.toString(task.hashCode()),
               task.getText(),
               () -> {

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
@@ -80,17 +80,17 @@ public class SmugMugPhotosImporter
       UUID jobId,
       IdempotentImportExecutor idempotentExecutor,
       TokenSecretAuthData authData,
-      PhotosContainerResource data) {
+      PhotosContainerResource data) throws Exception {
     try {
       SmugMugInterface smugMugInterface = getOrCreateSmugMugInterface(authData);
       for (PhotoAlbum album : data.getAlbums()) {
-        idempotentExecutor.executeAndSwallowExceptions(
+        idempotentExecutor.executeAndSwallowIOExceptions(
             album.getId(),
             album.getName(),
             () -> importSingleAlbum(album, smugMugInterface));
       }
       for (PhotoModel photo : data.getPhotos()) {
-        idempotentExecutor.executeAndSwallowExceptions(
+        idempotentExecutor.executeAndSwallowIOExceptions(
             photo.getDataId(),
             photo.getTitle(),
             () -> importSinglePhoto(jobId, idempotentExecutor, photo, smugMugInterface));

--- a/extensions/data-transfer/portability-data-transfer-solid/src/main/java/org/datatransferproject/transfer/solid/contacts/SolidContactsImport.java
+++ b/extensions/data-transfer/portability-data-transfer-solid/src/main/java/org/datatransferproject/transfer/solid/contacts/SolidContactsImport.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
@@ -148,10 +149,17 @@ public class SolidContactsImport implements Importer<CookiesAndUrlAuthData, Cont
         addressBookSlug,
         () -> createPersonDirectory(baseUrl + containerUrl, utilities));
 
-    Map<String, VCard> insertedPeople = people.stream()
-        .collect(Collectors.toMap(
-            p -> importPerson(idempotentExecutor, p, baseUrl, personDirectory, utilities),
-            Function.identity()));
+    Map<String, VCard> insertedPeople = new HashMap<>();
+    for (VCard person : people ){
+      insertedPeople.put(
+        importPerson(idempotentExecutor, person, baseUrl, personDirectory, utilities),
+        person);
+    }
+
+    // people.stream()
+    //     .collect(Collectors.toMap(
+    //         p -> importPerson(idempotentExecutor, p, baseUrl, personDirectory, utilities),
+    //         Function.identity()));
 
     idempotentExecutor.executeOrThrowException(
         "peopleFile",
@@ -163,8 +171,8 @@ public class SolidContactsImport implements Importer<CookiesAndUrlAuthData, Cont
       VCard person,
       String baseUrl,
       String personDirectory,
-      SolidUtilities utilities) {
-    return executor.executeAndSwallowExceptions(
+      SolidUtilities utilities) throws Exception {
+    return executor.executeAndSwallowIOExceptions(
         Integer.toString(person.hashCode()),
         person.getFormattedName().getValue(),
         () -> insertPerson(baseUrl, personDirectory, person, utilities));

--- a/extensions/data-transfer/portability-data-transfer-spotify/src/main/java/org/datatransferproject/transfer/spotify/playlists/SpotifyPlaylistImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-spotify/src/main/java/org/datatransferproject/transfer/spotify/playlists/SpotifyPlaylistImporter.java
@@ -69,8 +69,8 @@ public class SpotifyPlaylistImporter
   private void createPlaylist(IdempotentImportExecutor idempotentExecutor,
       MusicPlaylist playlist,
       String userId)
-      throws IOException, SpotifyWebApiException {
-    String playlistId = idempotentExecutor.executeAndSwallowExceptions(
+      throws Exception, SpotifyWebApiException {
+    String playlistId = idempotentExecutor.executeAndSwallowIOExceptions(
         playlist.getIdentifier(),
         "Playlist: " + playlist.getHeadline(),
         () -> spotifyApi
@@ -93,8 +93,8 @@ public class SpotifyPlaylistImporter
       String playlistId,
       String playlistName,
       MusicRecording track)
-      throws IOException {
-    idempotentExecutor.executeAndSwallowExceptions(
+      throws Exception {
+    idempotentExecutor.executeAndSwallowIOExceptions(
         playlistId + "-" + track.hashCode(),
         playlistName + " - " + track.getHeadline(),
         () -> {

--- a/extensions/data-transfer/portability-data-transfer-twitter/src/main/java/org/datatransferproject/transfer/twitter/TwitterPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-twitter/src/main/java/org/datatransferproject/transfer/twitter/TwitterPhotosImporter.java
@@ -50,7 +50,7 @@ final class TwitterPhotosImporter
       UUID jobId,
       IdempotentImportExecutor idempotentExecutor,
       TokenSecretAuthData authData,
-      PhotosContainerResource data) {
+      PhotosContainerResource data) throws Exception {
     Twitter twitterApi = TwitterApiWrapper.getInstance(appCredentials, authData);
     // Twitter doesn't support an 'Albums' concept, so that information is just lost.
 
@@ -61,7 +61,7 @@ final class TwitterPhotosImporter
             new InputStreamContent(null, getImageAsStream(image.getFetchableUrl()));
         update.media(image.getTitle(), content.getInputStream());
 
-        idempotentExecutor.executeAndSwallowExceptions(
+        idempotentExecutor.executeAndSwallowIOExceptions(
             image.getDataId(),
             image.getTitle(),
             () -> twitterApi.tweets().updateStatus(update));

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutor.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutor.java
@@ -34,7 +34,8 @@ public interface IdempotentImportExecutor {
    * Executes a callable, a callable will only be executed once for a given idempotentId, subsequent
    * calls will return the same result as the first invocation if it was successful.
    *
-   * <p>If the provided callable throws an exception if is logged and ignored and null is returned.
+   * <p>If the provided callable throws an IO exception if is logged and ignored and null is
+   * returned. All other exceptions are passed through
    *
    * <p>This is useful for leaf level imports where the importer should continue if a single item
    * can't be imported.
@@ -47,8 +48,8 @@ public interface IdempotentImportExecutor {
    * @param callable the callable to execute
    * @return the result of executing the callable.
    */
-  <T extends Serializable> T executeAndSwallowExceptions(
-      String idempotentId, String itemName, Callable<T> callable);
+  <T extends Serializable> T executeAndSwallowIOExceptions(
+      String idempotentId, String itemName, Callable<T> callable) throws Exception;
 
   /**
    * Executes a callable, a callable will only be executed once for a given idempotentId, subsequent
@@ -68,7 +69,7 @@ public interface IdempotentImportExecutor {
    * @return the result of executing the callable.
    */
   <T extends Serializable> T executeOrThrowException(
-      String idempotentId, String itemName, Callable<T> callable) throws IOException;
+      String idempotentId, String itemName, Callable<T> callable) throws Exception;
 
   /**
    * Returns a cached result from a previous call to {@code execute}.

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutor.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutor.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableList;
 import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;
+import org.datatransferproject.transfer.TerminalImportException;
+
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -44,14 +46,11 @@ public class InMemoryIdempotentImportExecutor implements IdempotentImportExecuto
   }
 
   @Override
-  public <T extends Serializable> T executeAndSwallowExceptions(
-      String idempotentId, String itemName, Callable<T> callable) {
+  public <T extends Serializable> T executeAndSwallowIOExceptions(
+      String idempotentId, String itemName, Callable<T> callable) throws Exception{
     try {
       return executeOrThrowException(idempotentId, itemName, callable);
     } catch (IOException e) {
-      // Only catching IOException to allow any RuntimeExceptions in the the catch block of
-      // executeOrThrowException bubble up and get noticed.
-
       // Note all errors are logged in executeOrThrowException so no need to re-log them here.
       return null;
     }
@@ -60,7 +59,7 @@ public class InMemoryIdempotentImportExecutor implements IdempotentImportExecuto
   @Override
   @SuppressWarnings("unchecked")
   public <T extends Serializable> T executeOrThrowException(
-      String idempotentId, String itemName, Callable<T> callable) throws IOException {
+      String idempotentId, String itemName, Callable<T> callable) throws Exception {
     String jobIdPrefix = "Job " + jobId + ": ";
 
     if (knownValues.containsKey(idempotentId)) {
@@ -86,7 +85,7 @@ public class InMemoryIdempotentImportExecutor implements IdempotentImportExecuto
               .build();
       errors.put(idempotentId, errorDetail);
       monitor.severe(() -> jobIdPrefix + "Problem with importing item: " + errorDetail);
-      throw new IOException("Problem executing callable for: " + idempotentId, e);
+      throw e;
     }
   }
 

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/DestinationMemoryFullException.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/DestinationMemoryFullException.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 package org.datatransferproject.transfer;
-import java.io.IOException;	
 
-public class DestinationMemoryFullException extends IOException {
+public class DestinationMemoryFullException extends Exception {
   public DestinationMemoryFullException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/portability-test-utilities/src/main/java/org/datatransferproject/test/types/FakeIdempotentImportExecutor.java
+++ b/portability-test-utilities/src/main/java/org/datatransferproject/test/types/FakeIdempotentImportExecutor.java
@@ -16,8 +16,8 @@ public class FakeIdempotentImportExecutor implements IdempotentImportExecutor {
   private HashMap<String, Serializable> knownValues = new HashMap<>();
 
   @Override
-  public <T extends Serializable> T executeAndSwallowExceptions(
-      String idempotentId, String itemName, Callable<T> callable) {
+  public <T extends Serializable> T executeAndSwallowIOExceptions(
+      String idempotentId, String itemName, Callable<T> callable) throws Exception {
     try {
       return executeOrThrowException(idempotentId, itemName, callable);
     } catch (IOException e) {
@@ -27,7 +27,7 @@ public class FakeIdempotentImportExecutor implements IdempotentImportExecutor {
 
   @Override
   public <T extends Serializable> T executeOrThrowException(
-      String idempotentId, String itemName, Callable<T> callable) throws IOException {
+      String idempotentId, String itemName, Callable<T> callable) throws Exception {
     if (knownValues.containsKey(idempotentId)) {
       System.out.println("Using cached key " + idempotentId + " from cache");
       return (T) knownValues.get(idempotentId);


### PR DESCRIPTION
The existing implementation was A) Converting everything to IO exceptions and B) swallowing everything, which was too aggressive on both counts. 

The other option was to "Swallow everything except X", but this felt more in-line with how one would expect an error handling framework to work. 

(Context: This was blocking the DestinationMemoryFullException error from A) stopping the job and B) propagating to where it was being handled)
