### PR TITLE
Fix Demo Server environment.apiBaseUrl

### DIFF
--- a/client-rest/src/environments/environment.ts
+++ b/client-rest/src/environments/environment.ts
@@ -5,5 +5,5 @@
 export const environment = {
     production: false,
     encryptionScheme: "jwe", // supported values are "jwe" and "cleartext" which must correspond to the schemes supported by the server
-    apiBaseUrl: ((typeof document !== "undefined") && document.baseURI) || 'https://localhost:3000'
+    apiBaseUrl: ((typeof document !== "undefined") && document.baseURI.replace(/\/+$/, "")) || 'https://localhost:3000'
 };


### PR DESCRIPTION
Fixes #800 

With this change, API calls will now be formed by a base URL that is cleaned up to remove any trailing slashes. 