### PR TITLE
Fix counts nullpointerexception

### DIFF
--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/ImportResult.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/ImportResult.java
@@ -3,9 +3,7 @@ package org.datatransferproject.spi.transfer.provider;
 import java.util.Map;
 import java.util.Optional;
 
-/**
- * The result of an item import operation, after retries.
- */
+/** The result of an item import operation, after retries. */
 public class ImportResult {
 
   public static final ImportResult OK = new ImportResult(ResultType.OK);
@@ -47,23 +45,17 @@ public class ImportResult {
     this.counts = Optional.ofNullable(counts);
   }
 
-  /**
-   * Returns the type of result.
-   */
+  /** Returns the type of result. */
   public ResultType getType() {
     return type;
   }
 
-  /**
-   * Returns the throwable or an empty optional if no throwable is present.
-   */
+  /** Returns the throwable or an empty optional if no throwable is present. */
   public Optional<Throwable> getThrowable() {
     return throwable;
   }
 
-  /**
-   * Returns the number of imported items or an empty optional if no mapping is present.
-   */
+  /** Returns the number of imported items or an empty optional if no mapping is present. */
   public Optional<Map<String, Integer>> getCounts() {
     return counts;
   }
@@ -76,18 +68,12 @@ public class ImportResult {
     return new ImportResult(type, throwable, newCounts);
   }
 
-  /**
-   * Result types.
-   */
+  /** Result types. */
   public enum ResultType {
-    /**
-     * Indicates a successful import.
-     */
+    /** Indicates a successful import. */
     OK,
 
-    /**
-     * Indicates an unrecoverable error was raised.
-     */
+    /** Indicates an unrecoverable error was raised. */
     ERROR
   }
 }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/ImportResult.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/ImportResult.java
@@ -44,7 +44,7 @@ public class ImportResult {
   public ImportResult(ResultType type, Optional<Throwable> throwable, Map<String, Integer> counts) {
     this.type = type;
     this.throwable = throwable;
-    this.counts = Optional.of(counts);
+    this.counts = Optional.ofNullable(counts);
   }
 
   /**

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
@@ -19,12 +19,17 @@ package org.datatransferproject.types.common.models.videos;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.datatransferproject.types.common.models.ContainerResource;
 
 import java.util.Collection;
 import java.util.Objects;
 
 public class VideosContainerResource extends ContainerResource {
+  private static final String VIDEOS_COUNT_DATA_NAME = "videosCount";
+  private static final String ALBUMS_COUNT_DATA_NAME = "albumsCount";
+
   private final Collection<VideoAlbum> albums;
   private final Collection<VideoObject> videos;
 
@@ -42,6 +47,14 @@ public class VideosContainerResource extends ContainerResource {
 
   public Collection<VideoObject> getVideos() {
     return videos;
+  }
+
+  @Override
+  public Map<String, Integer> getCounts() {
+    return new ImmutableMap.Builder<String, Integer>()
+        .put(VIDEOS_COUNT_DATA_NAME, videos.size())
+        .put(ALBUMS_COUNT_DATA_NAME, albums.size())
+        .build();
   }
 
   @Override

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
@@ -20,11 +20,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import org.datatransferproject.types.common.models.ContainerResource;
-
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
+import org.datatransferproject.types.common.models.ContainerResource;
 
 public class VideosContainerResource extends ContainerResource {
   private static final String VIDEOS_COUNT_DATA_NAME = "videosCount";
@@ -35,8 +34,8 @@ public class VideosContainerResource extends ContainerResource {
 
   @JsonCreator
   public VideosContainerResource(
-          @JsonProperty("albums") Collection<VideoAlbum> albums,
-          @JsonProperty("videos") Collection<VideoObject> videos) {
+      @JsonProperty("albums") Collection<VideoAlbum> albums,
+      @JsonProperty("videos") Collection<VideoObject> videos) {
     this.albums = albums == null ? ImmutableList.of() : albums;
     this.videos = videos == null ? ImmutableList.of() : videos;
   }
@@ -62,7 +61,7 @@ public class VideosContainerResource extends ContainerResource {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     VideosContainerResource that = (VideosContainerResource) o;
-    return Objects.equals(getAlbums(), that.getAlbums()) &&
-            Objects.equals(getVideos(), that.getVideos());
+    return Objects.equals(getAlbums(), that.getAlbums())
+        && Objects.equals(getVideos(), that.getVideos());
   }
 }


### PR DESCRIPTION
By default a DataModel will return a null Counts. This throws a NullPointerException when passed into ImportResult. I make the constructor not throw a NullPointerException and also add a getCounts implementation to VideosContainerResource.