### PR TITLE
Fix token refresh issue for google photo importer

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -228,7 +228,10 @@ public class GooglePhotosImporter
 
   private synchronized GooglePhotosInterface getOrCreatePhotosInterface(
       TokensAndUrlAuthData authData) {
-    return photosInterface == null ? makePhotosInterface(authData) : photosInterface;
+    if (photosInterface == null) {
+      photosInterface = makePhotosInterface(authData);
+    }
+    return photosInterface;
   }
 
   private synchronized GooglePhotosInterface makePhotosInterface(TokensAndUrlAuthData authData) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -56,10 +56,10 @@ public class GooglePhotosImporter
   private final TemporaryPerJobDataStore jobStore;
   private final JsonFactory jsonFactory;
   private final ImageStreamProvider imageStreamProvider;
-  private volatile Map<UUID, GooglePhotosInterface> photosInterfacesMap;
-  private volatile GooglePhotosInterface photosInterface;
   private final Monitor monitor;
   private final double writesPerSecond;
+  private volatile Map<UUID, GooglePhotosInterface> photosInterfacesMap;
+  private volatile GooglePhotosInterface photosInterface;
 
   public GooglePhotosImporter(
       GoogleCredentialFactory credentialFactory,
@@ -150,7 +150,8 @@ public class GooglePhotosImporter
     }
     googleAlbum.setTitle(title);
 
-    GoogleAlbum responseAlbum = getOrCreatePhotosInterface(jobId, authData).createAlbum(googleAlbum);
+    GoogleAlbum responseAlbum =
+        getOrCreatePhotosInterface(jobId, authData).createAlbum(googleAlbum);
     return responseAlbum.getId();
   }
 
@@ -181,7 +182,8 @@ public class GooglePhotosImporter
       inputStream = conn.getInputStream();
     }
 
-    String uploadToken = getOrCreatePhotosInterface(jobId, authData).uploadPhotoContent(inputStream);
+    String uploadToken =
+        getOrCreatePhotosInterface(jobId, authData).uploadPhotoContent(inputStream);
 
     String description = getPhotoDescription(inputPhoto);
     NewMediaItem newMediaItem = new NewMediaItem(description, uploadToken);
@@ -233,7 +235,7 @@ public class GooglePhotosImporter
   }
 
   private synchronized GooglePhotosInterface getOrCreatePhotosInterface(
-          UUID jobId, TokensAndUrlAuthData authData) {
+      UUID jobId, TokensAndUrlAuthData authData) {
 
     if (photosInterface != null) {
       return photosInterface;

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -49,14 +49,14 @@ import org.mockito.Mockito;
 
 public class GooglePhotosImporterTest {
 
+  private static final String OLD_ALBUM_ID = "OLD_ALBUM_ID";
+  private static final String NEW_ALBUM_ID = "NEW_ALBUM_ID";
   private String PHOTO_TITLE = "Model photo title";
   private String PHOTO_DESCRIPTION = "Model photo description";
   private String IMG_URI = "image uri";
   private String JPEG_MEDIA_TYPE = "image/jpeg";
   private String UPLOAD_TOKEN = "uploadToken";
-
   private UUID uuid = UUID.randomUUID();
-
   private GooglePhotosImporter googlePhotosImporter;
   private GooglePhotosInterface googlePhotosInterface;
   private TemporaryPerJobDataStore jobStore;
@@ -64,9 +64,6 @@ public class GooglePhotosImporterTest {
   private InputStream inputStream;
   private IdempotentImportExecutor executor;
   private Monitor monitor;
-
-  private static final String OLD_ALBUM_ID = "OLD_ALBUM_ID";
-  private static final String NEW_ALBUM_ID = "NEW_ALBUM_ID";
 
   @Before
   public void setUp() throws IOException, InvalidTokenException, PermissionDeniedException {

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -91,7 +91,7 @@ public class GooglePhotosImporterTest {
 
     googlePhotosImporter =
         new GooglePhotosImporter(
-            null, jobStore, null, googlePhotosInterface, imageStreamProvider, monitor, 1.0);
+            null, jobStore, null, null, googlePhotosInterface, imageStreamProvider, monitor, 1.0);
   }
 
   @Test
@@ -107,7 +107,7 @@ public class GooglePhotosImporterTest {
         .thenReturn(responseAlbum);
 
     // Run test
-    googlePhotosImporter.importSingleAlbum(null, albumModel);
+    googlePhotosImporter.importSingleAlbum(uuid, null, albumModel);
 
     // Check results
     ArgumentCaptor<GoogleAlbum> albumArgumentCaptor = ArgumentCaptor.forClass(GoogleAlbum.class);


### PR DESCRIPTION
Summary:
Currently google photo importer create a new google photo interface
every time it sends a http request.

If the original access token is expired, the new access token acquired
from refresh token would not be persisted across http request.

This commit is to fix the inefficiency here that we don't create a new
google photo interface every time we send a new request.

Test Plan:
Send request after access token expires then the refresh action should
only happen once for the next few requests.