### PR TITLE
Rate limit writes to Google Photos to avoid hitting the per user rate limits.

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
@@ -102,7 +102,13 @@ public class GoogleTransferExtension implements TransferExtension {
     importerBuilder.put("MAIL", new GoogleMailImporter(credentialFactory, monitor));
     importerBuilder.put("TASKS", new GoogleTasksImporter(credentialFactory));
     importerBuilder.put(
-        "PHOTOS", new GooglePhotosImporter(credentialFactory, jobStore, jsonFactory, monitor));
+        "PHOTOS",
+        new GooglePhotosImporter(
+            credentialFactory,
+            jobStore,
+            jsonFactory,
+            monitor,
+            context.getSetting("googleWritesPerSecond", 1.0)));
     importerBuilder.put("VIDEOS", new GoogleVideosImporter(appCredentials, jobStore, monitor));
     importerMap = importerBuilder.build();
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
@@ -339,7 +339,8 @@ public class GooglePhotosExporter
 
   private synchronized GooglePhotosInterface makePhotosInterface(TokensAndUrlAuthData authData) {
     Credential credential = credentialFactory.createCredential(authData);
-    return new GooglePhotosInterface(credentialFactory, credential, jsonFactory, monitor);
+    return new GooglePhotosInterface(
+        credentialFactory, credential, jsonFactory, monitor, /* arbitrary writesPerSecond */ 1.0);
   }
 
   private static String createCacheKey() {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -54,13 +54,22 @@ public class GooglePhotosImporter
   private final ImageStreamProvider imageStreamProvider;
   private volatile GooglePhotosInterface photosInterface;
   private final Monitor monitor;
+  private final double writesPerSecond;
 
   public GooglePhotosImporter(
       GoogleCredentialFactory credentialFactory,
       TemporaryPerJobDataStore jobStore,
       JsonFactory jsonFactory,
-      Monitor monitor) {
-    this(credentialFactory, jobStore, jsonFactory, null, new ImageStreamProvider(), monitor);
+      Monitor monitor,
+      double writesPerSecond) {
+    this(
+        credentialFactory,
+        jobStore,
+        jsonFactory,
+        null,
+        new ImageStreamProvider(),
+        monitor,
+        writesPerSecond);
   }
 
   @VisibleForTesting
@@ -70,13 +79,15 @@ public class GooglePhotosImporter
       JsonFactory jsonFactory,
       GooglePhotosInterface photosInterface,
       ImageStreamProvider imageStreamProvider,
-      Monitor monitor) {
+      Monitor monitor,
+      double writesPerSecond) {
     this.credentialFactory = credentialFactory;
     this.jobStore = jobStore;
     this.jsonFactory = jsonFactory;
     this.photosInterface = photosInterface;
     this.imageStreamProvider = imageStreamProvider;
     this.monitor = monitor;
+    this.writesPerSecond = writesPerSecond;
   }
 
   @Override
@@ -220,6 +231,7 @@ public class GooglePhotosImporter
 
   private synchronized GooglePhotosInterface makePhotosInterface(TokensAndUrlAuthData authData) {
     Credential credential = credentialFactory.createCredential(authData);
-    return new GooglePhotosInterface(credentialFactory, credential, jsonFactory, monitor);
+    return new GooglePhotosInterface(
+        credentialFactory, credential, jsonFactory, monitor, writesPerSecond);
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -90,7 +90,7 @@ public class GooglePhotosImporterTest {
 
     googlePhotosImporter =
         new GooglePhotosImporter(
-            null, jobStore, null, googlePhotosInterface, imageStreamProvider, monitor);
+            null, jobStore, null, googlePhotosInterface, imageStreamProvider, monitor, 1.0);
   }
 
   @Test


### PR DESCRIPTION
Can be set via the setting 'googleWritesPerSecond' or will default to 1/second