### PR TITLE
Improve job cancellation logging

### DIFF
--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/events/EventCode.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/monitor/events/EventCode.java
@@ -10,6 +10,7 @@ public class EventCode {
 
   public static final EventCode WORKER_CREDS_STORED = new EventCode("WORKER_CREDS_STORED");
   public static final EventCode WORKER_CREDS_TIMEOUT = new EventCode("WORKER_CREDS_TIMEOUT");
+  public static final EventCode WORKER_JOB_CANCELED = new EventCode("WORKER_JOB_CANCELED");
   public static final EventCode WORKER_JOB_ERRORED = new EventCode("WORKER_JOB_ERRORED");
   public static final EventCode WORKER_JOB_FINISHED = new EventCode("WORKER_JOB_FINISHED");
   public static final EventCode WORKER_JOB_STARTED = new EventCode("WORKER_JOB_STARTED");

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
@@ -18,6 +18,7 @@ package org.datatransferproject.transfer;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.inject.Inject;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.launcher.monitor.events.EventCode;
 import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 
@@ -43,11 +44,14 @@ class JobCancelWatchingService extends AbstractScheduledService {
     monitor.debug(() -> "polling for job to check cancellation");
     PortabilityJob currentJob = store.findJob(JobMetadata.getJobId());
     boolean isCanceled = currentJob.state() == PortabilityJob.State.CANCELED;
-    monitor.debug(
-        () -> String.format("Job %s is canceled: %s", JobMetadata.getJobId(), isCanceled));
     if (isCanceled) {
+      monitor.info(
+          () -> String.format("Job %s is canceled", JobMetadata.getJobId()),
+          EventCode.WORKER_JOB_CANCELED);
       monitor.flushLogs();
       System.exit(-1);
+    } else {
+      monitor.debug(() -> String.format("Job %s is not canceled", JobMetadata.getJobId()));
     }
   }
 


### PR DESCRIPTION
Add an EventCode and increase the log level for when a job is terminated because it has been canceled.