### PR TITLE
importers: make item name prefixes configurable

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/FlickrTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/FlickrTransferExtension.java
@@ -72,6 +72,8 @@ public class FlickrTransferExtension implements TransferExtension {
     jobStore = context.getService(TemporaryPerJobDataStore.class);
     Monitor monitor = context.getMonitor();
 
+    String photoPrefix = context.getSetting("imported_photos_photo_prefix", FlickrPhotosImporter.DEFAULT_PHOTO_PREFIX);
+
     try {
       appCredentials =
           context.getService(AppCredentialStore.class).getAppCredentials(FLICKR_KEY, FLICKR_SECRET);
@@ -88,7 +90,7 @@ public class FlickrTransferExtension implements TransferExtension {
 
     TransferServiceConfig serviceConfig = context.getService(TransferServiceConfig.class);
 
-    importer = new FlickrPhotosImporter(appCredentials, jobStore, monitor, serviceConfig);
+    importer = new FlickrPhotosImporter(appCredentials, jobStore, monitor, serviceConfig, photoPrefix);
     exporter = new FlickrPhotosExporter(appCredentials, serviceConfig);
     initialized = true;
   }

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
@@ -104,7 +104,7 @@ public class FlickrPhotosImporterTest {
     when(uploader.upload(any(BufferedInputStream.class), any(UploadMetaData.class)))
         .thenReturn(FLICKR_PHOTO_ID);
 
-    String flickrAlbumTitle = FlickrPhotosImporter.COPY_PREFIX + ALBUM_NAME;
+    String flickrAlbumTitle = FlickrPhotosImporter.DEFAULT_PHOTO_PREFIX + ALBUM_NAME;
     Photoset photoset =
         FlickrTestUtils.initializePhotoset(FLICKR_ALBUM_ID, ALBUM_DESCRIPTION, FLICKR_PHOTO_ID);
     when(photosetsInterface.create(flickrAlbumTitle, ALBUM_DESCRIPTION, FLICKR_PHOTO_ID))
@@ -116,7 +116,8 @@ public class FlickrPhotosImporterTest {
         jobStore,
         imageStreamProvider,
         monitor,
-        TransferServiceConfig.getDefaultInstance());
+        TransferServiceConfig.getDefaultInstance(),
+        FlickrPhotosImporter.DEFAULT_PHOTO_PREFIX);
     ImportResult result = importer.importItem(
         jobId,
         EXECUTOR,
@@ -129,7 +130,7 @@ public class FlickrPhotosImporterTest {
     verify(uploader).upload(eq(bufferedInputStream), uploadMetaDataArgumentCaptor.capture());
     UploadMetaData actualUploadMetaData = uploadMetaDataArgumentCaptor.getValue();
     assertThat(actualUploadMetaData.getTitle())
-            .isEqualTo(FlickrPhotosImporter.COPY_PREFIX + PHOTO_TITLE);
+            .isEqualTo(FlickrPhotosImporter.DEFAULT_PHOTO_PREFIX + PHOTO_TITLE);
     assertThat(actualUploadMetaData.getDescription()).isEqualTo(PHOTO_DESCRIPTION);
 
     // Verify the photosets interface got the command to create the correct album

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
@@ -90,6 +90,10 @@ public class GoogleTransferExtension implements TransferExtension {
     }
 
     Monitor monitor = context.getMonitor();
+    String photoAlbumPrefix = context.getSetting("imported_photos_album_prefix", GooglePhotosImporter.DEFAULT_ALBUM_PREFIX);
+    String photoPrefix = context.getSetting("imported_photos_photo_prefix", GooglePhotosImporter.DEFAULT_PHOTO_PREFIX);
+    String videoPrefix = context.getSetting("imported_videos_video_prefix", GoogleVideosImporter.DEFAULT_VIDEO_PREFIX);
+    String calendarPrefix = context.getSetting("imported_calendars_calendar_prefix", GoogleCalendarImporter.DEFAULT_CALENDAR_PREFIX);
 
     // Create the GoogleCredentialFactory with the given {@link AppCredentials}.
     GoogleCredentialFactory credentialFactory =
@@ -99,12 +103,12 @@ public class GoogleTransferExtension implements TransferExtension {
     ImmutableMap.Builder<String, Importer> importerBuilder = ImmutableMap.builder();
     importerBuilder.put("BLOBS", new DriveImporter(credentialFactory, jobStore, monitor));
     importerBuilder.put("CONTACTS", new GoogleContactsImporter(credentialFactory));
-    importerBuilder.put("CALENDAR", new GoogleCalendarImporter(credentialFactory));
+    importerBuilder.put("CALENDAR", new GoogleCalendarImporter(credentialFactory, calendarPrefix));
     importerBuilder.put("MAIL", new GoogleMailImporter(credentialFactory, monitor));
     importerBuilder.put("TASKS", new GoogleTasksImporter(credentialFactory));
     importerBuilder.put(
-            "PHOTOS", new GooglePhotosImporter(credentialFactory, jobStore, jsonFactory, monitor));
-    importerBuilder.put("VIDEOS", new GoogleVideosImporter(credentialFactory, jsonFactory, monitor));
+            "PHOTOS", new GooglePhotosImporter(credentialFactory, jobStore, jsonFactory, monitor, photoAlbumPrefix, photoPrefix));
+    importerBuilder.put("VIDEOS", new GoogleVideosImporter(credentialFactory, jsonFactory, monitor, videoPrefix));
     importerMap = importerBuilder.build();
 
     ImmutableMap.Builder<String, Exporter> exporterBuilder = ImmutableMap.builder();

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -41,8 +41,8 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 public class GooglePhotosImporter
     implements Importer<TokensAndUrlAuthData, PhotosContainerResource> {
 
-  // TODO: internationalize copy prefix
-  private static final String COPY_PREFIX = "Copy of ";
+  public static final String DEFAULT_PHOTO_PREFIX = "Copy of ";
+  public static final String DEFAULT_ALBUM_PREFIX = "Copy of ";
 
   private final GoogleCredentialFactory credentialFactory;
   private final TemporaryPerJobDataStore jobStore;
@@ -50,13 +50,17 @@ public class GooglePhotosImporter
   private final ImageStreamProvider imageStreamProvider;
   private volatile GooglePhotosInterface photosInterface;
   private final Monitor monitor;
+  private final String albumPrefix;
+  private final String photoPrefix;
 
   public GooglePhotosImporter(
       GoogleCredentialFactory credentialFactory,
       TemporaryPerJobDataStore jobStore,
       JsonFactory jsonFactory,
-      Monitor monitor) {
-    this(credentialFactory, jobStore, jsonFactory, null, new ImageStreamProvider(), monitor);
+      Monitor monitor,
+      String albumPrefix,
+      String photoPrefix) {
+    this(credentialFactory, jobStore, jsonFactory, null, new ImageStreamProvider(), monitor, albumPrefix, photoPrefix);
   }
 
   @VisibleForTesting
@@ -66,13 +70,17 @@ public class GooglePhotosImporter
       JsonFactory jsonFactory,
       GooglePhotosInterface photosInterface,
       ImageStreamProvider imageStreamProvider,
-      Monitor monitor) {
+      Monitor monitor,
+      String albumPrefix,
+      String photoPrefix) {
     this.credentialFactory = credentialFactory;
     this.jobStore = jobStore;
     this.jsonFactory = jsonFactory;
     this.photosInterface = photosInterface;
     this.imageStreamProvider = imageStreamProvider;
     this.monitor = monitor;
+    this.albumPrefix = albumPrefix;
+    this.photoPrefix = photoPrefix;
   }
 
   @Override
@@ -113,7 +121,7 @@ public class GooglePhotosImporter
       throws IOException {
     // Set up album
     GoogleAlbum googleAlbum = new GoogleAlbum();
-    googleAlbum.setTitle(COPY_PREFIX + inputAlbum.getName());
+    googleAlbum.setTitle(this.albumPrefix + inputAlbum.getName());
 
     GoogleAlbum responseAlbum = getOrCreatePhotosInterface(authData).createAlbum(googleAlbum);
     return responseAlbum.getId();
@@ -145,7 +153,7 @@ public class GooglePhotosImporter
     if (Strings.isNullOrEmpty(inputPhoto.getDescription())) {
       description = "";
     } else {
-      description = COPY_PREFIX + inputPhoto.getDescription();
+      description = this.photoPrefix + inputPhoto.getDescription();
     }
     NewMediaItem newMediaItem = new NewMediaItem(description, uploadToken);
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -55,17 +55,17 @@ import java.util.UUID;
 public class GoogleVideosImporter
         implements Importer<TokensAndUrlAuthData, VideosContainerResource> {
 
-  // TODO: internationalize copy prefix
-  private static final String COPY_PREFIX = "Copy of ";
+  public static final String DEFAULT_VIDEO_PREFIX = "Copy of ";
 
   private final GoogleCredentialFactory credentialFactory;
   private final ImageStreamProvider videoStreamProvider;
   private volatile GoogleVideosInterface videosInterface;
   private Monitor monitor;
   private JsonFactory jsonFactory;
+  private final String videoPrefix;
 
-  public GoogleVideosImporter(GoogleCredentialFactory credentialFactory, JsonFactory jsonFactory, Monitor monitor) {
-    this(credentialFactory, null, new ImageStreamProvider(), jsonFactory, monitor);
+  public GoogleVideosImporter(GoogleCredentialFactory credentialFactory, JsonFactory jsonFactory, Monitor monitor, String videoPrefix) {
+    this(credentialFactory, null, new ImageStreamProvider(), jsonFactory, monitor, videoPrefix);
   }
 
   @VisibleForTesting
@@ -74,12 +74,14 @@ public class GoogleVideosImporter
           GoogleVideosInterface videosInterface,
           ImageStreamProvider videoStreamProvider,
           JsonFactory jsonFactory,
-          Monitor monitor) {
+          Monitor monitor,
+          String videoPrefix) {
     this.credentialFactory = credentialFactory;
     this.videosInterface = videosInterface;
     this.videoStreamProvider = videoStreamProvider;
     this.jsonFactory = jsonFactory;
     this.monitor = monitor;
+    this.videoPrefix = videoPrefix;
   }
 
   @Override
@@ -123,7 +125,7 @@ public class GoogleVideosImporter
     if (Strings.isNullOrEmpty(inputVideo.getName())) {
       filename = "untitled";
     } else {
-      filename = COPY_PREFIX + inputVideo.getName();
+      filename = this.videoPrefix + inputVideo.getName();
     }
 
     String uploadToken =

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarImporterTest.java
@@ -27,7 +27,6 @@ import org.datatransferproject.types.common.models.calendar.CalendarModel;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -58,7 +57,8 @@ public class GoogleCalendarImporterTest {
 
     executor = new FakeIdempotentImportExecutor();
 
-    calendarService = new GoogleCalendarImporter(credentialFactory, calendarClient);
+    calendarService =
+        new GoogleCalendarImporter(credentialFactory, calendarClient, GoogleCalendarImporter.DEFAULT_CALENDAR_PREFIX);
 
     when(calendarClient.calendars()).thenReturn(calendarCalendars);
     when(calendarClient.events()).thenReturn(calendarEvents);
@@ -75,13 +75,13 @@ public class GoogleCalendarImporterTest {
     // Set up calendar, events, and mocks
     CalendarModel calendarModel = new CalendarModel(modelCalendarId, null, null);
     com.google.api.services.calendar.model.Calendar calendarToInsert =
-        GoogleCalendarImporter.convertToGoogleCalendar(calendarModel);
+        calendarService.convertToGoogleCalendar(calendarModel);
     com.google.api.services.calendar.model.Calendar responseCalendar =
         new com.google.api.services.calendar.model.Calendar().setId(googleCalendarId);
 
     CalendarEventModel eventModel =
         new CalendarEventModel(modelCalendarId, null, null, null, null, null, null, null);
-    Event eventToInsert = GoogleCalendarImporter.convertToGoogleCalendarEvent(eventModel);
+    Event eventToInsert = calendarService.convertToGoogleCalendarEvent(eventModel);
     Event responseEvent = new Event();
 
     when(eventInsertRequest.execute()).thenReturn(responseEvent);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -82,7 +82,7 @@ public class GooglePhotosImporterTest {
     Mockito.when(imageStreamProvider.get(Matchers.anyString())).thenReturn(inputStream);
 
     googlePhotosImporter = new GooglePhotosImporter(null, jobStore, null,
-        googlePhotosInterface, imageStreamProvider, monitor);
+        googlePhotosInterface, imageStreamProvider, monitor, "[Album] copy of ", "[Photo] copy of ");
   }
 
   @Test
@@ -103,7 +103,7 @@ public class GooglePhotosImporterTest {
     // Check results
     ArgumentCaptor<GoogleAlbum> albumArgumentCaptor = ArgumentCaptor.forClass(GoogleAlbum.class);
     Mockito.verify(googlePhotosInterface).createAlbum(albumArgumentCaptor.capture());
-    assertEquals(albumArgumentCaptor.getValue().getTitle(), "Copy of " + albumName);
+    assertEquals(albumArgumentCaptor.getValue().getTitle(), "[Album] copy of " + albumName);
     assertNull(albumArgumentCaptor.getValue().getId());
   }
 
@@ -140,6 +140,6 @@ public class GooglePhotosImporterTest {
     assertEquals(newMediaItems.size(), 1);
     NewMediaItem mediaItem = newMediaItems.get(0);
     assertEquals(mediaItem.getSimpleMediaItem().getUploadToken(), UPLOAD_TOKEN);
-    assertEquals(mediaItem.getDescription(), "Copy of " + PHOTO_DESCRIPTION);
+    assertEquals(mediaItem.getDescription(), "[Photo] copy of " + PHOTO_DESCRIPTION);
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
@@ -72,7 +72,7 @@ public class GoogleVideosImporterTest {
     when(videoStreamProvider.get(Matchers.anyString())).thenReturn(inputStream);
 
     googleVideosImporter =
-        new GoogleVideosImporter(null, googleVideosInterface, videoStreamProvider,null,null);
+        new GoogleVideosImporter(null, googleVideosInterface, videoStreamProvider,null,null, GoogleVideosImporter.DEFAULT_VIDEO_PREFIX);
   }
 
   @Test

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/RememberTheMilkTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/RememberTheMilkTransferExtension.java
@@ -24,6 +24,7 @@ import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.rememberthemilk.tasks.RememberTheMilkService;
 import org.datatransferproject.transfer.rememberthemilk.tasks.RememberTheMilkTasksExporter;
 import org.datatransferproject.transfer.rememberthemilk.tasks.RememberTheMilkTasksImporter;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
@@ -82,8 +83,10 @@ public class RememberTheMilkTransferExtension implements TransferExtension {
 
     Monitor monitor = context.getMonitor();
 
+    String taskPrefix = context.getSetting("imported_tasks_task_prefix", RememberTheMilkService.DEFAULT_TASK_PREFIX);
+
     exporter = new RememberTheMilkTasksExporter(credentials);
-    importer = new RememberTheMilkTasksImporter(credentials, monitor);
+    importer = new RememberTheMilkTasksImporter(credentials, monitor, taskPrefix);
 
     initialized = true;
   }

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/tasks/RememberTheMilkService.java
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/tasks/RememberTheMilkService.java
@@ -42,14 +42,22 @@ import org.datatransferproject.transfer.rememberthemilk.model.tasks.TaskUpdateRe
 import org.datatransferproject.transfer.rememberthemilk.model.tasks.TaskSeries;
 import org.datatransferproject.transfer.rememberthemilk.model.tasks.TimelineCreateResponse;
 
-class RememberTheMilkService {
+public class RememberTheMilkService {
   private static final String BASE_URL = "https://api.rememberthemilk.com/services/rest/";
   private static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
   private RememberTheMilkSignatureGenerator signatureGenerator;
   private XmlMapper xmlMapper = new XmlMapper();
+  private final String taskPrefix;
+
+  public static final String DEFAULT_TASK_PREFIX = "Copy of: ";
 
   RememberTheMilkService(RememberTheMilkSignatureGenerator signatureGenerator) {
+    this(signatureGenerator, DEFAULT_TASK_PREFIX);
+  }
+
+  RememberTheMilkService(RememberTheMilkSignatureGenerator signatureGenerator, String taskPrefix) {
     this.signatureGenerator = signatureGenerator;
+    this.taskPrefix = taskPrefix;
   }
 
   public String createTimeline() throws IOException {
@@ -69,7 +77,7 @@ class RememberTheMilkService {
             "timeline",
             timeline,
             "name",
-            ("Copy of: " + name));
+            (this.taskPrefix + name));
     ListAddResponse response = makeRequest(params, ListAddResponse.class);
     checkState(response.list != null, "Added list is null");
     checkState(response.list.id != 0, "Added list has id of zero");

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/tasks/RememberTheMilkTasksImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/tasks/RememberTheMilkTasksImporter.java
@@ -42,12 +42,14 @@ public class RememberTheMilkTasksImporter implements Importer<AuthData, TaskCont
   private final AppCredentials appCredentials;
   private final Monitor monitor;
   private RememberTheMilkService service;
+  private final String taskPrefix;
 
   public RememberTheMilkTasksImporter(
-      AppCredentials appCredentials, Monitor monitor) {
+      AppCredentials appCredentials, Monitor monitor, String taskPrefix) {
     this.appCredentials = appCredentials;
     this.monitor = monitor;
     this.service = null;
+    this.taskPrefix = taskPrefix;
   }
 
   @Override
@@ -113,6 +115,7 @@ public class RememberTheMilkTasksImporter implements Importer<AuthData, TaskCont
 
   private RememberTheMilkService createService(TokenAuthData authData) {
     return new RememberTheMilkService(
-        new RememberTheMilkSignatureGenerator(appCredentials, authData.getToken()));
+        new RememberTheMilkSignatureGenerator(appCredentials, authData.getToken()),
+        this.taskPrefix);
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/SmugMugTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/SmugMugTransferExtension.java
@@ -28,6 +28,7 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.smugmug.photos.SmugMugInterface;
 import org.datatransferproject.transfer.smugmug.photos.SmugMugPhotosExporter;
 import org.datatransferproject.transfer.smugmug.photos.SmugMugPhotosImporter;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
@@ -54,7 +55,7 @@ public class SmugMugTransferExtension implements TransferExtension {
   @Override
   public Exporter<?, ?> getExporter(String transferDataType) {
     Preconditions.checkArgument(
-        initialized, "Trying to call getExporter before initalizing SmugMugTransferExtension");
+        initialized, "Trying to call getExporter before initializing SmugMugTransferExtension");
     Preconditions.checkArgument(
         SUPPORTED_TYPES.contains(transferDataType),
         "Export of " + transferDataType + " not supported by SmugMug");
@@ -64,7 +65,7 @@ public class SmugMugTransferExtension implements TransferExtension {
   @Override
   public Importer<?, ?> getImporter(String transferDataType) {
     Preconditions.checkArgument(
-        initialized, "Trying to call getImporter before initalizing SmugMugTransferExtension");
+        initialized, "Trying to call getImporter before initializing SmugMugTransferExtension");
     Preconditions.checkArgument(
         SUPPORTED_TYPES.contains(transferDataType),
         "Import of " + transferDataType + " not supported by SmugMug");
@@ -98,10 +99,13 @@ public class SmugMugTransferExtension implements TransferExtension {
       return;
     }
 
+    String photoAlbumPrefix = context.getSetting("imported_photos_album_prefix", SmugMugInterface.DEFAULT_PHOTO_ALBUM_PREFIX);
+    String niceNameAlbumPrefix = context.getSetting("imported_photos_nicename_prefix", SmugMugInterface.DEFAULT_NICE_NAME_PREFIX);
+
     ObjectMapper mapper = context.getService(TypeManager.class).getMapper();
 
     exporter = new SmugMugPhotosExporter(transport, appCredentials, mapper, jobStore, monitor);
-    importer = new SmugMugPhotosImporter(jobStore, transport, appCredentials, mapper, monitor);
+    importer = new SmugMugPhotosImporter(jobStore, transport, appCredentials, mapper, monitor, photoAlbumPrefix, niceNameAlbumPrefix);
     initialized = true;
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
@@ -47,6 +47,8 @@ public class SmugMugPhotosImporter
   private final HttpTransport transport;
   private final ObjectMapper mapper;
   private final Monitor monitor;
+  private final String photoAlbumPrefix;
+  private final String niceNamePrefix;
 
   private SmugMugInterface smugMugInterface;
 
@@ -55,8 +57,10 @@ public class SmugMugPhotosImporter
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,
-      Monitor monitor) {
-    this(null, jobStore, transport, appCredentials, mapper, monitor);
+      Monitor monitor,
+      String photoAlbumPrefix,
+      String niceNamePrefix) {
+    this(null, jobStore, transport, appCredentials, mapper, monitor, photoAlbumPrefix, niceNamePrefix);
   }
 
   @VisibleForTesting
@@ -66,13 +70,17 @@ public class SmugMugPhotosImporter
       HttpTransport transport,
       AppCredentials appCredentials,
       ObjectMapper mapper,
-      Monitor monitor) {
+      Monitor monitor,
+      String photoAlbumPrefix,
+      String niceNamePrefix) {
     this.smugMugInterface = smugMugInterface;
     this.jobStore = jobStore;
     this.transport = transport;
     this.appCredentials = appCredentials;
     this.mapper = mapper;
     this.monitor = monitor;
+    this.photoAlbumPrefix = photoAlbumPrefix;
+    this.niceNamePrefix = niceNamePrefix;
   }
 
   @Override
@@ -137,7 +145,7 @@ public class SmugMugPhotosImporter
   private SmugMugInterface getOrCreateSmugMugInterface(TokenSecretAuthData authData)
       throws IOException {
     return smugMugInterface == null
-        ? new SmugMugInterface(transport, appCredentials, authData, mapper)
+        ? new SmugMugInterface(transport, appCredentials, authData, mapper, photoAlbumPrefix, niceNamePrefix)
         : smugMugInterface;
   }
 


### PR DESCRIPTION
Resolves https://github.com/google/data-transfer-project/issues/762

For the purposes of internationalization and general customization, it would be nice to be able to opt out of the `Copy of` prefixes that the importers are automatically appending. For example (i.e. the self-serving reason for this pull request), we're planning to make the album name an input from users, and don't want to have `Copy of ` appear in front of what they've entered.

Default functionality is unchanged - this change provides the ability to opt out only.

I am not loving the pattern here of adding these values via constructors to every importer. Maybe it's fine, and there aren't additional config values, but it feels a little dirty to inject string like this. If there's a cleaner way to do it, I'm happy to refactor it! Or, if there's a preference that this is applied tactically to just the Google Photos Importer (we only selfishly care about the photo album import right now), happy to do that, too.

@seehamrun PTAL
