### PR TITLE
Update subtypes of ContainerResource

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/ContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/ContainerResource.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.datatransferproject.types.common.models.calendar.CalendarContainerResource;
 import org.datatransferproject.types.common.models.mail.MailContainerResource;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.common.models.playlists.PlaylistContainerResource;
+import org.datatransferproject.types.common.models.social.SocialActivityContainerResource;
 import org.datatransferproject.types.common.models.tasks.TaskContainerResource;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 
 /**
  * A resource that contains data items such as a photo album or song list.
@@ -16,9 +19,12 @@ import org.datatransferproject.types.common.models.tasks.TaskContainerResource;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
         @JsonSubTypes.Type(PhotosContainerResource.class),
+        @JsonSubTypes.Type(VideosContainerResource.class),
         @JsonSubTypes.Type(MailContainerResource.class),
         @JsonSubTypes.Type(CalendarContainerResource.class),
         @JsonSubTypes.Type(TaskContainerResource.class),
+        @JsonSubTypes.Type(PlaylistContainerResource.class),
+        @JsonSubTypes.Type(SocialActivityContainerResource.class),
         @JsonSubTypes.Type(IdOnlyContainerResource.class)
 })
 public abstract class ContainerResource extends DataModel {}


### PR DESCRIPTION
I noticed that VideoContainerResource was not a subtype of ContainerResource.

This diff corrects the ContainerResource file to add the other subtypes of Container resource, the only exception being BlobbyDataContainerResource - this is because it resides in another module and doing so would introduce a cyclic build dependency. (https://github.com/google/data-transfer-project/issues/916 already flags this). 
