### PR TITLE
Remove NiceName specification, revert other encoding change

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -227,7 +227,7 @@ public class SmugMugInterface {
 
     // Add body params
     for (Entry<String, String> param : contentParams.entrySet()) {
-      request.addBodyParameter(param.getValue());
+      request.addBodyParameter(param.getKey(), param.getValue());
     }
 
     // sign request before adding any of the headers since those shouldn't be included in the

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -110,14 +110,11 @@ public class SmugMugInterface {
   SmugMugAlbumResponse createAlbum(String albumName) throws IOException {
     // Set up album
     Map<String, String> json = new HashMap<>();
-    String niceName = "Copy-of-" + albumName.replace(' ', '-');
-    json.put("NiceName", niceName);
     // Allow conflicting names to be changed
     json.put("AutoRename", "true");
     json.put("Title", "Copy of " + albumName);
     // All imported content is private by default.
     json.put("Privacy", "Private");
-    HttpContent content = new JsonHttpContent(new JacksonFactory(), json);
 
     // Upload album
     String folder = user.getUris().get(FOLDER_KEY).getUri();
@@ -230,7 +227,7 @@ public class SmugMugInterface {
 
     // Add body params
     for (Entry<String, String> param : contentParams.entrySet()) {
-      request.addBodyParameter(param.getKey(), URLEncoder.encode(param.getValue(), StandardCharsets.UTF_8.toString()));
+      request.addBodyParameter(param.getValue());
     }
 
     // sign request before adding any of the headers since those shouldn't be included in the
@@ -247,7 +244,7 @@ public class SmugMugInterface {
     Response response = request.send();
     if (response.getCode() < 200 || response.getCode() >= 300) {
       throw new IOException(
-          String.format("Error occurred in request for %s : %s", fullUrl, response.getMessage()));
+          String.format("Error occurred in request for %s : %s \n %s", fullUrl, response.getMessage(), contentParams.toString()));
     }
 
     return mapper.readValue(response.getBody(), typeReference);


### PR DESCRIPTION
I'm guessing that because we specified the nicename, it didn't do its own auto-convert logic. So hopefully removing that will fix it for us.