### PR TITLE
Fix wrong importer retry due to getErrors on executor

### DIFF
--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutor.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutor.java
@@ -96,4 +96,14 @@ public interface IdempotentImportExecutor {
    * @param jobId The jobId of the job that this IdempotentImportExecutor is being used for
    */
   void setJobId(UUID jobId);
+
+
+  /** Get the set of recent errors that occurred, and weren't subsequently successful. */
+  default Collection<ErrorDetail> getRecentErrors() {
+    return getErrors();
+  }
+
+  /** Reset recent errors to empty set */
+  default void resetRecentErrors() {}
+
 }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutor.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutor.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Callable;
 public class InMemoryIdempotentImportExecutor implements IdempotentImportExecutor {
   private final Map<String, Serializable> knownValues = new HashMap<>();
   private final Map<String, ErrorDetail> errors = new HashMap<>();
+  private final Map<String, ErrorDetail> recentErrors = new HashMap<>();
   private final Monitor monitor;
   private UUID jobId;
 
@@ -83,6 +84,7 @@ public class InMemoryIdempotentImportExecutor implements IdempotentImportExecuto
               .setException(Throwables.getStackTraceAsString(e))
               .build();
       errors.put(idempotentId, errorDetail);
+      recentErrors.put(idempotentId, errorDetail);
       monitor.severe(() -> jobIdPrefix + "Problem with importing item: " + errorDetail);
       throw e;
     }
@@ -113,5 +115,15 @@ public class InMemoryIdempotentImportExecutor implements IdempotentImportExecuto
   @Override
   public void setJobId(UUID jobId) {
     this.jobId = jobId;
+  }
+
+  @Override
+  public Collection<ErrorDetail> getRecentErrors() {
+    return ImmutableList.copyOf(recentErrors.values());
+  }
+
+  @Override
+  public void resetRecentErrors() {
+    recentErrors.clear();
   }
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java
@@ -63,9 +63,11 @@ public class CallableImporter implements Callable<ImportResult> {
     boolean success = false;
     Stopwatch stopwatch = Stopwatch.createStarted();
     try {
+      idempotentImportExecutor.resetRecentErrors();
       ImportResult result = importerProvider.get()
           .importItem(jobId, idempotentImportExecutor, authData, data);
-      Collection<ErrorDetail> errors = idempotentImportExecutor.getErrors();
+
+      Collection<ErrorDetail> errors = idempotentImportExecutor.getRecentErrors();
       success = result.getType() == ImportResult.ResultType.OK && errors.isEmpty();
 
       if (!success) {


### PR DESCRIPTION
Summary:
Currently in CallableImporter, the code would call getErrors on
idempotentExecutor to determine if there was any error when importing.

However, this getErrors would contain ALL errors happened in the
previous import actions, not errors only happened for the current
import. This would mean one import error in the early stage would cause
retry for all subsequent import actions.

This commit is to add new methods to track only recent errors on
executor and only throw out exceptions when those recent errors are
created.

Test Plan:
Raise one IOException when importing and check if it would impact the
subseqent import retries.