### PR TITLE
Enable exporting of specific resources in the GooglePhotosExporter and FlickrPhotosExporter

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosExporter.java
@@ -123,6 +123,14 @@ public class FlickrPhotosExporter implements Exporter<AuthData, PhotosContainerR
 
     RequestContext.getRequestContext().setAuth(auth);
 
+    if (exportInformation.isPresent()
+        && exportInformation.get().getContainerResource() instanceof PhotosContainerResource) {
+      // if ExportInformation is a photos container, this is a request to only export the contents
+      // in that container instead of the whole user library
+      return exportPhotosContainer(
+          (PhotosContainerResource) exportInformation.get().getContainerResource());
+    }
+
     PaginationData paginationData =
         exportInformation.isPresent() ? exportInformation.get().getPaginationData() : null;
     IdOnlyContainerResource resource =
@@ -134,6 +142,37 @@ public class FlickrPhotosExporter implements Exporter<AuthData, PhotosContainerR
     } else {
       return getAlbums(paginationData, auth);
     }
+  }
+
+  private ExportResult<PhotosContainerResource> exportPhotosContainer(
+      PhotosContainerResource container) {
+    ImmutableList.Builder<PhotoAlbum> albumBuilder = ImmutableList.builder();
+    ImmutableList.Builder<PhotoModel> photosBuilder = ImmutableList.builder();
+    List<IdOnlyContainerResource> subResources = new ArrayList<>();
+
+    try {
+      for (PhotoAlbum album : container.getAlbums()) {
+        Photoset photoset = photosetsInterface.getInfo(album.getId());
+        // Saving data to the album allows the target service to recreate the album structure
+        albumBuilder.add(
+            new PhotoAlbum(photoset.getId(), photoset.getTitle(), photoset.getDescription()));
+        // Adding subresources tells the framework to recall export to get all the photos
+        subResources.add(new IdOnlyContainerResource(photoset.getId()));
+      }
+
+      for (PhotoModel photo : container.getPhotos()) {
+        Photo p = photosInterface.getInfo(photo.getDataId(), null);
+        photosBuilder.add(toCommonPhoto(p, null));
+      }
+    } catch (FlickrException e) {
+      return new ExportResult<>(e);
+    }
+
+    PhotosContainerResource photosContainerResource =
+        new PhotosContainerResource(albumBuilder.build(), photosBuilder.build());
+    ContinuationData continuationData = new ContinuationData(null);
+    subResources.forEach(resource -> continuationData.addContainerResource(resource));
+    return new ExportResult<>(ResultType.CONTINUE, photosContainerResource, continuationData);
   }
 
   private ExportResult<PhotosContainerResource> getPhotos(

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosExporter.java
@@ -123,10 +123,10 @@ public class FlickrPhotosExporter implements Exporter<AuthData, PhotosContainerR
 
     RequestContext.getRequestContext().setAuth(auth);
 
+    // If ExportInformation is a photos container, this is a request to only export the contents
+    // in that container instead of the whole user library
     if (exportInformation.isPresent()
         && exportInformation.get().getContainerResource() instanceof PhotosContainerResource) {
-      // if ExportInformation is a photos container, this is a request to only export the contents
-      // in that container instead of the whole user library
       return exportPhotosContainer(
           (PhotosContainerResource) exportInformation.get().getContainerResource());
     }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
@@ -110,18 +110,21 @@ public class GooglePhotosExporter
           (PhotosContainerResource) exportInformation.get().getContainerResource(), authData);
     }
 
-    /* Use the export information to determine whether this export call should export albums or
-    photos.
-    Albums are exported if and only if the export information doesn't hold an album
-    already, and the pagination token begins with the album prefix.  There must be a pagination
-    token for album export since this is isn't the first export operation performed (if it was,
-    there wouldn't be any export information at all).
-    Otherwise, photos are exported.  If photos are exported, there may or may not be pagination
-    information, and there may or may not be album information.
-    If there is no container resource, that means that we're exporting albumless photos and a
-    pagination token must be present.  The beginning step of exporting albumless photos is
-    indicated by a pagination token containing only PHOTO_TOKEN_PREFIX with no token attached, in
-    order to differentiate this case for the first step of export (no export information at all).
+    /*
+     * Use the export information to determine whether this export call should export albums or
+     * photos.
+     *
+     * Albums are exported if and only if the export information doesn't hold an album
+     * already, and the pagination token begins with the album prefix.  There must be a pagination
+     * token for album export since this is isn't the first export operation performed (if it was,
+     * there wouldn't be any export information at all).
+     *
+     * Otherwise, photos are exported. If photos are exported, there may or may not be pagination
+     * information, and there may or may not be album information. If there is no container
+     * resource, that means that we're exporting albumless photos and a pagination token must be
+     * present. The beginning step of exporting albumless photos is indicated by a pagination token
+     * containing only PHOTO_TOKEN_PREFIX with no token attached, in order to differentiate this
+     * case for the first step of export (no export information at all).
      */
     StringPaginationToken paginationToken =
         (StringPaginationToken) exportInformation.get().getPaginationData();
@@ -263,7 +266,9 @@ public class GooglePhotosExporter
     return new ExportResult<>(resultType, containerResource, continuationData);
   }
 
-  /** Method for storing a list of all photos that are already contained in albums */
+  /**
+   * Method for storing a list of all photos that are already contained in albums
+   */
   @VisibleForTesting
   void populateContainedPhotosList(UUID jobId, TokensAndUrlAuthData authData)
       throws IOException, InvalidTokenException, PermissionDeniedException {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporter.java
@@ -161,7 +161,7 @@ public class GooglePhotosExporter
     for (PhotoModel photo : container.getPhotos()) {
       GoogleMediaItem googleMediaItem =
           getOrCreatePhotosInterface(authData).getMediaItem(photo.getDataId());
-      photosBuilder.add(convertToPhotoModel(null, googleMediaItem));
+      photosBuilder.add(convertToPhotoModel(Optional.empty(), googleMediaItem));
     }
 
     PhotosContainerResource photosContainerResource =

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosInterface.java
@@ -56,6 +56,7 @@ import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactor
 import org.datatransferproject.datatransfer.google.mediaModels.AlbumListResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
+import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
 import org.datatransferproject.datatransfer.google.mediaModels.MediaItemSearchResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
@@ -108,6 +109,17 @@ public class GooglePhotosInterface {
       params.put(TOKEN_KEY, pageToken.get());
     }
     return makeGetRequest(BASE_URL + "albums", Optional.of(params), AlbumListResponse.class);
+  }
+
+  GoogleAlbum getAlbum(String albumId) throws IOException, InvalidTokenException, PermissionDeniedException{
+    Map<String, String> params = new LinkedHashMap<>();
+    return makeGetRequest(BASE_URL + "albums/" + albumId, Optional.of(params), GoogleAlbum.class);
+  }
+
+  GoogleMediaItem getMediaItem(String mediaId) throws IOException, InvalidTokenException, PermissionDeniedException {
+    Map<String, String> params = new LinkedHashMap<>();
+    return makeGetRequest(BASE_URL + "mediaItems/" + mediaId, Optional.of(params), GoogleMediaItem
+        .class);
   }
 
   MediaItemSearchResponse listMediaItems(Optional<String> albumId, Optional<String> pageToken)


### PR DESCRIPTION
This is a quick first pass at enabling exporting specific resources in these exporters. 

Previously they only accepted IdOnlyContainerResources in the export information. This assumes that if the ExportInformation contains a PhotosContainerResource that the export process should start there instead of listing out all the user media items