### PR TITLE
Use album id and photo id as the idempotent ids in MicrosoftPhotosImporter

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -115,7 +115,7 @@ public class MicrosoftPhotosImporter implements Importer<TokensAndUrlAuthData, P
     for (PhotoModel photoModel : resource.getPhotos()) {
 
       idempotentImportExecutor.executeAndSwallowIOExceptions(
-          Integer.toString(photoModel.hashCode()),
+          photoModel.getAlbumId() + "-" + photoModel.getDataId(),
           photoModel.getTitle(),
           () -> {
             return importSinglePhoto(photoModel, jobId, idempotentImportExecutor);


### PR DESCRIPTION
We were using the hashcode before which caused the IDs to be different when jobs were restarted. Both the albumid and photoid are used because we need a way to store photos in multiple albums, this is already being done in the flickr and google importers: 

https://github.com/google/data-transfer-project/blob/master/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java#L102

https://github.com/google/data-transfer-project/blob/master/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java#L154