### PR TITLE
Change default frontend apiBaseUrl to use `document.baseURI` if present

### DIFF
--- a/client-rest/src/environments/environment.ts
+++ b/client-rest/src/environments/environment.ts
@@ -5,5 +5,5 @@
 export const environment = {
     production: false,
     encryptionScheme: "jwe", // supported values are "jwe" and "cleartext" which must correspond to the schemes supported by the server
-    apiBaseUrl: 'https://localhost:3000'
+    apiBaseUrl: ((typeof document !== "undefined") && document.baseURI) || 'https://localhost:3000'
 };


### PR DESCRIPTION
idea discussed around here https://github.com/google/data-transfer-project/issues/782#issuecomment-554247636

Whereas the previous default of 'https://localhost:3000' works only in a very narrow set of possible configurations, `document.baseURI` should return whatever base URI at which the page is accessed, even if another hostname or port.