### PR TITLE
Add photo model coercion logic to generally account for loose photos and album size

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -34,19 +34,18 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Stream;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.datatransferproject.transfer.smugmug.photos.model.SmugMugImageUploadResponse;
 import org.datatransferproject.transfer.smugmug.photos.model.SmugMugAlbumImageResponse;
 import org.datatransferproject.transfer.smugmug.photos.model.SmugMugAlbumResponse;
 import org.datatransferproject.transfer.smugmug.photos.model.SmugMugAlbumsResponse;
+import org.datatransferproject.transfer.smugmug.photos.model.SmugMugImageUploadResponse;
 import org.datatransferproject.transfer.smugmug.photos.model.SmugMugResponse;
 import org.datatransferproject.transfer.smugmug.photos.model.SmugMugUser;
 import org.datatransferproject.transfer.smugmug.photos.model.SmugMugUserResponse;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
-import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.scribe.builder.ServiceBuilder;
 import org.scribe.model.OAuthRequest;
 import org.scribe.model.Response;
@@ -246,8 +245,17 @@ public class SmugMugInterface {
 
     Response response = request.send();
     if (response.getCode() < 200 || response.getCode() >= 300) {
+      if (response.getCode() == 400) {
+        throw new IOException(
+            String.format(
+                "Error occurred in request for %s, code: %s, message: %s, request: %s, bodyParams: %s, payload: %s",
+                fullUrl,
+                response.getCode(), response.getMessage(), request.toString(),
+                request.getBodyParams(), request.getBodyContents()));
+      }
       throw new IOException(
-          String.format("Error occurred in request for %s : %s", fullUrl, response.getMessage()));
+          String.format("Error occurred in request for %s, code: %s, message: %s", fullUrl,
+              response.getCode(), response.getMessage()));
     }
 
     return mapper.readValue(response.getBody(), typeReference);

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
@@ -42,7 +42,11 @@ import static com.google.common.base.Preconditions.checkState;
 public class SmugMugPhotosImporter
     implements Importer<TokenSecretAuthData, PhotosContainerResource> {
 
-  private static final int MAX_ALBUM_SIZE=5000;
+  // Album size specified here:
+  // https://github.com/google/data-transfer-project/pull/805/files
+  private static final int MAX_ALBUM_SIZE = 5000;
+  // Smugmug doesn't allow photos to exist outside of a folder
+  private static final boolean ALLOW_LOOSE_PHOTOS = false;
 
   private final TemporaryPerJobDataStore jobStore;
   private final AppCredentials appCredentials;
@@ -83,7 +87,7 @@ public class SmugMugPhotosImporter
       IdempotentImportExecutor idempotentExecutor,
       TokenSecretAuthData authData,
       PhotosContainerResource data) throws Exception {
-    data.transmogrifyAlbums(MAX_ALBUM_SIZE, false);
+    data.transmogrifyAlbums(MAX_ALBUM_SIZE, ALLOW_LOOSE_PHOTOS);
     try {
       SmugMugInterface smugMugInterface = getOrCreateSmugMugInterface(authData);
       for (PhotoAlbum album : data.getAlbums()) {

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoAlbum.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoAlbum.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
 import java.util.Objects;
+import java.util.List;
+import java.util.ArrayList;
 
 public class PhotoAlbum {
   private final String id;
@@ -62,5 +64,19 @@ public class PhotoAlbum {
   public int hashCode() {
 
     return Objects.hash(id);
+  }
+
+  public List<PhotoAlbum> split(int numberOfNewAlbums){
+    List<PhotoAlbum> newAlbums = new ArrayList<>();
+    for(int i = 1; i <= numberOfNewAlbums; i++){
+      newAlbums.add(
+        new PhotoAlbum(
+          String.format("%s-pt%d", id, i),
+          String.format("%s (%d/%d)", id, i, numberOfNewAlbums),
+          description
+        )
+      );
+    }
+    return newAlbums;
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoAlbum.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoAlbum.java
@@ -66,6 +66,10 @@ public class PhotoAlbum {
     return Objects.hash(id);
   }
 
+  // Generates PhotoAlbum objects that represent fragments of this one.
+  // Used in cases where an album from the originating service is larger than the allowable size
+  // in the destination service.
+  // If an album "MyAlbum" is split into 3, the results will be "MyAlbum (1/3)", etc.
   public List<PhotoAlbum> split(int numberOfNewAlbums){
     List<PhotoAlbum> newAlbums = new ArrayList<>();
     for(int i = 1; i <= numberOfNewAlbums; i++){

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoModel.java
@@ -26,7 +26,7 @@ public class PhotoModel {
   private final String fetchableUrl;
   private final String description;
   private final String mediaType;
-  private final String albumId;
+  private String albumId;
   private final boolean inTempStore;
   private String dataId;
 
@@ -89,7 +89,7 @@ public class PhotoModel {
         .add("inTempStore", inTempStore)
         .toString();
   }
-  
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -101,5 +101,9 @@ public class PhotoModel {
             Objects.equal(getMediaType(), that.getMediaType()) &&
             Objects.equal(getDataId(), that.getDataId()) &&
             Objects.equal(getAlbumId(), that.getAlbumId());
+  }
+
+  public void reassignToAlbum(String newAlbum){
+    this.albumId = newAlbum;
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoModel.java
@@ -103,6 +103,9 @@ public class PhotoModel {
             Objects.equal(getAlbumId(), that.getAlbumId());
   }
 
+  // Assign this photo to a different album. Used in cases where an album is too large and
+  // needs to be divided into smaller albums, the photos will each get reassigned to new
+  // albumnIds.
   public void reassignToAlbum(String newAlbum){
     this.albumId = newAlbum;
   }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotosContainerResource.java
@@ -89,13 +89,15 @@ public class PhotosContainerResource extends ContainerResource {
   }
 
   // Coerce the albums of the transfer using the specification provided, e.g.
-  // limiting max album size or grouping un-collected photos into a root album
+  // limiting max album size or grouping un-collected photos into a root album.
   public void transmogrifyAlbums(int maxSize, boolean allowRootPhotos){
       ensureRootAlbum(allowRootPhotos);
       ensureAlbumSize(maxSize);
   }
 
-  public void ensureAlbumSize(int maxSize){
+  // Splits albumns that are too large into albums that are smaller than {maxSize}.
+  // A value of maxSize=-1 signals that there is no maximum
+  void ensureAlbumSize(int maxSize){
     if (maxSize == -1){
       // No max size; no need to go through that code.
       return;
@@ -108,7 +110,7 @@ public class PhotosContainerResource extends ContainerResource {
     // Go through groups, splitting up anything that's too big
     for(Entry<String,Collection<PhotoModel>> entry : albumGroups.asMap().entrySet()){
       if (entry.getValue().size() > maxSize) {
-        for(PhotoAlbum album: albums){
+        for(PhotoAlbum album : albums){
           if (album.getId() != entry.getKey()){
             break;
           }
@@ -134,6 +136,8 @@ public class PhotosContainerResource extends ContainerResource {
     }
   }
 
+  // Ensures that the model obeys the restrictions of the destination service, grouping all
+  // un-nested photos into their own root album if allowRootPhotos is true, noop otherwise
   void ensureRootAlbum(boolean allowRootPhotos){
     if (allowRootPhotos) {
       return;

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotosContainerResource.java
@@ -22,9 +22,18 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.datatransferproject.types.common.models.ContainerResource;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 import java.util.Collection;
 import java.util.Objects;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Iterator;
+import java.util.HashSet;
+import java.util.Map.Entry;
 
 /** A Wrapper for all the possible objects that can be returned by a photos exporter. */
 @JsonTypeName("PhotosContainerResource")
@@ -32,8 +41,9 @@ public class PhotosContainerResource extends ContainerResource {
 
   public static final String PHOTOS_COUNT_DATA_NAME = "photosCount";
   public static final String ALBUMS_COUNT_DATA_NAME = "albumsCount";
+  private static final String ROOT_ALBUM = "Transferred Photos";
 
-  private final Collection<PhotoAlbum> albums;
+  private Collection<PhotoAlbum> albums;
   private final Collection<PhotoModel> photos;
 
   @JsonCreator
@@ -72,5 +82,79 @@ public class PhotosContainerResource extends ContainerResource {
   @Override
   public int hashCode() {
     return Objects.hash(getAlbums(), getPhotos());
+  }
+
+  public void transmogrifyAlbums(int maxSize){
+    transmogrifyAlbums(maxSize, true);
+  }
+
+  // Coerce the albums of the transfer using the specification provided, e.g.
+  // limiting max album size or grouping un-collected photos into a root album
+  public void transmogrifyAlbums(int maxSize, boolean allowRootPhotos){
+      ensureRootAlbum(allowRootPhotos);
+      ensureAlbumSize(maxSize);
+  }
+
+  public void ensureAlbumSize(int maxSize){
+    if (maxSize == -1){
+      // No max size; no need to go through that code.
+      return;
+    }
+    // Group photos by albumId
+    Multimap<String, PhotoModel> albumGroups = ArrayListMultimap.create();
+    for (PhotoModel photo: photos){
+      albumGroups.put(photo.getAlbumId(), photo);
+    }
+    // Go through groups, splitting up anything that's too big
+    for(Entry<String,Collection<PhotoModel>> entry : albumGroups.asMap().entrySet()){
+      if (entry.getValue().size() > maxSize) {
+        for(PhotoAlbum album: albums){
+          if (album.getId() != entry.getKey()){
+            break;
+          }
+          // Create new partial album objects and reassign photos to those albums
+          List<PhotoAlbum> newAlbums = album.split(-Math.floorDiv(- entry.getValue().size(), maxSize));
+          Iterator<PhotoModel> remainingAlbums = entry.getValue().iterator();
+          for (PhotoAlbum newAlbum: newAlbums){
+            for (int i = 0; i < maxSize; i++){
+              remainingAlbums.next().reassignToAlbum(newAlbum.getId());
+              if (!remainingAlbums.hasNext()){
+                break;
+              }
+            }
+          }
+
+          // Replace original album in state
+          List<PhotoAlbum> albums_ = new ArrayList<PhotoAlbum>(albums);
+          albums_.remove(album);
+          albums_.addAll(newAlbums);
+          this.albums = albums_;
+        }
+      }
+    }
+  }
+
+  void ensureRootAlbum(boolean allowRootPhotos){
+    if (allowRootPhotos) {
+      return;
+    }
+    PhotoAlbum rootAlbum = new PhotoAlbum(
+        ROOT_ALBUM,
+        ROOT_ALBUM,
+        "A copy of your transferred photos that were not in any album"
+    );
+    boolean usedRootAlbum = false;
+
+    for (PhotoModel photo: photos){
+      if (photo.getAlbumId() == null) {
+        photo.reassignToAlbum(rootAlbum.getId());
+        usedRootAlbum = true;
+      }
+    }
+    if (usedRootAlbum){
+      List<PhotoAlbum> albums_ = new ArrayList<PhotoAlbum>(albums);
+      albums_.add(rootAlbum);
+      this.albums = albums_;
+    }
   }
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotosContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotosContainerResourceTest.java
@@ -37,4 +37,113 @@ public class PhotosContainerResourceTest {
     Truth.assertThat(deserialized.getAlbums()).hasSize(1);
     Truth.assertThat(deserialized.getPhotos()).hasSize(2);
   }
+
+    @Test
+  public void verifyTransmogrifyAlbums_evenDivision() throws Exception {
+    List<PhotoAlbum> albums =
+        ImmutableList.of(new PhotoAlbum("id1", "albumb1", "This is a fake album"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel("Pic4", "http://fake.com/3.jpg", "A pic", "image/jpg", "p4", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
+
+    PhotosContainerResource data = new PhotosContainerResource(albums, photos);
+    data.transmogrifyAlbums(2);
+    Truth.assertThat(data.getAlbums()).hasSize(2);
+    Truth.assertThat(data.getPhotos()).hasSize(4);
+  }
+
+@Test
+  public void verifyTransmogrifyAlbums_oddDivision() throws Exception {
+    List<PhotoAlbum> albums =
+        ImmutableList.of(new PhotoAlbum("id1", "albumb1", "This is a fake album"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
+
+    PhotosContainerResource data = new PhotosContainerResource(albums, photos);
+    data.transmogrifyAlbums(2);
+    Truth.assertThat(data.getAlbums()).hasSize(2);
+    Truth.assertThat(data.getPhotos()).hasSize(3);
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_oddDivisionWithLoosePhotos() throws Exception {
+    List<PhotoAlbum> albums =
+        ImmutableList.of(new PhotoAlbum("id1", "albumb1", "This is a fake album"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel("Pic4", "http://fake.com/3.jpg", "A pic", "image/jpg", "p4", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false),
+            new PhotoModel(
+                "Pic5", "https://fake.com/pic.png", "fine art", "image/png", "p5", null, false),
+            new PhotoModel(
+                "Pic6", "https://fake.com/pic.png", "fine art", "image/png", "p6", null, false));
+
+    PhotosContainerResource data = new PhotosContainerResource(albums, photos);
+    data.transmogrifyAlbums(2);
+    Truth.assertThat(data.getAlbums()).hasSize(2);
+    Truth.assertThat(data.getPhotos()).hasSize(6);
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_NoLimit() throws Exception {
+    List<PhotoAlbum> albums =
+        ImmutableList.of(new PhotoAlbum("id1", "albumb1", "This is a fake album"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
+
+    PhotosContainerResource data = new PhotosContainerResource(albums, photos);
+    data.transmogrifyAlbums(-1);
+    Truth.assertThat(data.getAlbums()).hasSize(1);
+    Truth.assertThat(data.getPhotos()).hasSize(3);
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_NoRootPhotos() throws Exception {
+    List<PhotoAlbum> albums =
+        ImmutableList.of(new PhotoAlbum("id1", "albumb1", "This is a fake album"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    PhotosContainerResource data = new PhotosContainerResource(albums, photos);
+    data.transmogrifyAlbums(-1, false);
+    Truth.assertThat(data.getAlbums()).hasSize(2);
+    Truth.assertThat(data.getPhotos()).hasSize(3);
+  }
+
 }


### PR DESCRIPTION
Adds a "transmogrification" function to the PhotosContainerResource that allows for coercion to meet a services' particular restrictions (currently album size and existence of loose photos; eventually this could include filetype coercion, size limitation, etc.)

As-implemented, just gets called from the SmugmugPhotosImporter, but in the long run could be generalized to read from some sort of per-service config.