### PR TITLE
Add new exception to capture user permission denial

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
@@ -42,6 +42,7 @@ import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
+import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
 import org.datatransferproject.spi.transfer.types.TempPhotosData;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.PaginationData;
@@ -96,7 +97,7 @@ public class GooglePhotosExporter
   @Override
   public ExportResult<PhotosContainerResource> export(
       UUID jobId, TokensAndUrlAuthData authData, Optional<ExportInformation> exportInformation)
-      throws IOException, InvalidTokenException {
+      throws IOException, InvalidTokenException, PermissionDeniedException {
     if (!exportInformation.isPresent()) {
       // Make list of photos contained in albums so they are not exported twice later on
       populateContainedPhotosList(jobId, authData);
@@ -143,7 +144,7 @@ public class GooglePhotosExporter
   @VisibleForTesting
   ExportResult<PhotosContainerResource> exportAlbums(
       TokensAndUrlAuthData authData, Optional<PaginationData> paginationData, UUID jobId)
-      throws IOException, InvalidTokenException {
+      throws IOException, InvalidTokenException, PermissionDeniedException {
     Optional<String> paginationToken = Optional.empty();
     if (paginationData.isPresent()) {
       String token = ((StringPaginationToken) paginationData.get()).getToken();
@@ -195,7 +196,7 @@ public class GooglePhotosExporter
       Optional<IdOnlyContainerResource> albumData,
       Optional<PaginationData> paginationData,
       UUID jobId)
-      throws IOException, InvalidTokenException {
+      throws IOException, InvalidTokenException, PermissionDeniedException {
     Optional<String> albumId = Optional.empty();
     if (albumData.isPresent()) {
       albumId = Optional.of(albumData.get().getId());
@@ -231,7 +232,7 @@ public class GooglePhotosExporter
   /** Method for storing a list of all photos that are already contained in albums */
   @VisibleForTesting
   void populateContainedPhotosList(UUID jobId, TokensAndUrlAuthData authData)
-      throws IOException, InvalidTokenException {
+      throws IOException, InvalidTokenException, PermissionDeniedException {
     // This method is only called once at the beginning of the transfer, so we can start by
     // initializing a new TempPhotosData to be store in the job store.
     TempPhotosData tempPhotosData = new TempPhotosData(jobId);

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -34,8 +34,10 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputS
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason;
 import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
+import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
@@ -131,7 +133,7 @@ public class GooglePhotosImporter
 
   @VisibleForTesting
   String importSingleAlbum(TokensAndUrlAuthData authData, PhotoAlbum inputAlbum)
-      throws IOException, InvalidTokenException {
+      throws IOException, InvalidTokenException, PermissionDeniedException {
     // Set up album
     GoogleAlbum googleAlbum = new GoogleAlbum();
     String title = COPY_PREFIX + inputAlbum.getName();
@@ -152,7 +154,7 @@ public class GooglePhotosImporter
       TokensAndUrlAuthData authData,
       PhotoModel inputPhoto,
       IdempotentImportExecutor idempotentImportExecutor)
-      throws IOException, DestinationMemoryFullException, InvalidTokenException {
+      throws IOException, CopyExceptionWithFailureReason {
     /*
     TODO: resumable uploads https://developers.google.com/photos/library/guides/resumable-uploads
     Resumable uploads would allow the upload of larger media that don't fit in memory.  To do this,

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
@@ -49,6 +49,7 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputS
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
+import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
 import org.datatransferproject.spi.transfer.types.TempPhotosData;
 import org.datatransferproject.types.common.PaginationData;
 import org.datatransferproject.types.common.StringPaginationToken;
@@ -80,7 +81,7 @@ public class GooglePhotosExporterTest {
   private AlbumListResponse albumListResponse;
 
   @Before
-  public void setup() throws IOException, InvalidTokenException {
+  public void setup() throws IOException, InvalidTokenException, PermissionDeniedException {
     GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
     jobStore = mock(TemporaryPerJobDataStore.class);
     when(jobStore.getStream(any(), anyString())).thenReturn(mock(InputStreamWrapper.class));
@@ -103,7 +104,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void exportAlbumFirstSet() throws IOException, InvalidTokenException {
+  public void exportAlbumFirstSet() throws IOException, InvalidTokenException, PermissionDeniedException {
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(ALBUM_TOKEN);
 
@@ -141,7 +142,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void exportAlbumSubsequentSet() throws IOException, InvalidTokenException {
+  public void exportAlbumSubsequentSet() throws IOException, InvalidTokenException, PermissionDeniedException {
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(null);
 
@@ -165,7 +166,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void exportPhotoFirstSet() throws IOException, InvalidTokenException {
+  public void exportPhotoFirstSet() throws IOException, InvalidTokenException, PermissionDeniedException {
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(null);
     GoogleMediaItem mediaItem = setUpSinglePhoto(IMG_URI, PHOTO_ID);
@@ -204,7 +205,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void exportPhotoSubsequentSet() throws IOException, InvalidTokenException {
+  public void exportPhotoSubsequentSet() throws IOException, InvalidTokenException, PermissionDeniedException {
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(null);
     GoogleMediaItem mediaItem = setUpSinglePhoto(IMG_URI, PHOTO_ID);
@@ -232,7 +233,7 @@ public class GooglePhotosExporterTest {
   }
 
   @Test
-  public void populateContainedPhotosList() throws IOException, InvalidTokenException {
+  public void populateContainedPhotosList() throws IOException, InvalidTokenException, PermissionDeniedException {
     // Set up an album with two photos
     setUpSingleAlbum();
     when(albumListResponse.getNextPageToken()).thenReturn(null);
@@ -265,7 +266,7 @@ public class GooglePhotosExporterTest {
   /* Tests that when there is no album information passed along to exportPhotos, only albumless
   photos are exported.
   */
-  public void onlyExportAlbumlessPhoto() throws IOException, InvalidTokenException {
+  public void onlyExportAlbumlessPhoto() throws IOException, InvalidTokenException, PermissionDeniedException {
     // Set up - two photos will be returned by a media item search without an album id, but one of
     // them will have already been put into the list of contained photos
     String containedPhotoUri = "contained photo uri";

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -37,6 +37,7 @@ import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUploa
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
+import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
@@ -68,7 +69,7 @@ public class GooglePhotosImporterTest {
   private static final String NEW_ALBUM_ID = "NEW_ALBUM_ID";
 
   @Before
-  public void setUp() throws IOException, InvalidTokenException {
+  public void setUp() throws IOException, InvalidTokenException, PermissionDeniedException {
     executor = new FakeIdempotentImportExecutor();
     googlePhotosInterface = Mockito.mock(GooglePhotosInterface.class);
     monitor = Mockito.mock(Monitor.class);

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/FailureReasons.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/FailureReasons.java
@@ -2,7 +2,9 @@ package org.datatransferproject.spi.transfer.types;
 
 public enum FailureReasons {
   DESTINATION_FULL("DESTINATION_FULL"),
-  INVALID_TOKEN("INVALID_TOKEN");
+  INVALID_TOKEN("INVALID_TOKEN"),
+  PERMISSION_DENIED("PERMISSION_DENIED"),
+  UPLOAD_ERROR("UPLOAD_ERROR");
 
   private final String string;
 

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/PermissionDeniedException.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/PermissionDeniedException.java
@@ -1,0 +1,16 @@
+package org.datatransferproject.spi.transfer.types;
+
+import javax.annotation.Nonnull;
+
+public class PermissionDeniedException extends CopyExceptionWithFailureReason {
+
+  public PermissionDeniedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Nonnull
+  @Override
+  public String getFailureReason() {
+    return FailureReasons.PERMISSION_DENIED.toString();
+  }
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/UploadErrorException.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/UploadErrorException.java
@@ -1,0 +1,16 @@
+package org.datatransferproject.spi.transfer.types;
+
+import javax.annotation.Nonnull;
+
+public class UploadErrorException extends CopyExceptionWithFailureReason {
+
+  public UploadErrorException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Nonnull
+  @Override
+  public String getFailureReason() {
+    return FailureReasons.UPLOAD_ERROR.toString();
+  }
+}


### PR DESCRIPTION
Summary:
Currently, when user import photos to google photos, the user needs to
select the google account with access to photos.

Otherwise, Google API would reply with a 403 error which cause a Java
IOException.

This commit is to capture this 403 error in a new exception class based
on CopyExceptionWithFailureReason. So it would allow displaying better
error message to the front end users.

Test Plan:
Import photos to a google account with no access to photos. Worker
should throw a PermissionDeniedException rather than an IOException