### PR TITLE
Fix bug in UniformRetryStategy and improve logging for retries

### DIFF
--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/ExponentialBackoffStrategy.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/ExponentialBackoffStrategy.java
@@ -58,4 +58,13 @@ public class ExponentialBackoffStrategy implements RetryStrategy {
     Preconditions.checkArgument(tries <= maxAttempts, "Too many attempts");
     return getNextIntervalMillis(tries) - elapsedMillis;
   }
+
+  @Override
+  public String toString() {
+    return "ExponentialBackoffStrategy{" +
+        "maxAttempts=" + maxAttempts +
+        ", initialIntervalMillis=" + initialIntervalMillis +
+        ", multiplier=" + multiplier +
+        '}';
+  }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/NoRetryStrategy.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/NoRetryStrategy.java
@@ -37,4 +37,10 @@ public class NoRetryStrategy implements RetryStrategy {
   public long getRemainingIntervalMillis(int tries, long elapsedMillis) {
     return -1L;
   }
+
+  @Override
+  public String toString() {
+    return "NoRetryStrategy{}";
+  }
+
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryMapping.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryMapping.java
@@ -17,6 +17,7 @@
 package org.datatransferproject.types.transfer.retry;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
 
 /**
  * Class that determines whether a given {@link Throwable} is a match for its {@link RetryStrategy}.
@@ -55,5 +56,13 @@ public class RetryMapping {
       }
     }
     return false;
+  }
+
+  @Override
+  public String toString() {
+    return "RetryMapping{" +
+        "regexes=" + Arrays.toString(regexes) +
+        ", strategy=" + strategy +
+        '}';
   }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryStrategyLibrary.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryStrategyLibrary.java
@@ -68,4 +68,12 @@ public class RetryStrategyLibrary {
   public RetryStrategy getDefaultRetryStrategy() {
     return defaultRetryStrategy;
   }
+
+  @Override
+  public String toString() {
+    return "RetryStrategyLibrary{" +
+        "retryMappings=" + retryMappings +
+        ", defaultRetryStrategy=" + defaultRetryStrategy +
+        '}';
+  }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryingCallable.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryingCallable.java
@@ -71,6 +71,11 @@ public class RetryingCallable<T> implements Callable<T> {
         // TODO: do we want to reset anything (eg, number of retries) if we see a different
         // RetryStrategy?
         RetryStrategy strategy = retryStrategyLibrary.checkoutRetryStrategy(e);
+        monitor.info(
+            () ->
+                String.format(
+                    "Attempt %d failed, using retry strategy: %s",
+                    attempts, strategy.toString()));
         if (strategy.canTryAgain(attempts)) {
           long nextAttemptIntervalMillis =
               strategy.getRemainingIntervalMillis(attempts, elapsedMillis);

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryingCallable.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryingCallable.java
@@ -79,6 +79,9 @@ public class RetryingCallable<T> implements Callable<T> {
         if (strategy.canTryAgain(attempts)) {
           long nextAttemptIntervalMillis =
               strategy.getRemainingIntervalMillis(attempts, elapsedMillis);
+          monitor.debug(() -> String.format(
+              "Strategy has %d remainingIntervalMillis after %d elapsedMillis",
+              nextAttemptIntervalMillis, elapsedMillis));
           if (nextAttemptIntervalMillis > 0L) {
             try {
               Thread.sleep(nextAttemptIntervalMillis);
@@ -89,6 +92,8 @@ public class RetryingCallable<T> implements Callable<T> {
             }
           }
         } else {
+          monitor.debug(() -> String
+              .format("Strategy canTryAgain returned false after %d retries", attempts));
           throw new RetryException(attempts, mostRecentException);
         }
       }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryingCallable.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryingCallable.java
@@ -71,7 +71,7 @@ public class RetryingCallable<T> implements Callable<T> {
         // TODO: do we want to reset anything (eg, number of retries) if we see a different
         // RetryStrategy?
         RetryStrategy strategy = retryStrategyLibrary.checkoutRetryStrategy(e);
-        monitor.info(
+        monitor.debug(
             () ->
                 String.format(
                     "Attempt %d failed, using retry strategy: %s",

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/UniformRetryStrategy.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/UniformRetryStrategy.java
@@ -40,7 +40,7 @@ public class UniformRetryStrategy implements RetryStrategy {
 
   @Override
   public boolean canTryAgain(int tries) {
-    return tries >= maxAttempts;
+    return tries <= maxAttempts;
   }
 
   @Override

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/UniformRetryStrategy.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/UniformRetryStrategy.java
@@ -53,4 +53,12 @@ public class UniformRetryStrategy implements RetryStrategy {
     Preconditions.checkArgument(tries <= maxAttempts, "No retries left");
     return intervalMillis - elapsedMillis;
   }
+
+  @Override
+  public String toString() {
+    return "UniformRetryStrategy{" +
+        "maxAttempts=" + maxAttempts +
+        ", intervalMillis=" + intervalMillis +
+        '}';
+  }
 }


### PR DESCRIPTION
I found that it was difficult to tell from the logs which strategy was used for a given error so this logging should make it easier to do so and check that the expected strategies are being used.