### PR TITLE
Fix copy iteration counter

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
@@ -111,8 +111,9 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
       throws CopyException {
 
     String jobIdPrefix = "Job " + jobId + ": ";
+    final int i = COPY_ITERATION_COUNTER.incrementAndGet();
     monitor.debug(
-        () -> jobIdPrefix + "Copy iteration: " + COPY_ITERATION_COUNTER.incrementAndGet());
+        () -> jobIdPrefix + "Copy iteration: " + i);
 
     RetryStrategyLibrary retryStrategyLibrary = retryStrategyLibraryProvider.get();
 

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/PortabilityInMemoryDataCopier.java
@@ -112,8 +112,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
 
     String jobIdPrefix = "Job " + jobId + ": ";
     final int i = COPY_ITERATION_COUNTER.incrementAndGet();
-    monitor.debug(
-        () -> jobIdPrefix + "Copy iteration: " + i);
+    monitor.debug(() -> jobIdPrefix + "Copy iteration: " + i);
 
     RetryStrategyLibrary retryStrategyLibrary = retryStrategyLibraryProvider.get();
 
@@ -165,7 +164,7 @@ final class PortabilityInMemoryDataCopier implements InMemoryDataCopier {
           try {
             jobStore.addCounts(jobId, importResult.getCounts().orElse(null));
           } catch (IOException e) {
-            monitor.debug(()-> jobIdPrefix + "Unable to add counts to job: ", e);
+            monitor.debug(() -> jobIdPrefix + "Unable to add counts to job: ", e);
           }
         }
       } catch (RetryException | RuntimeException e) {


### PR DESCRIPTION
Incrementing in the string supplier causes multiple increments per iteration if there are multiple monitors.