### PR TITLE
Add chrome stable to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
             branch: master
 
 addons:
+  chrome: stable
   apt:
     sources:
       - google-chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,12 +67,6 @@ matrix:
 
 addons:
   chrome: stable
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - dpkg
-      - google-chrome-stable
       
 notifications:
   slack:


### PR DESCRIPTION
Not sure why this started failing but this answer and linked documentation suggests this could solve it https://travis-ci.community/t/the-following-packages-cannot-be-authenticated-google-chrome-stable/6866/6