### PR TITLE
check for image upload failure

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -150,6 +150,7 @@ public class SmugMugInterface {
             headersMap,
             new TypeReference<SmugMugImageUploadResponse>() {});
 
+    Preconditions.checkState(response.getStat().equals("ok"), "Failed to upload image");
     return Preconditions.checkNotNull(response, "Image upload Response is null");
   }
 

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/model/SmugMugImageUploadResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/model/SmugMugImageUploadResponse.java
@@ -53,6 +53,10 @@ public final class SmugMugImageUploadResponse {
     return image;
   }
 
+  public String getStat() {
+    return stat;
+  }
+
   public static class ImageInfo {
 
     @JsonProperty("ImageUri")


### PR DESCRIPTION
SmugMug's API returns 200 when an image fails to upload, so the code was failing to catch any failures, resulting in missing data. Now we check for failures by looking at the 'stat' field of the API response.