### PR TITLE
Handle NullPointerException when unwrapping Google Photos response

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -155,4 +155,26 @@ public class GooglePhotosImporterTest {
     assertEquals(mediaItem.getSimpleMediaItem().getUploadToken(), UPLOAD_TOKEN);
     assertEquals(mediaItem.getDescription(), "Copy of " + PHOTO_DESCRIPTION);
   }
+
+  @Test(expected = IOException.class)
+  public void createPhotoBadResponse() throws Exception {
+    // Set up
+    PhotoModel photoModel =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID",
+            OLD_ALBUM_ID,
+            false);
+
+    executor.executeOrThrowException(OLD_ALBUM_ID, OLD_ALBUM_ID, () -> NEW_ALBUM_ID);
+
+    Mockito.when(googlePhotosInterface.createPhoto(any(NewMediaItemUpload.class)))
+        .thenReturn(null); // bad response (null)
+
+    // Run test
+    googlePhotosImporter.importSinglePhoto(uuid, null, photoModel, executor);
+  }
 }


### PR DESCRIPTION
Summary:
Previously we got a null pointer exception when importing a single photo into Google Photos.  This commit adds null checks and instead throws an IOException, which can be used by our workers to retry a photo import.

Test Plan: Ran a test transfer in Docker. Add a test to confirm that an IOException is raised, not a NullPointerException.
