### PR TITLE
Fix AuthData serialization issues.

### DIFF
--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/CookiesAndUrlAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/CookiesAndUrlAuthData.java
@@ -1,6 +1,7 @@
 package org.datatransferproject.types.transfer.auth;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.List;
@@ -26,6 +27,7 @@ public class CookiesAndUrlAuthData extends AuthData {
     return cookies;
   }
 
+  @JsonIgnore
   @Override
   public String getToken() {
     // CookiesAndUrlAuthData is the only class not to have a token.

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokensAndUrlAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokensAndUrlAuthData.java
@@ -1,6 +1,7 @@
 package org.datatransferproject.types.transfer.auth;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -33,6 +34,7 @@ public class TokensAndUrlAuthData extends AuthData {
     return tokenServerEncodedUrl;
   }
 
+  @JsonIgnore
   @Override
   public String getToken() {
     return getAccessToken();

--- a/portability-types-transfer/src/test/java/org/datatransferproject/types/transfer/auth/AuthDataSerializationTest.java
+++ b/portability-types-transfer/src/test/java/org/datatransferproject/types/transfer/auth/AuthDataSerializationTest.java
@@ -1,0 +1,87 @@
+package org.datatransferproject.types.transfer.auth;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AuthDataSerializationTest {
+
+  private ObjectMapper objectMapper;
+
+  @Before
+  public void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerSubtypes(CookiesAndUrlAuthData.class, TokenAuthData.class,
+        TokensAndUrlAuthData.class, TokenSecretAuthData.class);
+  }
+
+  @Test
+  public void verifyCookiesAndUrlAuthData() throws IOException {
+    final ArrayList<String> cookies = Lists.newArrayList("cookie_1", "cookie_2");
+    final String url = "https://www.example.com/auth";
+    final CookiesAndUrlAuthData authData = new CookiesAndUrlAuthData(
+        cookies,
+        url);
+
+    final String s = objectMapper.writeValueAsString(authData);
+    final AuthData readValue = objectMapper.readValue(s, AuthData.class);
+    assertTrue("The read AuthData should be an instance of CookiesAndUrlAuthData",
+        readValue instanceof CookiesAndUrlAuthData);
+    final CookiesAndUrlAuthData readAuthData = (CookiesAndUrlAuthData) readValue;
+    assertEquals("Expect cookies to be the same", cookies, readAuthData.getCookies());
+    assertEquals("Expect url to be the same", url, readAuthData.getUrl());
+  }
+
+  @Test
+  public void verifyTokenAuthData() throws IOException {
+    final String token = "my_secret_token";
+    final TokenAuthData authData = new TokenAuthData(token);
+
+    final String s = objectMapper.writeValueAsString(authData);
+    final AuthData readValue = objectMapper.readValue(s, AuthData.class);
+    assertTrue("The read AuthData should be an instance of TokenAuthData",
+        readValue instanceof TokenAuthData);
+    final TokenAuthData readAuthData = (TokenAuthData) readValue;
+    assertEquals("Expect token to be the same", token, readAuthData.getToken());
+  }
+
+  @Test
+  public void verifyTokensAndUrlAuthData() throws IOException {
+    final String accessToken = "my_access_token";
+    final String refreshToken = "my_refresh_token";
+    final String url = "https://www.example.com/auth";
+    final TokensAndUrlAuthData authData = new TokensAndUrlAuthData(accessToken, refreshToken, url);
+
+    final String s = objectMapper.writeValueAsString(authData);
+    final AuthData readValue = objectMapper.readValue(s, AuthData.class);
+    assertTrue("The read AuthData should be an instance of TokenAuthData",
+        readValue instanceof TokensAndUrlAuthData);
+    final TokensAndUrlAuthData readAuthData = (TokensAndUrlAuthData) readValue;
+    assertEquals("Expect access token to be the same", accessToken, readAuthData.getAccessToken());
+    assertEquals("Expect refresh token to be the same", refreshToken, readAuthData.getRefreshToken());
+    assertEquals("Expect url to be the same", url, readAuthData.getTokenServerEncodedUrl());
+  }
+
+  @Test
+  public void verifyTokenSecretAuthData() throws IOException {
+    final String token = "my_secret_token";
+    final String secret = "my_secret";
+    final TokenSecretAuthData authData = new TokenSecretAuthData(token, secret);
+
+    final String s = objectMapper.writeValueAsString(authData);
+    final AuthData readValue = objectMapper.readValue(s, AuthData.class);
+    assertTrue("The read AuthData should be an instance of TokenAuthData",
+        readValue instanceof TokenSecretAuthData);
+    final TokenSecretAuthData readAuthData = (TokenSecretAuthData) readValue;
+    assertEquals("Expect token to be the same", token, readAuthData.getToken());
+    assertEquals("Expect secret to be the same", secret, readAuthData.getSecret());
+  }
+}


### PR DESCRIPTION
Do not serialize the getToken methods on AuthData classes where it is a proxy for another field. Also adds in a test that would have picked up this bug.

Should fix issue https://github.com/google/data-transfer-project/issues/786