### PR TITLE
Add flushLogs method to Monitor

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/StackdriverMonitor.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/StackdriverMonitor.java
@@ -1,21 +1,20 @@
 package org.datatransferproject.cloud.google;
 
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.Payload;
 import com.google.cloud.logging.Severity;
 import com.google.common.base.Throwables;
-import org.datatransferproject.api.launcher.JobAwareMonitor;
-import org.datatransferproject.launcher.monitor.events.EventCode;
-
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Supplier;
-
-import static com.google.common.base.Preconditions.checkState;
-import static java.lang.String.format;
+import org.datatransferproject.api.launcher.JobAwareMonitor;
+import org.datatransferproject.launcher.monitor.events.EventCode;
 
 class StackdriverMonitor implements JobAwareMonitor {
 
@@ -45,12 +44,13 @@ class StackdriverMonitor implements JobAwareMonitor {
   }
 
   private void log(Severity severity, Supplier<String> supplier, Object... data) {
-    MonitoredResource.Builder resourceBuilder = MonitoredResource.newBuilder("generic_task")
-        .addLabel("project_id", projectId)
-        // This is slightly backwards as in GCP a job can have many tasks
-        // but to line up with the DTP terminology around a job we'll use
-        // GCP's job to line up with DTP's job.
-        .addLabel("task_id", getHostName());
+    MonitoredResource.Builder resourceBuilder =
+        MonitoredResource.newBuilder("generic_task")
+            .addLabel("project_id", projectId)
+            // This is slightly backwards as in GCP a job can have many tasks
+            // but to line up with the DTP terminology around a job we'll use
+            // GCP's job to line up with DTP's job.
+            .addLabel("task_id", getHostName());
 
     if (null != jobId) {
       resourceBuilder.addLabel("job", jobId);
@@ -62,8 +62,7 @@ class StackdriverMonitor implements JobAwareMonitor {
     if (data != null) {
       for (Object datum : data) {
         if (datum instanceof Throwable) {
-          logMessage.append(
-              format("\n%s", Throwables.getStackTraceAsString(((Throwable) datum))));
+          logMessage.append(format("\n%s", Throwables.getStackTraceAsString(((Throwable) datum))));
         } else if (datum instanceof UUID) {
           logMessage.append(format("\nJobId: %s", ((UUID) datum)));
         } else if (datum instanceof EventCode) {
@@ -74,11 +73,12 @@ class StackdriverMonitor implements JobAwareMonitor {
       }
     }
 
-    LogEntry entry = LogEntry.newBuilder(Payload.StringPayload.of(logMessage.toString()))
-        .setSeverity(severity)
-        .setLogName(LOG_NAME)
-        .setResource(resourceBuilder.build())
-        .build();
+    LogEntry entry =
+        LogEntry.newBuilder(Payload.StringPayload.of(logMessage.toString()))
+            .setSeverity(severity)
+            .setLogName(LOG_NAME)
+            .setResource(resourceBuilder.build())
+            .build();
 
     try {
       // Writes the log entry asynchronously

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/StackdriverMonitor.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/StackdriverMonitor.java
@@ -103,4 +103,9 @@ class StackdriverMonitor implements JobAwareMonitor {
     this.jobId = jobId;
     debug(() -> format("Set job id to: %s", jobId));
   }
+
+  @Override
+  public void flushLogs() {
+    logging.flush();
+  }
 }

--- a/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/Monitor.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/Monitor.java
@@ -49,4 +49,9 @@ public interface Monitor {
    * @param data optional data items
    */
   default void debug(Supplier<String> supplier, Object... data) {}
+
+  /**
+   * Makes sure any queued logs are sent. Recommended to be called before exiting the Java process.
+   */
+  default void flushLogs() {}
 }

--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/MultiplexMonitor.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/MultiplexMonitor.java
@@ -15,10 +15,9 @@
  */
 package org.datatransferproject.launcher.monitor;
 
+import java.util.function.Supplier;
 import org.datatransferproject.api.launcher.JobAwareMonitor;
 import org.datatransferproject.api.launcher.Monitor;
-
-import java.util.function.Supplier;
 
 /** Forwards monitor events to a set of delegates. */
 public class MultiplexMonitor implements JobAwareMonitor {

--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/MultiplexMonitor.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/MultiplexMonitor.java
@@ -57,4 +57,11 @@ public class MultiplexMonitor implements JobAwareMonitor {
       }
     }
   }
+
+  @Override
+  public void flushLogs() {
+    for (Monitor delegate : delegates) {
+      delegate.flushLogs();
+    }
+  }
 }

--- a/portability-bootstrap-vm/src/main/java/org/datatransferproject/bootstrap/vm/SingleVMMain.java
+++ b/portability-bootstrap-vm/src/main/java/org/datatransferproject/bootstrap/vm/SingleVMMain.java
@@ -43,6 +43,7 @@ public class SingleVMMain {
     this.errorCallback =
         (e) -> {
           monitor.severe(() -> format("Exiting abnormally, exception:%n%n" + e));
+          monitor.flushLogs();
           System.exit(-1);
         };
   }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
@@ -21,10 +21,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 
-/**
- * A service that polls storage to see if a job is canceled, if it is
- * it kills the binary.
- */
+/** A service that polls storage to see if a job is canceled, if it is it kills the binary. */
 class JobCancelWatchingService extends AbstractScheduledService {
   private final JobStore store;
   private final Scheduler scheduler;
@@ -32,9 +29,7 @@ class JobCancelWatchingService extends AbstractScheduledService {
 
   @Inject
   JobCancelWatchingService(
-      JobStore store,
-      @Annotations.CancelScheduler Scheduler scheduler,
-      Monitor monitor) {
+      JobStore store, @Annotations.CancelScheduler Scheduler scheduler, Monitor monitor) {
     this.store = store;
     this.scheduler = scheduler;
     this.monitor = monitor;
@@ -48,7 +43,8 @@ class JobCancelWatchingService extends AbstractScheduledService {
     monitor.debug(() -> "polling for job to check cancellation");
     PortabilityJob currentJob = store.findJob(JobMetadata.getJobId());
     boolean isCanceled = currentJob.state() == PortabilityJob.State.CANCELED;
-    monitor.debug(() -> String.format("Job %s is canceled: %s", JobMetadata.getJobId(), isCanceled));
+    monitor.debug(
+        () -> String.format("Job %s is canceled: %s", JobMetadata.getJobId(), isCanceled));
     if (isCanceled) {
       monitor.flushLogs();
       System.exit(-1);

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
@@ -50,6 +50,7 @@ class JobCancelWatchingService extends AbstractScheduledService {
     boolean isCanceled = currentJob.state() == PortabilityJob.State.CANCELED;
     monitor.debug(() -> String.format("Job %s is canceled: %s", JobMetadata.getJobId(), isCanceled));
     if (isCanceled) {
+      monitor.flushLogs();
       System.exit(-1);
     }
   }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -38,6 +38,7 @@ import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.transfer.auth.AuthData;
 import org.datatransferproject.types.transfer.auth.AuthDataPair;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;
+
 /**
  * Process a job in two steps: <br>
  * (1) Decrypt the stored credentials, which have been encrypted with this transfer worker's public
@@ -119,17 +120,16 @@ final class JobProcessor {
           JobMetadata.getExportService(),
           JobMetadata.getImportService());
       stopwatch.start();
-      errors = copier.copy(
-          exportAuthData,
-          importAuthData,
-          jobId,
-          exportInfo);
+      errors = copier.copy(exportAuthData, importAuthData, jobId, exportInfo);
       final int numErrors = errors.size();
       monitor.debug(
           () -> format("Finished copy for jobId: %s with %d error(s).", jobId, numErrors));
       success = errors.isEmpty();
     } catch (DestinationMemoryFullException e) {
-      monitor.severe(() -> "Destination memory error processing jobId: " + jobId, e, EventCode.WORKER_JOB_ERRORED);
+      monitor.severe(
+          () -> "Destination memory error processing jobId: " + jobId,
+          e,
+          EventCode.WORKER_JOB_ERRORED);
       addFailureReasonToJob(jobId, DESTINATION_FULL_ENUM);
     } catch (IOException | CopyException | RuntimeException e) {
       monitor.severe(() -> "Error processing jobId: " + jobId, e, EventCode.WORKER_JOB_ERRORED);
@@ -156,7 +156,8 @@ final class JobProcessor {
     return null;
   }
 
-  private void addErrorsAndMarkJobFinished(UUID jobId, boolean success, Collection<ErrorDetail> errors) {
+  private void addErrorsAndMarkJobFinished(
+      UUID jobId, boolean success, Collection<ErrorDetail> errors) {
     try {
       store.addErrorsToJob(jobId, errors);
     } catch (IOException | RuntimeException e) {

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -143,6 +143,7 @@ final class JobProcessor {
           JobMetadata.getImportService(),
           success,
           stopwatch.elapsed());
+      monitor.flushLogs();
       JobMetadata.reset();
     }
   }


### PR DESCRIPTION
This adds a method to explicitly flush logs which is useful to  do before exiting the process. I have added implementations to the MultiplexMonitor and the Google Cloud StackdriverMonitor.

I have also run Google Java Format 1.7 on the modified files. This is a tradeoff related to https://github.com/google/data-transfer-project/issues/151 and I am happy to discuss this further or reverse the formatting commit.