### PR TITLE
Exit GooglePhotosInterface on an empty photo

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -134,6 +134,10 @@ public class GooglePhotosInterface {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     content.writeTo(outputStream);
     byte[] contentBytes = outputStream.toByteArray();
+    if (contentBytes.length == 0) {
+      // Google Photos cannot add an empty photo so gracefully ignore
+      return "EMPTY_PHOTO";
+    }
     HttpContent httpContent = new ByteArrayContent(null, contentBytes);
 
     return makePostRequest(
@@ -207,8 +211,8 @@ public class GooglePhotosInterface {
     }
   }
 
-  private HttpResponse handleHttpResponseException(SupplierWithIO<HttpRequest> httpRequest, HttpResponseException e)
-      throws IOException {
+  private HttpResponse handleHttpResponseException(
+      SupplierWithIO<HttpRequest> httpRequest, HttpResponseException e) throws IOException {
     // if the response is "unauthorized", refresh the token and try the request again
     if (e.getStatusCode() == 401) {
       monitor.info(() -> "Attempting to refresh authorization token");


### PR DESCRIPTION
I wanted to handle this issue without marking a transfer as failed. I'm wondering if there should be a category of exceptions/return codes which indicate that there was an issue but that do not result in a transfer being marked as failed? This is a simple fix but I'm happy to handle this edge case in another way if preferred.