### PR TITLE
Explicitly split up the cases when we refresh the authorization credential

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
@@ -103,7 +103,7 @@ public class GoogleTransferExtension implements TransferExtension {
     importerBuilder.put("MAIL", new GoogleMailImporter(credentialFactory, monitor));
     importerBuilder.put("TASKS", new GoogleTasksImporter(credentialFactory));
     importerBuilder.put(
-            "PHOTOS", new GooglePhotosImporter(credentialFactory, jobStore, jsonFactory));
+            "PHOTOS", new GooglePhotosImporter(credentialFactory, jobStore, jsonFactory, monitor));
     importerBuilder.put("VIDEOS", new GoogleVideosImporter(credentialFactory, jsonFactory, monitor));
     importerMap = importerBuilder.build();
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
@@ -332,7 +332,7 @@ public class GooglePhotosExporter
 
   private synchronized GooglePhotosInterface makePhotosInterface(TokensAndUrlAuthData authData) {
     Credential credential = credentialFactory.createCredential(authData);
-    return new GooglePhotosInterface(credential, jsonFactory);
+    return new GooglePhotosInterface(credential, jsonFactory, monitor);
   }
 
   private static String createCacheKey() {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -19,6 +19,7 @@ import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.json.JsonFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
@@ -49,12 +50,14 @@ public class GooglePhotosImporter
   private final JsonFactory jsonFactory;
   private final ImageStreamProvider imageStreamProvider;
   private volatile GooglePhotosInterface photosInterface;
+  private final Monitor monitor;
 
   public GooglePhotosImporter(
       GoogleCredentialFactory credentialFactory,
       TemporaryPerJobDataStore jobStore,
-      JsonFactory jsonFactory) {
-    this(credentialFactory, jobStore, jsonFactory, null, new ImageStreamProvider());
+      JsonFactory jsonFactory,
+      Monitor monitor) {
+    this(credentialFactory, jobStore, jsonFactory, null, new ImageStreamProvider(), monitor);
   }
 
   @VisibleForTesting
@@ -63,12 +66,14 @@ public class GooglePhotosImporter
       TemporaryPerJobDataStore jobStore,
       JsonFactory jsonFactory,
       GooglePhotosInterface photosInterface,
-      ImageStreamProvider imageStreamProvider) {
+      ImageStreamProvider imageStreamProvider,
+      Monitor monitor) {
     this.credentialFactory = credentialFactory;
     this.jobStore = jobStore;
     this.jsonFactory = jsonFactory;
     this.photosInterface = photosInterface;
     this.imageStreamProvider = imageStreamProvider;
+    this.monitor = monitor;
   }
 
   @Override
@@ -172,6 +177,6 @@ public class GooglePhotosImporter
 
   private synchronized GooglePhotosInterface makePhotosInterface(TokensAndUrlAuthData authData) {
     Credential credential = credentialFactory.createCredential(authData);
-    return new GooglePhotosInterface(credential, jsonFactory);
+    return new GooglePhotosInterface(credential, jsonFactory, monitor);
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -191,7 +191,7 @@ public class GooglePhotosInterface {
                   httpContent).execute();
           
         } else {
-          throw new IOException("Couldn't refresh access token!");
+          throw new IOException("Couldn't refresh authorization token!");
         }
       } else {
         // something else is wrong, bubble up the error

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -180,12 +180,19 @@ public class GooglePhotosInterface {
     try {
       response = postRequest.execute();
     } catch (HttpResponseException e) {
-      // if the response is "unauthorized" and we've successfully refreshed the token, try the request again
-      if (e.getStatusCode() == 401 && credential.refreshToken()) {
-        // if the second attempt throws an error, then something else is wrong, and we bubble up the response errors
-        response = requestFactory
-            .buildPostRequest(new GenericUrl(url + "?" + generateParamsString(parameters)),
-                httpContent).execute();
+      // if the response is "unauthorized", refresh the token and try the request again
+      if (e.getStatusCode() == 401) {
+        monitor.atInfo(() => "Attempting to refresh authorization token");
+        if (credential.refreshToken()) {
+          // if the second attempt throws an error, then something else is wrong, and we bubble up the response errors
+          monitor.atInfo(() => "Refreshed authorization token successfuly");
+          response = requestFactory
+              .buildPostRequest(new GenericUrl(url + "?" + generateParamsString(parameters)),
+                  httpContent).execute();
+          
+        } else {
+          throw new IOException("Couldn't refresh access token!");
+        }
       } else {
         // something else is wrong, bubble up the error
         throw new IOException(

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.mediaModels.AlbumListResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
@@ -77,10 +78,12 @@ public class GooglePhotosInterface {
   private final HttpTransport httpTransport = new NetHttpTransport();
   private final Credential credential;
   private final JsonFactory jsonFactory;
+  private final Monitor monitor;
 
-  GooglePhotosInterface(Credential credential, JsonFactory jsonFactory) {
+  GooglePhotosInterface(Credential credential, JsonFactory jsonFactory, Monitor monitor) {
     this.credential = credential;
     this.jsonFactory = jsonFactory;
+    this.monitor = monitor;
   }
 
   AlbumListResponse listAlbums(Optional<String> pageToken) throws IOException {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -191,7 +191,7 @@ public class GooglePhotosInterface {
                   httpContent).execute();
           
         } else {
-          throw new IOException("Couldn't refresh authorization token!");
+          throw new IOException("Couldn't refresh authorization token after retrying");
         }
       } else {
         // something else is wrong, bubble up the error

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -182,10 +182,10 @@ public class GooglePhotosInterface {
     } catch (HttpResponseException e) {
       // if the response is "unauthorized", refresh the token and try the request again
       if (e.getStatusCode() == 401) {
-        monitor.atInfo(() => "Attempting to refresh authorization token");
+        monitor.info(() -> "Attempting to refresh authorization token");
         if (credential.refreshToken()) {
           // if the second attempt throws an error, then something else is wrong, and we bubble up the response errors
-          monitor.atInfo(() => "Refreshed authorization token successfuly");
+          monitor.info(() -> "Refreshed authorization token successfuly");
           response = requestFactory
               .buildPostRequest(new GenericUrl(url + "?" + generateParamsString(parameters)),
                   httpContent).execute();

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -58,6 +58,7 @@ public class GooglePhotosImporterTest {
   private ImageStreamProvider imageStreamProvider;
   private InputStream inputStream;
   private IdempotentImportExecutor executor;
+  private Monitor monitor;
 
   private static final String OLD_ALBUM_ID = "OLD_ALBUM_ID";
   private static final String NEW_ALBUM_ID = "NEW_ALBUM_ID";
@@ -66,6 +67,7 @@ public class GooglePhotosImporterTest {
   public void setUp() throws IOException {
     executor = new FakeIdempotentImportExecutor();
     googlePhotosInterface = Mockito.mock(GooglePhotosInterface.class);
+    monitor = mock(Monitor.class);
 
     Mockito.when(googlePhotosInterface.uploadPhotoContent(Matchers.any(InputStream.class)))
         .thenReturn(UPLOAD_TOKEN);
@@ -79,7 +81,7 @@ public class GooglePhotosImporterTest {
     Mockito.when(imageStreamProvider.get(Matchers.anyString())).thenReturn(inputStream);
 
     googlePhotosImporter = new GooglePhotosImporter(null, jobStore, null,
-        googlePhotosInterface, imageStreamProvider);
+        googlePhotosInterface, imageStreamProvider, monitor);
   }
 
   @Test

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -67,7 +67,7 @@ public class GooglePhotosImporterTest {
   public void setUp() throws IOException {
     executor = new FakeIdempotentImportExecutor();
     googlePhotosInterface = Mockito.mock(GooglePhotosInterface.class);
-    monitor = mock(Monitor.class);
+    monitor = Mockito.mock(Monitor.class);
 
     Mockito.when(googlePhotosInterface.uploadPhotoContent(Matchers.any(InputStream.class)))
         .thenReturn(UPLOAD_TOKEN);

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -110,14 +110,11 @@ public class SmugMugInterface {
   SmugMugAlbumResponse createAlbum(String albumName) throws IOException {
     // Set up album
     Map<String, String> json = new HashMap<>();
-    String niceName = "Copy-of-" + albumName.replace(' ', '-');
-    json.put("NiceName", niceName);
     // Allow conflicting names to be changed
     json.put("AutoRename", "true");
     json.put("Title", "Copy of " + albumName);
     // All imported content is private by default.
     json.put("Privacy", "Private");
-    HttpContent content = new JsonHttpContent(new JacksonFactory(), json);
 
     // Upload album
     String folder = user.getUris().get(FOLDER_KEY).getUri();
@@ -230,7 +227,7 @@ public class SmugMugInterface {
 
     // Add body params
     for (Entry<String, String> param : contentParams.entrySet()) {
-      request.addBodyParameter(param.getKey(), URLEncoder.encode(param.getValue(), StandardCharsets.UTF_8.toString()));
+      request.addBodyParameter(param.getKey(), param.getValue());
     }
 
     // sign request before adding any of the headers since those shouldn't be included in the
@@ -247,7 +244,7 @@ public class SmugMugInterface {
     Response response = request.send();
     if (response.getCode() < 200 || response.getCode() >= 300) {
       throw new IOException(
-          String.format("Error occurred in request for %s : %s", fullUrl, response.getMessage()));
+          String.format("Error occurred in request for %s : %s \n %s", fullUrl, response.getMessage(), contentParams.toString()));
     }
 
     return mapper.readValue(response.getBody(), typeReference);


### PR DESCRIPTION
So that we can pin down why we're still getting 401 errors in the worker after the job reaches 60minutes