### PR TITLE
Export albumless photos in the flickr exporter

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosExporter.java
@@ -143,7 +143,7 @@ public class FlickrPhotosExporter implements Exporter<AuthData, PhotosContainerR
     PhotoList<Photo> photoSetList;
 
     try {
-      if (photoSetId == null) {
+      if (Strings.isNullOrEmpty(photoSetId)) {
         RequestContext.getRequestContext().setExtras(EXTRAS);
         perUserRateLimiter.acquire();
         photoSetList = photosInterface.getNotInSet(PHOTO_PER_PAGE, page);
@@ -208,6 +208,9 @@ public class FlickrPhotosExporter implements Exporter<AuthData, PhotosContainerR
         photoSetList.getPage() != photoSetList.getPages() && !photoSetList.getPhotosets().isEmpty();
     if (hasMore) {
       newPage = new IntPaginationToken(page + 1);
+    } else {
+      // No more albums to get, add a resource for albumless items
+      subResources.add(new IdOnlyContainerResource(""));
     }
 
     PhotosContainerResource photosContainerResource =


### PR DESCRIPTION
This gets triggered after we are done exporting all named albums by sending in an album with an empty title. 

Note: it is impossible for an album to have an empty title in Flickr, this is enforced in their UI when you create an album and in the API when you create an album, so we'll never have a collision here. And since this doesn't actually add an `AlbumContainerResource` there is no issue with it appearing in any importer as an album either (it will just trigger the subresources to be processed).

Fixes #906 