### PR TITLE
Create an InvalidTokenException and throw from GoogleCredentialFactory

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
@@ -41,6 +41,7 @@ import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
+import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.spi.transfer.types.TempPhotosData;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.PaginationData;
@@ -95,7 +96,7 @@ public class GooglePhotosExporter
   @Override
   public ExportResult<PhotosContainerResource> export(
       UUID jobId, TokensAndUrlAuthData authData, Optional<ExportInformation> exportInformation)
-      throws IOException {
+      throws IOException, InvalidTokenException {
     if (!exportInformation.isPresent()) {
       // Make list of photos contained in albums so they are not exported twice later on
       populateContainedPhotosList(jobId, authData);
@@ -142,7 +143,7 @@ public class GooglePhotosExporter
   @VisibleForTesting
   ExportResult<PhotosContainerResource> exportAlbums(
       TokensAndUrlAuthData authData, Optional<PaginationData> paginationData, UUID jobId)
-      throws IOException {
+      throws IOException, InvalidTokenException {
     Optional<String> paginationToken = Optional.empty();
     if (paginationData.isPresent()) {
       String token = ((StringPaginationToken) paginationData.get()).getToken();
@@ -194,7 +195,7 @@ public class GooglePhotosExporter
       Optional<IdOnlyContainerResource> albumData,
       Optional<PaginationData> paginationData,
       UUID jobId)
-      throws IOException {
+      throws IOException, InvalidTokenException {
     Optional<String> albumId = Optional.empty();
     if (albumData.isPresent()) {
       albumId = Optional.of(albumData.get().getId());
@@ -229,7 +230,8 @@ public class GooglePhotosExporter
 
   /** Method for storing a list of all photos that are already contained in albums */
   @VisibleForTesting
-  void populateContainedPhotosList(UUID jobId, TokensAndUrlAuthData authData) throws IOException {
+  void populateContainedPhotosList(UUID jobId, TokensAndUrlAuthData authData)
+      throws IOException, InvalidTokenException {
     // This method is only called once at the beginning of the transfer, so we can start by
     // initializing a new TempPhotosData to be store in the job store.
     TempPhotosData tempPhotosData = new TempPhotosData(jobId);

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -34,6 +34,7 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputS
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
@@ -118,7 +119,7 @@ public class GooglePhotosImporter
 
   @VisibleForTesting
   String importSingleAlbum(TokensAndUrlAuthData authData, PhotoAlbum inputAlbum)
-      throws IOException {
+      throws IOException, InvalidTokenException {
     // Set up album
     GoogleAlbum googleAlbum = new GoogleAlbum();
     String title = COPY_PREFIX + inputAlbum.getName();
@@ -139,7 +140,7 @@ public class GooglePhotosImporter
       TokensAndUrlAuthData authData,
       PhotoModel inputPhoto,
       IdempotentImportExecutor idempotentImportExecutor)
-      throws IOException {
+      throws IOException, InvalidTokenException {
     /*
     TODO: resumable uploads https://developers.google.com/photos/library/guides/resumable-uploads
     Resumable uploads would allow the upload of larger media that don't fit in memory.  To do this,

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -57,6 +57,7 @@ import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemRes
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaItemSearchResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
+import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 
 public class GooglePhotosInterface {
 
@@ -94,7 +95,8 @@ public class GooglePhotosInterface {
     this.credentialFactory = credentialFactory;
   }
 
-  AlbumListResponse listAlbums(Optional<String> pageToken) throws IOException {
+  AlbumListResponse listAlbums(Optional<String> pageToken)
+      throws IOException, InvalidTokenException {
     Map<String, String> params = new LinkedHashMap<>();
     params.put(PAGE_SIZE_KEY, String.valueOf(ALBUM_PAGE_SIZE));
     if (pageToken.isPresent()) {
@@ -104,7 +106,7 @@ public class GooglePhotosInterface {
   }
 
   MediaItemSearchResponse listMediaItems(Optional<String> albumId, Optional<String> pageToken)
-      throws IOException {
+      throws IOException, InvalidTokenException {
     Map<String, Object> params = new LinkedHashMap<>();
     params.put(PAGE_SIZE_KEY, String.valueOf(MEDIA_PAGE_SIZE));
     if (albumId.isPresent()) {
@@ -120,7 +122,7 @@ public class GooglePhotosInterface {
         BASE_URL + "mediaItems:search", Optional.empty(), content, MediaItemSearchResponse.class);
   }
 
-  GoogleAlbum createAlbum(GoogleAlbum googleAlbum) throws IOException {
+  GoogleAlbum createAlbum(GoogleAlbum googleAlbum) throws IOException, InvalidTokenException {
     Map<String, Object> albumMap = createJsonMap(googleAlbum);
     Map<String, Object> contentMap = ImmutableMap.of("album", albumMap);
     HttpContent content = new JsonHttpContent(jsonFactory, contentMap);
@@ -128,7 +130,7 @@ public class GooglePhotosInterface {
     return makePostRequest(BASE_URL + "albums", Optional.empty(), content, GoogleAlbum.class);
   }
 
-  String uploadPhotoContent(InputStream inputStream) throws IOException {
+  String uploadPhotoContent(InputStream inputStream) throws IOException, InvalidTokenException {
     // TODO: add filename
     InputStreamContent content = new InputStreamContent(null, inputStream);
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -144,7 +146,8 @@ public class GooglePhotosInterface {
         BASE_URL + "uploads/", Optional.of(PHOTO_UPLOAD_PARAMS), httpContent, String.class);
   }
 
-  BatchMediaItemResponse createPhoto(NewMediaItemUpload newMediaItemUpload) throws IOException {
+  BatchMediaItemResponse createPhoto(NewMediaItemUpload newMediaItemUpload)
+      throws IOException, InvalidTokenException {
     HashMap<String, Object> map = createJsonMap(newMediaItemUpload);
     HttpContent httpContent = new JsonHttpContent(new JacksonFactory(), map);
 
@@ -156,7 +159,7 @@ public class GooglePhotosInterface {
   }
 
   private <T> T makeGetRequest(String url, Optional<Map<String, String>> parameters, Class<T> clazz)
-      throws IOException {
+      throws IOException, InvalidTokenException {
     HttpRequestFactory requestFactory = httpTransport.createRequestFactory();
     HttpRequest getRequest =
         requestFactory.buildGetRequest(
@@ -182,7 +185,7 @@ public class GooglePhotosInterface {
 
   <T> T makePostRequest(
       String url, Optional<Map<String, String>> parameters, HttpContent httpContent, Class<T> clazz)
-      throws IOException {
+      throws IOException, InvalidTokenException {
     HttpRequestFactory requestFactory = httpTransport.createRequestFactory();
     HttpRequest postRequest =
         requestFactory.buildPostRequest(
@@ -212,7 +215,8 @@ public class GooglePhotosInterface {
   }
 
   private HttpResponse handleHttpResponseException(
-      SupplierWithIO<HttpRequest> httpRequest, HttpResponseException e) throws IOException {
+      SupplierWithIO<HttpRequest> httpRequest, HttpResponseException e)
+      throws IOException, InvalidTokenException {
     // if the response is "unauthorized", refresh the token and try the request again
     if (e.getStatusCode() == 401) {
       monitor.info(() -> "Attempting to refresh authorization token");

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
@@ -48,6 +48,7 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
+import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.spi.transfer.types.TempPhotosData;
 import org.datatransferproject.types.common.PaginationData;
 import org.datatransferproject.types.common.StringPaginationToken;
@@ -79,7 +80,7 @@ public class GooglePhotosExporterTest {
   private AlbumListResponse albumListResponse;
 
   @Before
-  public void setup() throws IOException {
+  public void setup() throws IOException, InvalidTokenException {
     GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
     jobStore = mock(TemporaryPerJobDataStore.class);
     when(jobStore.getStream(any(), anyString())).thenReturn(mock(InputStreamWrapper.class));
@@ -102,7 +103,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void exportAlbumFirstSet() throws IOException {
+  public void exportAlbumFirstSet() throws IOException, InvalidTokenException {
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(ALBUM_TOKEN);
 
@@ -140,7 +141,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void exportAlbumSubsequentSet() throws IOException {
+  public void exportAlbumSubsequentSet() throws IOException, InvalidTokenException {
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(null);
 
@@ -164,7 +165,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void exportPhotoFirstSet() throws IOException {
+  public void exportPhotoFirstSet() throws IOException, InvalidTokenException {
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(null);
     GoogleMediaItem mediaItem = setUpSinglePhoto(IMG_URI, PHOTO_ID);
@@ -203,7 +204,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void exportPhotoSubsequentSet() throws IOException {
+  public void exportPhotoSubsequentSet() throws IOException, InvalidTokenException {
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(null);
     GoogleMediaItem mediaItem = setUpSinglePhoto(IMG_URI, PHOTO_ID);
@@ -231,7 +232,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void populateContainedPhotosList() throws IOException {
+  public void populateContainedPhotosList() throws IOException, InvalidTokenException {
     // Set up an album with two photos
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(null);
@@ -264,7 +265,7 @@ public class GooglePhotosExporterTest {
   /* Tests that when there is no album information passed along to exportPhotos, only albumless
   photos are exported.
   */
-  public void onlyExportAlbumlessPhoto() throws IOException {
+  public void onlyExportAlbumlessPhoto() throws IOException, InvalidTokenException {
     // Set up - two photos will be returned by a media item search without an album id, but one of
     // them will have already been put into the list of contained photos
     String containedPhotoUri = "contained photo uri";

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -36,6 +36,7 @@ import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemResul
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
@@ -67,7 +68,7 @@ public class GooglePhotosImporterTest {
   private static final String NEW_ALBUM_ID = "NEW_ALBUM_ID";
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() throws IOException, InvalidTokenException {
     executor = new FakeIdempotentImportExecutor();
     googlePhotosInterface = Mockito.mock(GooglePhotosInterface.class);
     monitor = Mockito.mock(Monitor.class);

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/FailureReasons.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/FailureReasons.java
@@ -1,7 +1,8 @@
 package org.datatransferproject.spi.transfer.types;
 
 public enum FailureReasons {
-  DESTINATION_FULL("DESTINATION_FULL");
+  DESTINATION_FULL("DESTINATION_FULL"),
+  INVALID_TOKEN("INVALID_TOKEN");
 
   private final String string;
 

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/InvalidTokenException.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/InvalidTokenException.java
@@ -1,0 +1,16 @@
+package org.datatransferproject.spi.transfer.types;
+
+import javax.annotation.Nonnull;
+
+public class InvalidTokenException extends CopyExceptionWithFailureReason {
+
+  public InvalidTokenException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Nonnull
+  @Override
+  public String getFailureReason() {
+    return FailureReasons.INVALID_TOKEN.toString();
+  }
+}


### PR DESCRIPTION
Two main advantages to this:

1. We don't keep retrying if a token is invalid (this change does not touch the refresh logic though)
2. We store a specific failure reason

This definitely needs review from Google folks as it affects the GooglePhotosExporter.