### PR TITLE
Read ExportInformation as a string and deserialize it in the JobProcessor

### DIFF
--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/CreateTransferJobAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/CreateTransferJobAction.java
@@ -181,7 +181,7 @@ public class CreateTransferJobAction implements Action<CreateTransferJob, Transf
   }
 
   /** Populates the initial state of the {@link PortabilityJob} instance. */
-  private static PortabilityJob createJob(
+  private PortabilityJob createJob(
       String encodedSessionKey,
       String dataType,
       String exportService,
@@ -203,7 +203,10 @@ public class CreateTransferJobAction implements Action<CreateTransferJob, Transf
             .setExportService(exportService)
             .setImportService(importService)
             .setAndValidateJobAuthorization(jobAuthorization);
-    exportInformation.ifPresent(builder::setExportInformation);
+    if(exportInformation.isPresent()) {
+      builder.setExportInformation(objectMapper.writeValueAsString(exportConfiguration.getInitialAuthData()));
+    }
+
     return builder.build();
   }
 }

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
@@ -8,12 +8,9 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import org.datatransferproject.types.common.ExportInformation;
-
-import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * A job that will fulfill a transfer request.
@@ -94,7 +91,7 @@ public abstract class PortabilityJob {
         .setExportService((String) properties.get(EXPORT_SERVICE_KEY))
         .setImportService((String) properties.get(IMPORT_SERVICE_KEY))
         .setTransferDataType((String) properties.get(DATA_TYPE_KEY))
-        .setExportInformation((ExportInformation) properties.get(EXPORT_INFORMATION_KEY))
+        .setExportInformation((String) properties.get(EXPORT_INFORMATION_KEY))
         .setCreatedTimestamp(now) // TODO: get from DB
         .setLastUpdateTimestamp(now)
         .setFailureReason(failureReason)
@@ -141,7 +138,7 @@ public abstract class PortabilityJob {
 
   @Nullable
   @JsonProperty("exportInformation")
-  public abstract ExportInformation exportInformation();
+  public abstract String exportInformation();
 
   @JsonProperty("createdTimestamp")
   public abstract Instant createdTimestamp(); // ISO 8601 timestamp
@@ -241,7 +238,7 @@ public abstract class PortabilityJob {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("exportInformation")
-    public abstract Builder setExportInformation(ExportInformation exportInformation);
+    public abstract Builder setExportInformation(String exportInformation);
 
     @JsonProperty("createdTimestamp")
     public abstract Builder setCreatedTimestamp(Instant createdTimestamp);

--- a/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
+++ b/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
@@ -83,13 +83,13 @@ public class PortabilityJobTest {
             .setExportService("fooService")
             .setImportService("barService")
             .setTransferDataType("PHOTOS")
-            .setExportInformation(
+            .setExportInformation(objectMapper.writeValueAsString(
                 new ExportInformation(
                     null,
                     new PhotosContainerResource(
                         Lists.newArrayList(
                             new PhotoAlbum("album_id", "album name", "album description")),
-                        null)))
+                        null))))
             .setCreatedTimestamp(date)
             .setLastUpdateTimestamp(date.plusSeconds(120))
             .setJobAuthorization(jobAuthorization)

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -18,7 +18,7 @@ package org.datatransferproject.transfer;
 import static java.lang.String.format;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import java.io.IOException;
 import java.util.Collection;
@@ -112,7 +112,11 @@ final class JobProcessor {
       AuthData exportAuthData = objectMapper.readValue(pair.getExportAuthData(), AuthData.class);
       AuthData importAuthData = objectMapper.readValue(pair.getImportAuthData(), AuthData.class);
 
-      Optional<ExportInformation> exportInfo = Optional.ofNullable(job.exportInformation());
+      String exportInfoStr = job.exportInformation();
+      Optional<ExportInformation> exportInfo = Optional.empty();
+      if (!Strings.isNullOrEmpty(exportInfoStr)) {
+        exportInfo = Optional.of(objectMapper.readValue(exportInfoStr, ExportInformation.class));
+      }
 
       // Copy the data
       dtpInternalMetricRecorder.startedJob(


### PR DESCRIPTION
Previously we were expecting that the builder be able to pull out the the ExportInformation from the map, however the cloud extension thats used writes this out as a json string

Interested in thoughts here, we already deserialize objects in the Processor (ex: the AuthData pair). The other thing we can do is deserialize in the Cloud extension, but we dont have a good convention for what is and isnt deserialized (or decrypted) there. 