### PR TITLE
If temp data exists in the FlickrImporter, don't try to create it again

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -29,6 +29,12 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.RateLimiter;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collection;
+import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
@@ -41,13 +47,6 @@ import org.datatransferproject.types.common.models.photos.PhotosContainerResourc
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.AuthData;
 import org.datatransferproject.types.transfer.serviceconfig.TransferServiceConfig;
-
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.Collection;
-import java.util.UUID;
 
 public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerResource> {
 
@@ -137,9 +136,17 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
   // photo in it, so we have to wait for the first photo to create the album
   private void storeAlbums(UUID jobId, Collection<PhotoAlbum> albums) throws IOException {
     for (PhotoAlbum album : albums) {
-      jobStore.create(jobId,
+      FlickrTempPhotoData temp =
+          jobStore.findData(
+              jobId,
               ORIGINAL_ALBUM_PREFIX + album.getId(),
-              new FlickrTempPhotoData(album.getName(), album.getDescription()));
+              FlickrTempPhotoData.class);
+
+      if (temp == null) {
+        jobStore.create(jobId,
+            ORIGINAL_ALBUM_PREFIX + album.getId(),
+            new FlickrTempPhotoData(album.getName(), album.getDescription()));
+      }
     }
   }
 

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -114,7 +114,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
         data.getAlbums() != null || data.getPhotos() != null, "Error: There is no data to import");
 
     if (data.getAlbums() != null) {
-      storeAlbumbs(jobId, data.getAlbums());
+      storeAlbums(jobId, data.getAlbums());
     }
 
     if (data.getPhotos() != null) {
@@ -135,7 +135,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
 
   // Store any album data in the cache because Flickr only allows you to create an album with a
   // photo in it, so we have to wait for the first photo to create the album
-  private void storeAlbumbs(UUID jobId, Collection<PhotoAlbum> albums) throws IOException {
+  private void storeAlbums(UUID jobId, Collection<PhotoAlbum> albums) throws IOException {
     for (PhotoAlbum album : albums) {
       jobStore.create(jobId,
               ORIGINAL_ALBUM_PREFIX + album.getId(),


### PR DESCRIPTION
This can happen if the job was restarted, (since we do all the listing regardless if it the job is a restart). 

This doesnt cause any issues right now and isnt reported as a failure (because it doesnt go through the idempotentexecutor), but would if there were ever photos and albums in the same import call because we would fail before writing out the photos. 