### PR TITLE
Make MicrosoftPhotosImporter use upload sessions

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     testCompile("org.mockito:mockito-core:${mockitoVersion}")
     testCompile project(':extensions:auth:portability-auth-harness-microsoft')
     testCompile group: 'com.squareup.okhttp', name: 'mockwebserver', version: '2.7.5'
+    testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.2.0'
+    testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
 
 }
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/DataChunk.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/DataChunk.java
@@ -5,6 +5,10 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+  This utility class allows us to break up an InputStream into multiple chunks
+  for part-by-part upload to a service, for example to be consumed in an upload session.
+*/
 public class DataChunk {
   private static final int CHUNK_SIZE = 32000 * 1024; // 32000KiB
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/DataChunk.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/DataChunk.java
@@ -1,0 +1,66 @@
+package org.datatransferproject.transfer.microsoft;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DataChunk {
+  private static final int CHUNK_SIZE = 32000 * 1024; // 32000KiB
+
+  private final byte[] data;
+  private final int size;
+  private final int rangeStart;
+  public DataChunk(byte[] data, int size, int rangeStart) {
+    this.data = data;
+    this.size = size;
+    this.rangeStart = rangeStart;
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+
+  public int getStart() {
+    return rangeStart;
+  }
+
+  public int getEnd() {
+    return rangeStart + size - 1;
+  }
+
+  public static List<DataChunk> splitData(InputStream inputStream) throws IOException {
+    ArrayList<DataChunk> chunksToSend = new ArrayList();
+    byte[] data = new byte[CHUNK_SIZE];
+    int totalFileSize = 0;
+    int quantityToSend;
+    int roomLeft = CHUNK_SIZE;
+    int offset = 0;
+    int chunksRead = 0;
+
+    // start timing
+    while ((quantityToSend = inputStream.read(data, offset, roomLeft)) != -1) {
+      offset += quantityToSend;
+      roomLeft -= quantityToSend;
+      if (roomLeft == 0) {
+        chunksToSend.add(new DataChunk(data, CHUNK_SIZE, chunksRead * CHUNK_SIZE));
+        chunksRead++;
+        roomLeft = CHUNK_SIZE;
+        offset = 0;
+        totalFileSize += CHUNK_SIZE;
+        data = new byte[CHUNK_SIZE];
+      }
+    }
+    if (offset != 0) {
+      chunksToSend.add(new DataChunk(data, offset, chunksRead * CHUNK_SIZE));
+      totalFileSize += offset;
+      chunksRead++;
+    }
+    return chunksToSend;
+  }
+
+}

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -209,15 +209,6 @@ public class MicrosoftPhotosImporter
     Response chunkResponse = null;
     for (DataChunk chunk : chunksToSend) {
       chunkResponse = uploadChunk(chunk, photoUploadUrl, totalFileSize, photo.getMediaType());
-      chunkCode = chunkResponse.code();
-      if (chunkCode < 200 || chunkCode > 299) {
-        throw new IOException(
-          "Got error code: " + chunkCode + " message: " + chunkResponse.message() + " body: " + chunkResponse
-          .body().string());
-      }
-      if (chunkCode == 200) {
-        monitor.info(() -> String.format("Uploaded chunk %s-%s successfuly", chunk.getStart(), chunk.getEnd()));
-      }
     }
     // get complete file response
     Preconditions.checkState(chunkCode == 201 || chunkCode == 200, "Got bad response code when finishing uploadSession: %d", chunkCode);
@@ -324,6 +315,15 @@ public class MicrosoftPhotosImporter
       // update auth info, reupload chunk
       uploadRequestBuilder.header("Authorization", "Bearer " + credential.getAccessToken());
       chunkResponse = client.newCall(uploadRequestBuilder.build()).execute();
+    }
+    int chunkCode = chunkResponse.code();
+    if (chunkCode < 200 || chunkCode > 299) {
+      throw new IOException(
+        "Got error code: " + chunkCode + " message: " + chunkResponse.message() + " body: " + chunkResponse
+        .body().string());
+    }
+    if (chunkCode == 200) {
+      monitor.info(() -> String.format("Uploaded chunk %s-%s successfuly", chunk.getStart(), chunk.getEnd()));
     }
     return chunkResponse;
   }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -192,7 +192,7 @@ public class MicrosoftPhotosImporter
   throws IOException {
     BufferedInputStream inputStream = null;
     if (photo.isInTempStore()) {
-      inputStream = new BufferedInputStream(jobStore.getStream(jobId, photo.getFetchableUrl()));
+      inputStream = new BufferedInputStream(jobStore.getStream(jobId, photo.getFetchableUrl()).getStream());
     } else if (photo.getFetchableUrl() != null) {
       inputStream = new BufferedInputStream(new URL(photo.getFetchableUrl()).openStream());
     } else {

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -1,3 +1,38 @@
+package extensions.data - transfer.portability - data - transfer - microsoft.src.main.java.org.datatransferproject.transfer.microsoft.photos;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.microsoft.MicrosoftTransmogrificationConfig;
+import org.datatransferproject.transfer.microsoft.common.MicrosoftCredentialFactory;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.omg.CORBA.Object;
+
 /*
  * Copyright 2018 The Data-Portability Project Authors.
  *
@@ -13,49 +48,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.datatransferproject.transfer.microsoft.photos;
 
-import static com.google.common.base.Preconditions.checkState;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.auth.oauth2.Credential;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.lang.Long;
-import java.time.Instant;
-import java.time.Duration;
-import java.util.Map;
-import java.util.Timer;
-import java.util.UUID;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okhttp3.internal.Util;
-import okio.BufferedSink;
-import okio.Okio;
-import okio.Source;
-import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
-import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
-import org.datatransferproject.spi.transfer.provider.ImportResult;
-import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.transfer.microsoft.MicrosoftTransmogrificationConfig;
-import org.datatransferproject.transfer.microsoft.common.MicrosoftCredentialFactory;
-import org.datatransferproject.types.common.models.photos.PhotoAlbum;
-import org.datatransferproject.types.common.models.photos.PhotoModel;
-import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
-import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 /**
  * Imports albums and photos to OneDrive using the Microsoft Graph API.

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -225,6 +225,8 @@ public class MicrosoftPhotosImporter implements Importer<TokensAndUrlAuthData, P
     return this.credential;
   }
 
+  // Request an upload session to the OneDrive api so that we can upload chunks
+  // to the returned URL
   private String createUploadSession(PhotoModel photo, IdempotentImportExecutor idempotentImportExecutor) throws IOException {
 
     // Forming the URL to create an upload session
@@ -284,8 +286,8 @@ public class MicrosoftPhotosImporter implements Importer<TokensAndUrlAuthData, P
     return (String) responseData.get("uploadUrl");
   }
 
-
-  // PUT to {uploadurl}
+  // Uploads a single DataChunk to an upload URL
+  // PUT to {photoUploadUrl}
   // HEADERS
   // Content-Length: {chunk size in bytes}
   // Content-Range: bytes {begin}-{end}/{total size}

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -1,38 +1,3 @@
-package extensions.data - transfer.portability - data - transfer - microsoft.src.main.java.org.datatransferproject.transfer.microsoft.photos;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.auth.oauth2.Credential;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.net.URL;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.UUID;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
-import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
-import org.datatransferproject.spi.transfer.provider.ImportResult;
-import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.transfer.microsoft.MicrosoftTransmogrificationConfig;
-import org.datatransferproject.transfer.microsoft.common.MicrosoftCredentialFactory;
-import org.datatransferproject.types.common.models.photos.PhotoAlbum;
-import org.datatransferproject.types.common.models.photos.PhotoModel;
-import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
-import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.omg.CORBA.Object;
-
 /*
  * Copyright 2018 The Data-Portability Project Authors.
  *
@@ -48,7 +13,43 @@ import org.omg.CORBA.Object;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.datatransferproject.transfer.microsoft.photos;
 
+import static com.google.common.base.Preconditions.checkState;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.time.Instant;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Timer;
+import java.util.UUID;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.internal.Util;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.microsoft.MicrosoftTransmogrificationConfig;
+import org.datatransferproject.transfer.microsoft.common.MicrosoftCredentialFactory;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 /**
  * Imports albums and photos to OneDrive using the Microsoft Graph API.

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/DataChunkTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/DataChunkTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.microsoft.photos;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import com.google.api.client.auth.oauth2.Credential;
+
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.launcher.monitor.ConsoleMonitor;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.types.ContinuationData;
+import org.datatransferproject.transfer.microsoft.common.MicrosoftCredentialFactory;
+import org.datatransferproject.transfer.microsoft.driveModels.*;
+import org.datatransferproject.types.common.StringPaginationToken;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.datatransferproject.types.common.models.IdOnlyContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.transfer.microsoft.DataChunk;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+/** */
+public class DataChunkTest {
+
+  private static final int CHUNK_SIZE = 32000 * 1024; // 32000KiB
+
+  InputStream inputStream;
+
+  @Before
+  public void setUp() throws IOException {
+  }
+
+  @Test
+  public void testSplitDataSingleFullChunk() throws IOException {
+    inputStream = new ByteArrayInputStream(new byte[CHUNK_SIZE]);
+    List<DataChunk> l = DataChunk.splitData(inputStream);
+    assertThat(l).hasSize(1);
+    assertThat(l.get(0).getSize()).isEqualTo(CHUNK_SIZE);
+    assertThat(l.get(0).getStart()).isEqualTo(0);
+    assertThat(l.get(0).getEnd()).isEqualTo(CHUNK_SIZE - 1);
+  }
+
+  @Test
+  public void testSplitDataSingleNotFullChunk() throws IOException {
+    inputStream = new ByteArrayInputStream(new byte[CHUNK_SIZE-1]);
+    List<DataChunk> l = DataChunk.splitData(inputStream);
+    assertThat(l).hasSize(1);
+    assertThat(l.get(0).getSize()).isEqualTo(CHUNK_SIZE - 1);
+    assertThat(l.get(0).getStart()).isEqualTo(0);
+    assertThat(l.get(0).getEnd()).isEqualTo(CHUNK_SIZE - 2);
+  }
+
+  @Test
+  public void testSplitDataEmpty() throws IOException {
+    inputStream = new ByteArrayInputStream(new byte[0]);
+    List<DataChunk> l = DataChunk.splitData(inputStream);
+    assertThat(l).hasSize(0);
+  }
+
+  @Test
+  public void testSplitTwoEvenChunks() throws IOException {
+    inputStream = new ByteArrayInputStream(new byte[CHUNK_SIZE*2]);
+    List<DataChunk> l = DataChunk.splitData(inputStream);
+    assertThat(l).hasSize(2);
+    assertThat(l.get(0).getSize()).isEqualTo(CHUNK_SIZE);
+    assertThat(l.get(0).getStart()).isEqualTo(0);
+    assertThat(l.get(0).getEnd()).isEqualTo(CHUNK_SIZE - 1);
+    assertThat(l.get(1).getSize()).isEqualTo(CHUNK_SIZE);
+    assertThat(l.get(1).getStart()).isEqualTo(CHUNK_SIZE);
+    assertThat(l.get(1).getEnd()).isEqualTo(2*CHUNK_SIZE - 1);
+  }
+
+  @Test
+  public void testSplitTwoChunksUneven() throws IOException {
+    inputStream = new ByteArrayInputStream(new byte[CHUNK_SIZE*2 - 10]);
+    List<DataChunk> l = DataChunk.splitData(inputStream);
+    assertThat(l).hasSize(2);
+    assertThat(l.get(0).getSize()).isEqualTo(CHUNK_SIZE);
+    assertThat(l.get(0).getStart()).isEqualTo(0);
+    assertThat(l.get(0).getEnd()).isEqualTo(CHUNK_SIZE - 1);
+    assertThat(l.get(1).getSize()).isEqualTo(CHUNK_SIZE - 10);
+    assertThat(l.get(1).getStart()).isEqualTo(CHUNK_SIZE);
+    assertThat(l.get(1).getEnd()).isEqualTo(2*CHUNK_SIZE - 11);
+  }
+
+}

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.microsoft.photos;
+
+import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import com.google.api.client.auth.oauth2.Credential;
+
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.launcher.monitor.ConsoleMonitor;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.types.ContinuationData;
+import org.datatransferproject.transfer.microsoft.common.MicrosoftCredentialFactory;
+import org.datatransferproject.transfer.microsoft.driveModels.*;
+import org.datatransferproject.types.common.StringPaginationToken;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.datatransferproject.types.common.models.IdOnlyContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.transfer.microsoft.DataChunk;
+import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
+import org.junit.Before;
+import com.google.api.client.auth.oauth2.Credential;
+
+import com.google.api.client.auth.oauth2.BearerToken;
+
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.Call;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import com.google.common.collect.ImmutableList;
+
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+/** 
+  This tests the MicrosoftPhotosImporter. As of now, it only tests the number
+  of requests called. More tests are needed to test request bodies and parameters.
+*/
+public class MicrosoftPhotosImporterTest {
+
+  private static final int CHUNK_SIZE = 32000 * 1024; // 32000KiB
+  private final static String BASE_URL = "https://www.baseurl.com";
+  private final static UUID uuid = UUID.randomUUID();
+
+  MicrosoftPhotosImporter importer;
+  OkHttpClient client;
+  ObjectMapper objectMapper;
+  TemporaryPerJobDataStore jobStore;
+  Monitor monitor;
+  Credential credential;
+  MicrosoftCredentialFactory credentialFactory;
+  IdempotentImportExecutor executor;
+  TokensAndUrlAuthData authData;
+
+
+  @Before
+  public void setUp() throws IOException {
+    executor = new FakeIdempotentImportExecutor();
+    authData = mock(TokensAndUrlAuthData.class);
+    client =  mock(OkHttpClient.class);
+    objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    // mocked on a per test basis
+    jobStore = mock(TemporaryPerJobDataStore.class);
+    monitor = new ConsoleMonitor(ConsoleMonitor.Level.INFO);
+    credentialFactory = mock(MicrosoftCredentialFactory.class);
+    credential = new Credential.Builder(BearerToken.authorizationHeaderAccessMethod()).build();
+    when(credentialFactory.createCredential(any())).thenReturn(credential);
+    when(credentialFactory.refreshCredential(any())).thenReturn(credential);
+    credential.setAccessToken("acc");
+    credential.setExpirationTimeMilliseconds(null);
+    importer = new MicrosoftPhotosImporter(
+      BASE_URL,
+      client,
+      objectMapper,
+      jobStore,
+      monitor,
+      credentialFactory
+    );
+  }
+
+  @Test
+  public void testImportItemAllSuccess() throws Exception {
+    List<PhotoAlbum> albums =
+      ImmutableList.of(new PhotoAlbum("id1", "albumb1", "This is a fake albumb"));
+
+    List<PhotoModel> photos =
+      ImmutableList.of(
+        new PhotoModel(
+          "Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+          true),
+        new PhotoModel(
+          "Pic2", "https://fake.com/2.png", "fine art", "image/png", "p2", "id1", true));
+    when(jobStore.getStream(uuid, "http://fake.com/1.jpg"))
+    .thenReturn(new ByteArrayInputStream(new byte[CHUNK_SIZE]));
+    when(jobStore.getStream(uuid, "https://fake.com/2.png"))
+    .thenReturn(new ByteArrayInputStream(new byte[CHUNK_SIZE]));
+    PhotosContainerResource data = new PhotosContainerResource(albums, photos);
+
+    Call call = mock(Call.class);
+    doReturn(call).when(client).newCall(argThat((Request r) ->
+                                        r.url().toString().equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
+    Response response = mock(Response.class);
+    ResponseBody body = mock(ResponseBody.class);
+    when(body.bytes()).thenReturn(ResponseBody.create(MediaType.parse("application/json"),  "{\"id\": \"id1\"}").bytes());
+    when(body.string()).thenReturn(ResponseBody.create(MediaType.parse("application/json"),  "{\"id\": \"id1\"}").string());
+    when(response.code()).thenReturn(200);
+    when(response.body()).thenReturn(body);
+    when(call.execute()).thenReturn(response);
+
+    Call call2 = mock(Call.class);
+    doReturn(call2).when(client).newCall(argThat((Request r) ->
+                                         r.url().toString().contains("createUploadSession")));
+    Response response2 = mock(Response.class);
+    ResponseBody body2 = mock(ResponseBody.class);
+    when(body2.bytes()).thenReturn(ResponseBody.create(MediaType.parse("application/json"), "{\"uploadUrl\": \"https://scalia.com/link\"}").bytes());
+    when(body2.string()).thenReturn(ResponseBody.create(MediaType.parse("application/json"), "{\"uploadUrl\": \"https://scalia.com/link\"}").string());
+    when(response2.code()).thenReturn(200);
+    when(response2.body()).thenReturn(body2);
+    when(call2.execute()).thenReturn(response2);
+
+    Call call3 = mock(Call.class);
+    doReturn(call3).when(client).newCall(argThat((Request r) ->
+                                         r.url().toString().contains("scalia.com/link")));
+    Response response3 = mock(Response.class);
+    ResponseBody body3 = mock(ResponseBody.class);
+    when(body3.bytes()).thenReturn(ResponseBody.create(MediaType.parse("application/json"),  "{\"id\": \"rand1\"}").bytes());
+    when(body3.string()).thenReturn(ResponseBody.create(MediaType.parse("application/json"),  "{\"id\": \"rand1\"}").string());
+    when(response3.code()).thenReturn(200);
+    when(response3.body()).thenReturn(body3);
+    when(call3.execute()).thenReturn(response3);
+
+    ImportResult result = importer.importItem(uuid, executor, authData, data);
+    verify(client, times(5)).newCall(any());
+    assertThat(result).isEqualTo(ImportResult.OK);
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
@@ -29,6 +29,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.launcher.monitor.ConsoleMonitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.transfer.microsoft.common.MicrosoftCredentialFactory;
@@ -128,9 +129,9 @@ public class MicrosoftPhotosImporterTest {
         new PhotoModel(
           "Pic2", "https://fake.com/2.png", "fine art", "image/png", "p2", "id1", true));
     when(jobStore.getStream(uuid, "http://fake.com/1.jpg"))
-    .thenReturn(new ByteArrayInputStream(new byte[CHUNK_SIZE]));
+    .thenReturn(new InputStreamWrapper(new ByteArrayInputStream(new byte[CHUNK_SIZE])));
     when(jobStore.getStream(uuid, "https://fake.com/2.png"))
-    .thenReturn(new ByteArrayInputStream(new byte[CHUNK_SIZE]));
+    .thenReturn(new InputStreamWrapper(new ByteArrayInputStream(new byte[CHUNK_SIZE])));
     PhotosContainerResource data = new PhotosContainerResource(albums, photos);
 
     Call call = mock(Call.class);


### PR DESCRIPTION
According to this, for files larger than 4MB, it is required that we use createUploadSession of the OneDrive API.

https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#create-an-upload-session

This code completes that requirement, and now we can upload files that are larger than 4MB to OneDrive 😲