### PR TITLE
Add gettoken to authdata

### DIFF
--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/AuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/AuthData.java
@@ -18,4 +18,6 @@ package org.datatransferproject.types.transfer.auth;
 import org.datatransferproject.types.common.PortableType;
 
 /** Base type for authentication data. */
-public abstract class AuthData extends PortableType {}
+public abstract class AuthData extends PortableType {
+  public abstract String getToken();
+}

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/CookiesAndUrlAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/CookiesAndUrlAuthData.java
@@ -13,8 +13,7 @@ public class CookiesAndUrlAuthData extends AuthData {
 
   @JsonCreator
   public CookiesAndUrlAuthData(
-      @JsonProperty("cookies") List<String> cookies,
-      @JsonProperty("url") String url) {
+      @JsonProperty("cookies") List<String> cookies, @JsonProperty("url") String url) {
     this.cookies = cookies;
     this.url = url;
   }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/CookiesAndUrlAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/CookiesAndUrlAuthData.java
@@ -29,6 +29,6 @@ public class CookiesAndUrlAuthData extends AuthData {
   @Override
   public String getToken() {
     // CookiesAndUrlAuthData is the only class not to have a token.
-    return "";
+    throw new UnsupportedOperationException("CookiesAndUrlAuthData does not have a token.");
   }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/CookiesAndUrlAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/CookiesAndUrlAuthData.java
@@ -26,4 +26,10 @@ public class CookiesAndUrlAuthData extends AuthData {
   public List<String> getCookies() {
     return cookies;
   }
+
+  @Override
+  public String getToken() {
+    // CookiesAndUrlAuthData is the only class not to have a token.
+    return "";
+  }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokenAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokenAuthData.java
@@ -14,6 +14,7 @@ public class TokenAuthData extends AuthData {
     this.token = token;
   }
 
+  @Override
   public String getToken() {
     return token;
   }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokenSecretAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokenSecretAuthData.java
@@ -12,8 +12,7 @@ public class TokenSecretAuthData extends AuthData {
 
   @JsonCreator
   public TokenSecretAuthData(
-      @JsonProperty("token") String token,
-      @JsonProperty("secret") String secret) {
+      @JsonProperty("token") String token, @JsonProperty("secret") String secret) {
     this.token = token;
     this.secret = secret;
   }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokenSecretAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokenSecretAuthData.java
@@ -18,6 +18,7 @@ public class TokenSecretAuthData extends AuthData {
     this.secret = secret;
   }
 
+  @Override
   public String getToken() {
     return token;
   }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokensAndUrlAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokensAndUrlAuthData.java
@@ -32,4 +32,9 @@ public class TokensAndUrlAuthData extends AuthData {
   public String getTokenServerEncodedUrl() {
     return tokenServerEncodedUrl;
   }
+
+  @Override
+  public String getToken() {
+    return getAccessToken();
+  }
 }


### PR DESCRIPTION
Most subclasses of AuthData have a way to get a token. We currently use introspection to get tokens for revocation but we have to use java reflection. This would allow us to get the token for any AuthData.

It's a bit of a fudge for the CookiesAndUrlAuthData so I'm prepared to make an abstract subclass of AuthData if that is preferred.
