### PR TITLE
Fix token issue when importing video to google

### DIFF
--- a/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleOAuthConfig.java
+++ b/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleOAuthConfig.java
@@ -78,6 +78,6 @@ public class GoogleOAuthConfig implements OAuth2Config {
 
   @Override
   public Map<String, String> getAdditionalAuthUrlParameters() {
-    return ImmutableMap.of("prompt", "consent");
+    return ImmutableMap.of("prompt", "consent", "access_type", "offline");
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -52,7 +52,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.datatransferproject.api.launcher.Monitor;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -52,9 +52,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
@@ -74,23 +74,14 @@ public class GoogleVideosImporter
   // TODO: internationalize copy prefix
   private static final String COPY_PREFIX = "Copy of ";
 
-  private final ImageStreamProvider videoStreamProvider;
+  private final ImageStreamProvider videoStreamProvider = new ImageStreamProvider();
   private Monitor monitor;
   private final AppCredentials appCredentials;
   private final TemporaryPerJobDataStore dataStore;
+  private Map<UUID, PhotosLibrarySettings> settingsMap = new HashMap<>();
 
   public GoogleVideosImporter(
       AppCredentials appCredentials, TemporaryPerJobDataStore dataStore, Monitor monitor) {
-    this(new ImageStreamProvider(), monitor, appCredentials, dataStore);
-  }
-
-  @VisibleForTesting
-  GoogleVideosImporter(
-      ImageStreamProvider videoStreamProvider,
-      Monitor monitor,
-      AppCredentials appCredentials,
-      TemporaryPerJobDataStore dataStore) {
-    this.videoStreamProvider = videoStreamProvider;
     this.monitor = monitor;
     this.appCredentials = appCredentials;
     this.dataStore = dataStore;
@@ -108,17 +99,25 @@ public class GoogleVideosImporter
       return ImportResult.OK;
     }
 
-    PhotosLibrarySettings settings =
-        PhotosLibrarySettings.newBuilder()
-            .setCredentialsProvider(
-                FixedCredentialsProvider.create(
-                    UserCredentials.newBuilder()
-                        .setClientId(appCredentials.getKey())
-                        .setClientSecret(appCredentials.getSecret())
-                        .setAccessToken(new AccessToken(authData.getAccessToken(), null))
-                        .setRefreshToken(authData.getRefreshToken())
-                        .build()))
-            .build();
+    PhotosLibrarySettings settings;
+    if (settingsMap.containsKey(jobId)) {
+      settings = settingsMap.get(jobId);
+    } else {
+      settings =
+          PhotosLibrarySettings.newBuilder()
+              .setCredentialsProvider(
+                  FixedCredentialsProvider.create(
+                      UserCredentials.newBuilder()
+                          .setClientId(appCredentials.getKey())
+                          .setClientSecret(appCredentials.getSecret())
+                          .setAccessToken(
+                              new AccessToken(
+                                  authData.getAccessToken(), new Date()))
+                          .setRefreshToken(authData.getRefreshToken())
+                          .build()))
+              .build();
+      settingsMap.put(jobId, settings);
+    }
 
     long bytes = 0L;
     //     Uploads videos


### PR DESCRIPTION
Summary:
Currently once google auth token expires after 1 hour, all video imports
would be rejected by Google due to invalid token.

This commit is to ask the video importer always refresh token before it
sends the first http request. So the right expiry time would be filled in for the job. 

Test Plan: Test by using expired token to transfer video and the refresh logic would kick in.
