### PR TITLE
Catch uncaught exceptions when job starts

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -79,14 +79,16 @@ final class JobProcessor {
     boolean success = false;
     UUID jobId = JobMetadata.getJobId();
     monitor.debug(() -> format("Begin processing jobId: %s", jobId), EventCode.WORKER_JOB_STARTED);
-    markJobStarted(jobId);
-    hooks.jobStarted(jobId);
 
-    PortabilityJob job = store.findJob(jobId);
-    JobAuthorization jobAuthorization = job.jobAuthorization();
     Collection<ErrorDetail> errors = null;
 
     try {
+      markJobStarted(jobId);
+      hooks.jobStarted(jobId);
+
+      PortabilityJob job = store.findJob(jobId);
+      JobAuthorization jobAuthorization = job.jobAuthorization();
+
       monitor.debug(
           () ->
               format(


### PR DESCRIPTION
Summary:
When an exception is thrown during finding job or starting job, it would
terminate the whole worker because it will be uncaught.

This commit is to catch those exceptions and make best effort to mark
the job failed when these happen.

Test Plan:
Throw out exception in these cases and see if the error is gracefully
handled.

Log lines after test:
> DEBUG 2020-06-17T13:23:11.786 Begin processing jobId: 8d2627e3-748e-44e5-94b6-b1692648367d
> EventCode: WORKER_JOB_STARTED
> SEVERE 2020-06-17T13:23:11.787 Error processing jobId: 8d2627e3-748e-44e5-94b6-b1692648367d
> java.lang.RuntimeException
> 	at org.datatransferproject.spi.cloud.storage.JobStoreWithValidator.markJobAsStarted(JobStoreWithValidator.java:72)
> 	at org.datatransferproject.transfer.JobProcessor.markJobStarted(JobProcessor.java:187)
> 	at org.datatransferproject.transfer.JobProcessor.processJob(JobProcessor.java:86)
> 	at org.datatransferproject.transfer.Worker.doWork(Worker.java:39)
> 	at org.datatransferproject.transfer.WorkerMain.poll(WorkerMain.java:138)
> 	at org.datatransferproject.bootstrap.vm.SingleVMMain$WorkerRunner.run(SingleVMMain.java:111)
> 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
> 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
> 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
> 	at java.lang.Thread.run(Thread.java:748)
> EventCode: WORKER_JOB_ERRORED
> DEBUG 2020-06-17T13:23:11.789 Finished processing jobId: 8d2627e3-748e-44e5-94b6-b1692648367d
> EventCode: WORKER_JOB_FINISHED
> DEBUG 2020-06-17T13:23:11.79 polling for job to check cancellation
> DEBUG 2020-06-17T13:23:11.791 Job 8d2627e3-748e-44e5-94b6-b1692648367d is not canceled
> SEVERE 2020-06-17T13:23:11.794 Could not mark job 8d2627e3-748e-44e5-94b6-b1692648367d as finished.