### PR TITLE
Fix serialization bug

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -21,7 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.UUID;
@@ -210,23 +209,5 @@ public class GooglePhotosImporter
   private synchronized GooglePhotosInterface makePhotosInterface(TokensAndUrlAuthData authData) {
     Credential credential = credentialFactory.createCredential(authData);
     return new GooglePhotosInterface(credentialFactory, credential, jsonFactory, monitor);
-  }
-
-  private class PhotoResult implements Serializable {
-    private String id;
-    private Long bytes;
-
-    public PhotoResult(String id, Long bytes) {
-      this.id = id;
-      this.bytes = bytes;
-    }
-
-    public String getId() {
-      return id;
-    }
-
-    public Long getBytes() {
-      return bytes;
-    }
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/PhotoResult.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/PhotoResult.java
@@ -1,0 +1,21 @@
+package org.datatransferproject.datatransfer.google.photos;
+
+import java.io.Serializable;
+
+class PhotoResult implements Serializable {
+  private String id;
+  private Long bytes;
+
+  public PhotoResult(String id, Long bytes) {
+    this.id = id;
+    this.bytes = bytes;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Long getBytes() {
+    return bytes;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -50,7 +50,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
-import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.List;
@@ -204,24 +203,6 @@ public class GoogleVideosImporter
       } else {
         return itemResult.getMediaItem().getId();
       }
-    }
-  }
-
-  private class VideoResult implements Serializable {
-    private String id;
-    private Long bytes;
-
-    public VideoResult(String id, Long bytes) {
-      this.id = id;
-      this.bytes = bytes;
-    }
-
-    public String getId() {
-      return id;
-    }
-
-    public Long getBytes() {
-      return bytes;
     }
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/VideoResult.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/VideoResult.java
@@ -1,0 +1,21 @@
+package org.datatransferproject.datatransfer.google.videos;
+
+import java.io.Serializable;
+
+class VideoResult implements Serializable {
+  private String id;
+  private Long bytes;
+
+  public VideoResult(String id, Long bytes) {
+    this.id = id;
+    this.bytes = bytes;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Long getBytes() {
+    return bytes;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/PhotoResultSerializationTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/PhotoResultSerializationTest.java
@@ -1,0 +1,26 @@
+package org.datatransferproject.datatransfer.google.photos;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import java.io.*;
+import org.junit.Test;
+
+public class PhotoResultSerializationTest {
+  @Test
+  public void testSerialization() throws IOException, ClassNotFoundException {
+    String photoId = "photoId";
+    long bytes = 97397L;
+    PhotoResult result = new PhotoResult(photoId, bytes);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new ObjectOutputStream(out).writeObject(result);
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(out.toByteArray());
+    Object readObject = new ObjectInputStream(bais).readObject();
+    assertThat(readObject, instanceOf(PhotoResult.class));
+    PhotoResult deserialized = (PhotoResult) readObject;
+    assertThat(deserialized.getId(), equalTo(photoId));
+    assertThat(deserialized.getBytes(), equalTo(bytes));
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/VideoResultSerializationTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/VideoResultSerializationTest.java
@@ -1,0 +1,26 @@
+package org.datatransferproject.datatransfer.google.videos;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import java.io.*;
+import org.junit.Test;
+
+public class VideoResultSerializationTest {
+  @Test
+  public void testSerialization() throws IOException, ClassNotFoundException {
+    String videoId = "videoId";
+    long bytes = 97397L;
+    VideoResult result = new VideoResult(videoId, bytes);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new ObjectOutputStream(out).writeObject(result);
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(out.toByteArray());
+    Object readObject = new ObjectInputStream(bais).readObject();
+    assertThat(readObject, instanceOf(VideoResult.class));
+    VideoResult deserialized = (VideoResult) readObject;
+    assertThat(deserialized.getId(), equalTo(videoId));
+    assertThat(deserialized.getBytes(), equalTo(bytes));
+  }
+}


### PR DESCRIPTION
Because the Result classes were inner classes serialization broke. It was trying to serialize the outer class which was not possible. This adds unit tests to verify.