### PR TITLE
Create smugmug albums more flexibly

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
@@ -116,11 +116,14 @@ public class SmugMugPhotosImporter
       PhotoModel inputPhoto,
       SmugMugInterface smugMugInterface)
       throws IOException {
-    String newAlbumUri = idempotentExecutor.getCachedValue(inputPhoto.getAlbumId());
-    checkState(
-        !Strings.isNullOrEmpty(newAlbumUri),
-        "Cached album URI for %s is null",
-        inputPhoto.getAlbumId());
+    try {
+        String newAlbumUri = idempotentExecutor.getCachedValue(inputPhoto.getAlbumId());
+    } catch (IllegalArgumentException) {
+        String newAlbumUri = idempotentExecutor.executeAndSwallowIOExceptions(
+            album.getId(),
+            album.getName(),
+            () -> importSingleAlbum(inputPhoto.getAlbumId(), smugMugInterface));
+    }
 
     InputStream inputStream;
     if (inputPhoto.isInTempStore()) {


### PR DESCRIPTION
@seehamrun @holachuy 

I think this importer was making the assumption that every album would be created before trying to import any of the photos, but evidently data.getAlbums() does not cover all of the photo.getAlbumId() calls