### PR TITLE
Switch the stopped job exit code to 0

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
@@ -49,7 +49,7 @@ class JobCancelWatchingService extends AbstractScheduledService {
           () -> String.format("Job %s is canceled", JobMetadata.getJobId()),
           EventCode.WORKER_JOB_CANCELED);
       monitor.flushLogs();
-      System.exit(-1);
+      System.exit(0);
     } else {
       monitor.debug(() -> String.format("Job %s is not canceled", JobMetadata.getJobId()));
     }


### PR DESCRIPTION
This reflects the fact that the application did not crash and instead stopped as requested by the user.