### PR TITLE
 Revert "If temp data exists in the FlickrImporter, don't try to create it again (#790)"

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -29,12 +29,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.RateLimiter;
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.Collection;
-import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
@@ -47,6 +41,13 @@ import org.datatransferproject.types.common.models.photos.PhotosContainerResourc
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.AuthData;
 import org.datatransferproject.types.transfer.serviceconfig.TransferServiceConfig;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collection;
+import java.util.UUID;
 
 public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerResource> {
 
@@ -113,7 +114,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
         data.getAlbums() != null || data.getPhotos() != null, "Error: There is no data to import");
 
     if (data.getAlbums() != null) {
-      storeAlbums(jobId, data.getAlbums());
+      storeAlbumbs(jobId, data.getAlbums());
     }
 
     if (data.getPhotos() != null) {
@@ -134,19 +135,11 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
 
   // Store any album data in the cache because Flickr only allows you to create an album with a
   // photo in it, so we have to wait for the first photo to create the album
-  private void storeAlbums(UUID jobId, Collection<PhotoAlbum> albums) throws IOException {
+  private void storeAlbumbs(UUID jobId, Collection<PhotoAlbum> albums) throws IOException {
     for (PhotoAlbum album : albums) {
-      FlickrTempPhotoData temp =
-          jobStore.findData(
-              jobId,
+      jobStore.create(jobId,
               ORIGINAL_ALBUM_PREFIX + album.getId(),
-              FlickrTempPhotoData.class);
-
-      if (temp == null) {
-        jobStore.create(jobId,
-            ORIGINAL_ALBUM_PREFIX + album.getId(),
-            new FlickrTempPhotoData(album.getName(), album.getDescription()));
-      }
+              new FlickrTempPhotoData(album.getName(), album.getDescription()));
     }
   }
 


### PR DESCRIPTION
This reverts commit bbc38c8b18640536cc630c710f06f4a194289784.

Reverting because this actually imposes a couple of other issues on our side and needs to be implemented on the jobstore side of things first. Also this isn't consistent across the other importers that use this sort of temp data