### PR TITLE
Update the GooglePhotosInterface read timeout to 2 minutes instead of the default two seconds.

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -187,7 +187,7 @@ public class GooglePhotosInterface {
     HttpRequest postRequest =
         requestFactory.buildPostRequest(
             new GenericUrl(url + "?" + generateParamsString(parameters)), httpContent);
-
+    postRequest.setReadTimeout(2 * 60000);  // 2 minutes read timeout
     HttpResponse response;
 
     try {


### PR DESCRIPTION
This should prevent the consistent timeout errors we're seeing when listing some of the albums:
ex:

```
Error processing jobId: 374efb2e-10c6-4ca8-9bdb-3f535939819d
org.datatransferproject.transfer.CopyException: Job 374efb2e-10c6-4ca8-9bdb-3f535939819d: Error happened during export
	at org.datatransferproject.transfer.PortabilityInMemoryDataCopier.copyHelper(PortabilityInMemoryDataCopier.java:137)
	at org.datatransferproject.transfer.PortabilityInMemoryDataCopier.copy(PortabilityInMemoryDataCopier.java:93)
	at org.datatransferproject.transfer.JobProcessor.processJob(JobProcessor.java:123)
	at org.datatransferproject.transfer.Worker.doWork(Worker.java:39)
	at org.datatransferproject.transfer.WorkerMain.poll(WorkerMain.java:138)
	at org.datatransferproject.transfer.WorkerMain.main(WorkerMain.java:64)
Caused by: org.datatransferproject.types.transfer.retry.RetryException: java.net.SocketTimeoutException: Read timed out
	at org.datatransferproject.types.transfer.retry.RetryingCallable.call(RetryingCallable.java:98)
	at org.datatransferproject.transfer.PortabilityInMemoryDataCopier.copyHelper(PortabilityInMemoryDataCopier.java:134)
	... 5 more
Caused by: java.net.SocketTimeoutException: Read timed out
	at java.net.SocketInputStream.socketRead0(Native Method)
	at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
	at java.net.SocketInputStream.read(SocketInputStream.java:171)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
	at sun.security.ssl.InputRecord.read(InputRecord.java:503)
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:985)
	at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:942)
	at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
	at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
	at java.io.BufferedInputStream.read1(BufferedInputStream.java:286)
	at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
	at sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:735)
	at sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:678)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1587)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1492)
	at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:480)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:347)
	at com.google.api.client.http.javanet.NetHttpResponse.<init>(NetHttpResponse.java:36)
	at com.google.api.client.http.javanet.NetHttpRequest.execute(NetHttpRequest.java:100)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:909)
	at org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface.makePostRequest(GooglePhotosInterface.java:194)
	at org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface.listMediaItems(GooglePhotosInterface.java:119)
	at org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.populateContainedPhotosList(GooglePhotosExporter.java:250)
	at org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.export(GooglePhotosExporter.java:101)
	at org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter.export(GooglePhotosExporter.java:57)
	at org.datatransferproject.transfer.CallableExporter.call(CallableExporter.java:62)
	at org.datatransferproject.transfer.CallableExporter.call(CallableExporter.java:36)
	at org.datatransferproject.types.transfer.retry.RetryingCallable.call(RetryingCallable.java:65)
```