### PR TITLE
Add finishedJob metric when job is cancelled

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleDtpInternalMetricRecorder.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleDtpInternalMetricRecorder.java
@@ -320,6 +320,11 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
+  public void cancelledJob(String dataType, String exportService, String importService, Duration duration) {
+    // Need Google folks to implement the necessary changes here.
+  }
+
+  @Override
   public void recordGenericMetric(String dataType, String service, String tag) {
     recordGenericMetric(dataType, service, tag, 1);
   }

--- a/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureDtpInternalMetricRecorder.java
+++ b/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureDtpInternalMetricRecorder.java
@@ -112,6 +112,15 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
+  public void cancelledJob(String dataType, String exportService, String importService, Duration duration) {
+    monitor.debug(
+         () ->
+             format("Metric: cancelledJob, data type: %s, from: %s, to: %s, duration: %s",
+                    dataType, exportService, importService, duration));
+
+  }
+
+  @Override
   public void recordGenericMetric(String dataType, String service, String tag) {
     monitor.debug(
         () ->

--- a/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/DtpInternalMetricRecorder.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/DtpInternalMetricRecorder.java
@@ -38,6 +38,12 @@ public interface DtpInternalMetricRecorder {
       String importService,
       boolean success,
       Duration duration);
+  /** A DTP job cancelled **/
+  void cancelledJob(
+      String dataType,
+      String exportService,
+      String importService,
+      Duration duration);
 
   /** An single attempt to export a page of data finished. **/
   void exportPageAttemptFinished(

--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/metrics/LoggingDtpInternalMetricRecorder.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/metrics/LoggingDtpInternalMetricRecorder.java
@@ -124,6 +124,16 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
   }
 
   @Override
+  public void cancelledJob(
+      String dataType, String exportService, String importService, Duration duration) {
+    monitor.debug(
+        () ->
+            format(
+                "Metric: cancelledJob, data type: %s, from: %s, to: %s, duration: %s",
+                dataType, exportService, importService, duration));
+  }
+
+  @Override
   public void recordGenericMetric(String dataType, String service, String tag) {
     monitor.debug(
         () ->

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobMetadata.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobMetadata.java
@@ -16,6 +16,8 @@
 package org.datatransferproject.transfer;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+
 import java.util.UUID;
 
 /**
@@ -34,13 +36,15 @@ public final class JobMetadata {
   private static String dataType = null;
   private static String exportService = null;
   private static String importService = null;
+  private static Stopwatch stopWatch = null;
 
   public static boolean isInitialized() {
     return (jobId != null
         && encodedPrivateKey != null
         && dataType != null
         && exportService != null
-        && importService != null);
+        && importService != null
+        && stopWatch != null);
   }
 
   static void init(
@@ -48,13 +52,15 @@ public final class JobMetadata {
       byte[] initEncodedPrivateKey,
       String initDataType,
       String initExportService,
-      String initImportService) {
+      String initImportService,
+      Stopwatch initStopWatch) {
     Preconditions.checkState(!isInitialized(), "JobMetadata cannot be initialized twice");
     jobId = initJobId;
     encodedPrivateKey = initEncodedPrivateKey;
     dataType = initDataType;
     exportService = initExportService;
     importService = initImportService;
+    stopWatch = initStopWatch;
   }
 
   // TODO: remove this
@@ -64,6 +70,7 @@ public final class JobMetadata {
     dataType = null;
     exportService = null;
     importService = null;
+    stopWatch = null;
   }
 
   static byte[] getPrivateKey() {
@@ -89,5 +96,10 @@ public final class JobMetadata {
   public static String getImportService() {
     Preconditions.checkState(isInitialized(), "JobMetadata must be initialized");
     return importService;
+  }
+
+  public static Stopwatch getStopWatch() {
+    Preconditions.checkState(isInitialized(), "JobMetadata must be initialized");
+    return stopWatch;
   }
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -206,12 +206,14 @@ class JobPollingService extends AbstractScheduledService {
     if (monitor instanceof JobAwareMonitor) {
       ((JobAwareMonitor) monitor).setJobId(jobId.toString());
     }
+
     JobMetadata.init(
         jobId,
         keyPair.getEncodedPrivateKey(),
         existingJob.transferDataType(),
         existingJob.exportService(),
-        existingJob.importService());
+        existingJob.importService(),
+        Stopwatch.createUnstarted());
     monitor.debug(
         () -> format("Stored updated job: tryToClaimJob: JobMetadata initialized: %s", jobId));
 

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -84,7 +84,6 @@ final class JobProcessor {
 
     PortabilityJob job = store.findJob(jobId);
     JobAuthorization jobAuthorization = job.jobAuthorization();
-    Stopwatch stopwatch = Stopwatch.createUnstarted();
     Collection<ErrorDetail> errors = null;
 
     try {
@@ -118,7 +117,7 @@ final class JobProcessor {
           JobMetadata.getDataType(),
           JobMetadata.getExportService(),
           JobMetadata.getImportService());
-      stopwatch.start();
+      JobMetadata.getStopWatch().start();
       errors = copier.copy(exportAuthData, importAuthData, jobId, exportInfo);
       final int numErrors = errors.size();
       monitor.debug(
@@ -144,7 +143,7 @@ final class JobProcessor {
           JobMetadata.getExportService(),
           JobMetadata.getImportService(),
           success,
-          stopwatch.elapsed());
+          JobMetadata.getStopWatch().elapsed());
       monitor.flushLogs();
       JobMetadata.reset();
     }


### PR DESCRIPTION
Summary:
Currently when a job is started and then cancelled by user, dtp worker
would only print the startedJob metrics line in the log. This makes the
log line incomplete and confuses engineers with unfinished job.

The commit here is to add the finishedJob metrics in job cancellation.

Test Plan: Cancel a job and see the new log line appearing there.