### PR TITLE
store count of imported items by job id instead of overall

### DIFF
--- a/extensions/cloud/portability-cloud-local/src/main/java/org/datatransferproject/cloud/local/LocalJobStore.java
+++ b/extensions/cloud/portability-cloud-local/src/main/java/org/datatransferproject/cloud/local/LocalJobStore.java
@@ -15,9 +15,18 @@
  */
 package org.datatransferproject.cloud.local;
 
+import static java.lang.String.format;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.cloud.storage.JobStoreWithValidator;
@@ -26,16 +35,6 @@ import org.datatransferproject.spi.cloud.types.JobAuthorization.State;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.types.common.models.DataModel;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
-import static java.lang.String.format;
 
 /** An in-memory {@link JobStore} implementation that uses a concurrent map as its store. */
 public final class LocalJobStore extends JobStoreWithValidator {

--- a/extensions/cloud/portability-cloud-local/src/test/java/org/datatransferproject/cloud/local/LocalJobStoreTest.java
+++ b/extensions/cloud/portability-cloud-local/src/test/java/org/datatransferproject/cloud/local/LocalJobStoreTest.java
@@ -16,14 +16,13 @@
 
 package org.datatransferproject.cloud.local;
 
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
-import org.junit.Test;
-
 import java.util.Map;
 import java.util.UUID;
-
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class LocalJobStoreTest {
 
@@ -56,6 +55,7 @@ public class LocalJobStoreTest {
   }
 
   private void addItemToJobStoreCounts(final String itemName) {
-    localJobStore.addCounts(jobId, new ImmutableMap.Builder<String, Integer>().put(itemName, 1).build());
+    localJobStore.addCounts(
+        jobId, new ImmutableMap.Builder<String, Integer>().put(itemName, 1).build());
   }
 }

--- a/extensions/cloud/portability-cloud-local/src/test/java/org/datatransferproject/cloud/local/LocalJobStoreTest.java
+++ b/extensions/cloud/portability-cloud-local/src/test/java/org/datatransferproject/cloud/local/LocalJobStoreTest.java
@@ -16,30 +16,31 @@
 
 package org.datatransferproject.cloud.local;
 
-import static org.junit.Assert.assertTrue;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
-import java.util.Map;
 import org.junit.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
 
 public class LocalJobStoreTest {
 
   private final String ITEM_NAME = "item1";
-
+  private final UUID jobId = UUID.randomUUID();
   private final LocalJobStore localJobStore = new LocalJobStore();
 
   @Test
   public void addingNullDoesNotChangeTheCurrentCountsTest() {
-    localJobStore.addCounts(null);
-    assertTrue(localJobStore.getCounts().isEmpty());
+    localJobStore.addCounts(jobId, null);
+    assertTrue(localJobStore.getCounts(jobId).isEmpty());
   }
 
   @Test
   public void canAddNewKeysToTheCurrentCountsTest() {
     addItemToJobStoreCounts(ITEM_NAME);
-
-    final Map<String, Integer> counts = localJobStore.getCounts();
+    final Map<String, Integer> counts = localJobStore.getCounts(jobId);
     Truth.assertThat(counts.size()).isEqualTo(1);
     Truth.assertThat(counts.get(ITEM_NAME)).isEqualTo(1);
   }
@@ -49,14 +50,12 @@ public class LocalJobStoreTest {
     addItemToJobStoreCounts(ITEM_NAME);
     addItemToJobStoreCounts(ITEM_NAME);
 
-    final Map<String, Integer> counts = localJobStore.getCounts();
+    final Map<String, Integer> counts = localJobStore.getCounts(jobId);
     Truth.assertThat(counts.size()).isEqualTo(1);
     Truth.assertThat(counts.get(ITEM_NAME)).isEqualTo(2);
   }
 
   private void addItemToJobStoreCounts(final String itemName) {
-    localJobStore.addCounts(new ImmutableMap.Builder<String, Integer>()
-        .put(itemName, 1)
-        .build());
+    localJobStore.addCounts(jobId, new ImmutableMap.Builder<String, Integer>().put(itemName, 1).build());
   }
 }

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
@@ -1,14 +1,13 @@
 package org.datatransferproject.spi.cloud.storage;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.spi.cloud.types.PortabilityJob.State;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.UUID;
 
 /**
  * A store for {@link PortabilityJob}s.
@@ -23,7 +22,7 @@ public interface JobStore extends TemporaryPerJobDataStore {
    * <p>To update an existing {@link PortabilityJob} instead, use {@link #update}.
    *
    * @throws IOException if a job already exists for {@code job}'s ID, or if there was a different
-   * problem inserting the job.
+   *     problem inserting the job.
    */
   void createJob(UUID jobId, PortabilityJob job) throws IOException;
 
@@ -54,7 +53,7 @@ public interface JobStore extends TemporaryPerJobDataStore {
    * Stores errors related to a transfer job.
    *
    * @throws IOException if a job didn't already exist for {@code jobId} or there was a problem
-   * updating it
+   *     updating it
    */
   void addErrorsToJob(UUID jobId, Collection<ErrorDetail> errors) throws IOException;
 
@@ -62,12 +61,13 @@ public interface JobStore extends TemporaryPerJobDataStore {
    * Stores a FailureReason related to a transfer job.
    *
    * @throws IOException if a job didn't already exist for {@code jobId} or there was a problem
-   * updating it
+   *     updating it
    */
   void addFailureReasonToJob(UUID jobId, String failureReason) throws IOException;
 
   /**
    * Updates a job to mark as finished.
+   *
    * @param state The new state of the job. Can be {@code State.ERROR} or {@code State.COMPLETE}.
    * @throws IOException if unable to update the job
    */
@@ -75,6 +75,7 @@ public interface JobStore extends TemporaryPerJobDataStore {
 
   /**
    * Updates a job to mark as in progress.
+   *
    * @throws IOException if unable to update the job
    */
   void markJobAsStarted(UUID jobId) throws IOException;
@@ -120,5 +121,7 @@ public interface JobStore extends TemporaryPerJobDataStore {
    *
    * @return mapping from items names to items counts or null if none exist
    */
-  default Map<String, Integer> getCounts(UUID jobId) {return null;}
+  default Map<String, Integer> getCounts(UUID jobId) {
+    return null;
+  }
 }

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
@@ -113,12 +113,12 @@ public interface JobStore extends TemporaryPerJobDataStore {
    *
    * @param newCounts the new items counted
    */
-  default void addCounts(Map<String, Integer> newCounts) {}
+  default void addCounts(UUID jobId, Map<String, Integer> newCounts) {}
 
   /**
    * Provides the total number of items recorded.
    *
    * @return mapping from items names to items counts or null if none exist
    */
-  default Map<String, Integer> getCounts() {return null;}
+  default Map<String, Integer> getCounts(UUID jobId) {return null;}
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
@@ -19,6 +19,13 @@ import static java.lang.String.format;
 
 import com.google.common.base.Stopwatch;
 import com.google.inject.Provider;
+import java.io.IOException;
+import java.time.Clock;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Inject;
 import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.launcher.monitor.events.EventCode;
@@ -36,15 +43,6 @@ import org.datatransferproject.types.transfer.errors.ErrorDetail;
 import org.datatransferproject.types.transfer.retry.RetryException;
 import org.datatransferproject.types.transfer.retry.RetryStrategyLibrary;
 import org.datatransferproject.types.transfer.retry.RetryingCallable;
-import org.datatransferproject.transfer.DestinationMemoryFullException;
-
-import javax.inject.Inject;
-import java.io.IOException;
-import java.time.Clock;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /** Implementation of {@link InMemoryDataCopier}. */
 final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
@@ -85,11 +83,11 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
 
   /** Kicks off transfer job {@code jobId} from {@code exporter} to {@code importer}. */
   @Override
-   public Collection<ErrorDetail> copy(
-       AuthData exportAuthData,
-       AuthData importAuthData,
-       UUID jobId,
-       Optional<ExportInformation> exportInfo)
+  public Collection<ErrorDetail> copy(
+      AuthData exportAuthData,
+      AuthData importAuthData,
+      UUID jobId,
+      Optional<ExportInformation> exportInfo)
       throws IOException, CopyException {
     idempotentImportExecutor.setJobId(jobId);
     return copyHelper(jobId, exportAuthData, importAuthData, exportInfo);
@@ -109,7 +107,8 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
       UUID jobId,
       AuthData exportAuthData,
       AuthData importAuthData,
-      Optional<ExportInformation> exportInformation) throws CopyException {
+      Optional<ExportInformation> exportInformation)
+      throws CopyException {
 
     String jobIdPrefix = "Job " + jobId + ": ";
     monitor.debug(
@@ -123,11 +122,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
     monitor.debug(() -> jobIdPrefix + "Starting export", EventCode.COPIER_STARTED_EXPORT);
     CallableExporter callableExporter =
         new CallableExporter(
-            exporterProvider,
-            jobId,
-            exportAuthData,
-            exportInformation,
-            metricRecorder);
+            exporterProvider, jobId, exportAuthData, exportInformation, metricRecorder);
     RetryingCallable<ExportResult> retryingExporter =
         new RetryingCallable<>(callableExporter, retryStrategyLibrary, Clock.systemUTC(), monitor);
     ExportResult<?> exportResult;
@@ -138,7 +133,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
       exportSuccess = exportResult.getType() != ExportResult.ResultType.ERROR;
     } catch (RetryException | RuntimeException e) {
       throw new CopyException(jobIdPrefix + "Error happened during export", e);
-    } finally{
+    } finally {
       metricRecorder.exportPageFinished(
           JobMetadata.getDataType(),
           JobMetadata.getExportService(),
@@ -170,11 +165,11 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
         }
       } catch (RetryException | RuntimeException e) {
         monitor.severe(() -> format("Got error importing data: %s", e), e);
-        if (e.getClass() == RetryException.class &&
-            e.getCause().getClass() == DestinationMemoryFullException.class){
+        if (e.getClass() == RetryException.class
+            && e.getCause().getClass() == DestinationMemoryFullException.class) {
           throw (DestinationMemoryFullException) e.getCause();
         }
-      } finally{
+      } finally {
         metricRecorder.importPageFinished(
             JobMetadata.getDataType(),
             JobMetadata.getImportService(),
@@ -195,18 +190,22 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
             jobId,
             exportAuthData,
             importAuthData,
-            Optional.of(new ExportInformation(
-                continuationData.getPaginationData(),
-                exportInformation.isPresent()
-                    ? exportInformation.get().getContainerResource()
-                    : null)));
+            Optional.of(
+                new ExportInformation(
+                    continuationData.getPaginationData(),
+                    exportInformation.isPresent()
+                        ? exportInformation.get().getContainerResource()
+                        : null)));
       }
 
       // Start processing sub-resources
       if (continuationData.getContainerResources() != null
           && !continuationData.getContainerResources().isEmpty()) {
         for (ContainerResource resource : continuationData.getContainerResources()) {
-          copyHelper(jobId, exportAuthData, importAuthData,
+          copyHelper(
+              jobId,
+              exportAuthData,
+              importAuthData,
               Optional.of(new ExportInformation(null, resource)));
         }
       }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
@@ -166,7 +166,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
         ImportResult importResult = retryingImporter.call();
         importSuccess = importResult.getType() == ImportResult.ResultType.OK;
         if (importSuccess) {
-          jobStore.addCounts(importResult.getCounts().orElse(null));
+          jobStore.addCounts(jobId, importResult.getCounts().orElse(null));
         }
       } catch (RetryException | RuntimeException e) {
         monitor.severe(() -> format("Got error importing data: %s", e), e);


### PR DESCRIPTION
#742 added the count of imported items, but the interface doesn't allow you to add the items for the job like the rest of the functions. 

@dragosmartac and @wmorland since this changes the interface used. 