### PR TITLE
Allow flickr to import untitled albums

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -205,9 +205,9 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
         oldAlbumId,
         album.getName(),
         () -> {
-          // TODO: do we want to keep the COPY_PREFIX?  I feel like not
+          // TODO: make COPY_PREFIX configurable.
           String albumName =
-              Strings.isNullOrEmpty(album.getName()) ? "" : COPY_PREFIX + album.getName();
+              Strings.isNullOrEmpty(album.getName()) ? "untitled" : COPY_PREFIX + album.getName();
           String albumDescription = cleanString(album.getDescription());
 
           perUserRateLimiter.acquire();


### PR DESCRIPTION
This ideally should be done in a transmogrification config, but there isnt one hooked up to flickr yet and the existing config doesnt handle empty titles.

We can fix this later on