### PR TITLE
Create an abstract CopyExceptionWithFailureReason

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -40,7 +40,7 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.transfer.DestinationMemoryFullException;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/CopyException.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/CopyException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.datatransferproject.transfer;
+package org.datatransferproject.spi.transfer.types;
 
 public class CopyException extends Exception {
   public CopyException(String message, Throwable cause) {

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/CopyExceptionWithFailureReason.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/CopyExceptionWithFailureReason.java
@@ -1,0 +1,13 @@
+package org.datatransferproject.spi.transfer.types;
+
+import javax.annotation.Nonnull;
+
+public abstract class CopyExceptionWithFailureReason extends CopyException {
+
+  public CopyExceptionWithFailureReason(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Nonnull
+  public abstract String getFailureReason();
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/DestinationMemoryFullException.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/DestinationMemoryFullException.java
@@ -13,11 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.datatransferproject.transfer;
-import org.datatransferproject.transfer.CopyException;
+package org.datatransferproject.spi.transfer.types;
 
-public class DestinationMemoryFullException extends CopyException {
+import javax.annotation.Nonnull;
+
+public class DestinationMemoryFullException extends CopyExceptionWithFailureReason {
+
   public DestinationMemoryFullException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  @Nonnull
+  @Override
+  public String getFailureReason() {
+    return "DESTINATION_FULL";
   }
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/InMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/InMemoryDataCopier.java
@@ -15,6 +15,7 @@
  */
 package org.datatransferproject.transfer;
 
+import org.datatransferproject.spi.transfer.types.CopyException;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.transfer.auth.AuthData;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;


### PR DESCRIPTION
 So exceptions can store the failure reason on the exception and we have no MemoryFull specific logic.