### PR TITLE
Restore smugmug to functionality of v0.3.5

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -31,8 +31,6 @@ import com.google.common.net.HttpHeaders;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -230,7 +228,7 @@ public class SmugMugInterface {
 
     // Add body params
     for (Entry<String, String> param : contentParams.entrySet()) {
-      request.addBodyParameter(param.getKey(), URLEncoder.encode(param.getValue(), StandardCharsets.UTF_8.toString()));
+      request.addBodyParameter(param.getKey(), param.getValue());
     }
 
     // sign request before adding any of the headers since those shouldn't be included in the

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -110,11 +110,14 @@ public class SmugMugInterface {
   SmugMugAlbumResponse createAlbum(String albumName) throws IOException {
     // Set up album
     Map<String, String> json = new HashMap<>();
+    String niceName = "Copy-of-" + albumName.replace(' ', '-');
+    json.put("NiceName", niceName);
     // Allow conflicting names to be changed
     json.put("AutoRename", "true");
     json.put("Title", "Copy of " + albumName);
     // All imported content is private by default.
     json.put("Privacy", "Private");
+    HttpContent content = new JsonHttpContent(new JacksonFactory(), json);
 
     // Upload album
     String folder = user.getUris().get(FOLDER_KEY).getUri();
@@ -227,7 +230,7 @@ public class SmugMugInterface {
 
     // Add body params
     for (Entry<String, String> param : contentParams.entrySet()) {
-      request.addBodyParameter(param.getKey(), param.getValue());
+      request.addBodyParameter(param.getKey(), URLEncoder.encode(param.getValue(), StandardCharsets.UTF_8.toString()));
     }
 
     // sign request before adding any of the headers since those shouldn't be included in the
@@ -244,7 +247,7 @@ public class SmugMugInterface {
     Response response = request.send();
     if (response.getCode() < 200 || response.getCode() >= 300) {
       throw new IOException(
-          String.format("Error occurred in request for %s : %s \n %s", fullUrl, response.getMessage(), contentParams.toString()));
+          String.format("Error occurred in request for %s : %s", fullUrl, response.getMessage()));
     }
 
     return mapper.readValue(response.getBody(), typeReference);


### PR DESCRIPTION
Undoing the changes I thought would fix the special character issue.

This leaves the smugmug integration in a state where it will fail to create albums with special characters in them, but work otherwise