### PR TITLE
Override equality for container resources

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarAttendeeModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarAttendeeModel.java
@@ -18,6 +18,8 @@ package org.datatransferproject.types.common.models.calendar;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 public class CalendarAttendeeModel {
   private final String displayName;
   private final String email;
@@ -43,5 +45,20 @@ public class CalendarAttendeeModel {
 
   public String getDisplayName() {
     return displayName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CalendarAttendeeModel that = (CalendarAttendeeModel) o;
+    return getOptional() == that.getOptional() &&
+            Objects.equals(getDisplayName(), that.getDisplayName()) &&
+            Objects.equals(getEmail(), that.getEmail());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getDisplayName(), getEmail(), getOptional());
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
+import java.util.Objects;
 import org.datatransferproject.types.common.models.ContainerResource;
 
 /** A Wrapper for all the possible objects that can be returned by a calendar exporter. */
@@ -42,5 +43,19 @@ public class CalendarContainerResource extends ContainerResource {
 
   public Collection<CalendarEventModel> getEvents() {
     return events;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CalendarContainerResource that = (CalendarContainerResource) o;
+    return Objects.equals(getCalendars(), that.getCalendars()) &&
+            Objects.equals(getEvents(), that.getEvents());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getCalendars(), getEvents());
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarEventModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarEventModel.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 public class CalendarEventModel {
 
@@ -83,6 +84,34 @@ public class CalendarEventModel {
     return recurrenceRule;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CalendarEventModel that = (CalendarEventModel) o;
+    return Objects.equals(getCalendarId(), that.getCalendarId())
+        && Objects.equals(getTitle(), that.getTitle())
+        && Objects.equals(getNotes(), that.getNotes())
+        && Objects.equals(getAttendees(), that.getAttendees())
+        && Objects.equals(getLocation(), that.getLocation())
+        && Objects.equals(getStartTime(), that.getStartTime())
+        && Objects.equals(getEndTime(), that.getEndTime())
+        && Objects.equals(getRecurrenceRule(), that.getRecurrenceRule());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getCalendarId(),
+        getTitle(),
+        getNotes(),
+        getAttendees(),
+        getLocation(),
+        getStartTime(),
+        getEndTime(),
+        getRecurrenceRule());
+  }
+
   public static class CalendarEventTime {
     private final OffsetDateTime dateTime;
     private final boolean dateOnly;
@@ -101,6 +130,20 @@ public class CalendarEventModel {
 
     public boolean isDateOnly() {
       return dateOnly;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      CalendarEventTime that = (CalendarEventTime) o;
+      return isDateOnly() == that.isDateOnly() &&
+              Objects.equals(getDateTime(), that.getDateTime());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getDateTime(), isDateOnly());
     }
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarModel.java
@@ -18,6 +18,8 @@ package org.datatransferproject.types.common.models.calendar;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 public class CalendarModel {
   private final String id;
   private final String name;
@@ -44,4 +46,20 @@ public class CalendarModel {
   public String getId() {
     return id;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CalendarModel that = (CalendarModel) o;
+    return Objects.equals(getId(), that.getId()) &&
+            Objects.equals(getName(), that.getName()) &&
+            Objects.equals(getDescription(), that.getDescription());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), getName(), getDescription());
+  }
+
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/mail/MailContainerModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/mail/MailContainerModel.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
+import java.util.Objects;
+
 // Model for a mail folder or label, which may contain sub folders and messages
 public final class MailContainerModel {
   private final String id;
@@ -41,5 +43,19 @@ public final class MailContainerModel {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("id", id).add("name", name).toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MailContainerModel that = (MailContainerModel) o;
+    return Objects.equals(getId(), that.getId()) &&
+            Objects.equals(getName(), that.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), getName());
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/mail/MailContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/mail/MailContainerResource.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
+import java.util.Objects;
 import org.datatransferproject.types.common.models.ContainerResource;
 
 /** A Wrapper for all the possible objects that can be returned by a mail exporter. */
@@ -51,5 +52,19 @@ public class MailContainerResource extends ContainerResource {
         .add("folders", folders.size())
         .add("messages", messages.size())
         .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MailContainerResource that = (MailContainerResource) o;
+    return Objects.equals(getFolders(), that.getFolders()) &&
+            Objects.equals(getMessages(), that.getMessages());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getFolders(), getMessages());
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/mail/MailMessageModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/mail/MailMessageModel.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
 
 public final class MailMessageModel {
   private final String rawString;
@@ -48,5 +49,19 @@ public final class MailMessageModel {
         .add("rawString", rawString.length())
         .add("containerIds", containerIds.size())
         .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MailMessageModel that = (MailMessageModel) o;
+    return Objects.equals(getRawString(), that.getRawString()) &&
+            Objects.equals(getContainerIds(), that.getContainerIds());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getRawString(), getContainerIds());
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/tasks/TaskContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/tasks/TaskContainerResource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
+import java.util.Objects;
 import org.datatransferproject.types.common.models.ContainerResource;
 
 /** A Wrapper for all the possible objects that can be returned by a task exporter. */
@@ -42,5 +43,19 @@ public class TaskContainerResource extends ContainerResource {
 
   public Collection<TaskModel> getTasks() {
     return tasks;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TaskContainerResource that = (TaskContainerResource) o;
+    return Objects.equals(getLists(), that.getLists())
+        && Objects.equals(getTasks(), that.getTasks());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getLists(), getTasks());
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/tasks/TaskListModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/tasks/TaskListModel.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.datatransferproject.types.common.models.DataModel;
 
+import java.util.Objects;
+
 public class TaskListModel extends DataModel {
   private final String id;
   private final String name;
@@ -35,5 +37,19 @@ public class TaskListModel extends DataModel {
 
   public String getId() {
     return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TaskListModel that = (TaskListModel) o;
+    return Objects.equals(getId(), that.getId()) &&
+            Objects.equals(getName(), that.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), getName());
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/tasks/TaskModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/tasks/TaskModel.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 
 public class TaskModel {
   private final String taskListId;
@@ -56,4 +57,21 @@ public class TaskModel {
   public Instant getCompletedTime() { return completedTime; }
 
   public Instant getDueTime() { return dueTime; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TaskModel taskModel = (TaskModel) o;
+    return Objects.equals(getTaskListId(), taskModel.getTaskListId()) &&
+            Objects.equals(getText(), taskModel.getText()) &&
+            Objects.equals(getNotes(), taskModel.getNotes()) &&
+            Objects.equals(getCompletedTime(), taskModel.getCompletedTime()) &&
+            Objects.equals(getDueTime(), taskModel.getDueTime());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getTaskListId(), getText(), getNotes(), getCompletedTime(), getDueTime());
+  }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
@@ -55,4 +55,18 @@ public class VideosContainerResource extends ContainerResource {
         .put(ALBUMS_COUNT_DATA_NAME, albums.size())
         .build();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    VideosContainerResource that = (VideosContainerResource) o;
+    return Objects.equals(getAlbums(), that.getAlbums())
+        && Objects.equals(getVideos(), that.getVideos());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getAlbums(), getVideos());
+  }
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResourceTest.java
@@ -9,6 +9,7 @@ import org.datatransferproject.types.common.models.calendar.CalendarEventModel.C
 import org.junit.Test;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 public class CalendarContainerResourceTest {
@@ -18,7 +19,8 @@ public class CalendarContainerResourceTest {
     objectMapper.registerModule(new JavaTimeModule());
     objectMapper.registerSubtypes(CalendarContainerResource.class);
 
-    CalendarEventTime today = new CalendarEventTime(OffsetDateTime.now(), true);
+    CalendarEventTime today =
+        new CalendarEventTime(OffsetDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), true);
 
     List<CalendarModel> calendars =
         ImmutableList.of(new CalendarModel("id1", "name", "description"));
@@ -48,5 +50,6 @@ public class CalendarContainerResourceTest {
     CalendarContainerResource deserialized = (CalendarContainerResource) deserializedModel;
     Truth.assertThat(deserialized.getCalendars()).hasSize(1);
     Truth.assertThat(deserialized.getEvents()).hasSize(2);
+    Truth.assertThat(deserialized).isEqualTo(data);
   }
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/mail/MailContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/mail/MailContainerResourceTest.java
@@ -38,5 +38,6 @@ public class MailContainerResourceTest {
     MailContainerResource deserialized = (MailContainerResource) deserializedModel;
     Truth.assertThat(deserialized.getMessages()).hasSize(2);
     Truth.assertThat(deserialized.getFolders()).hasSize(2);
+    Truth.assertThat(deserialized).isEqualTo(data);
   }
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotosContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotosContainerResourceTest.java
@@ -39,6 +39,7 @@ public class PhotosContainerResourceTest {
     PhotosContainerResource deserialized = (PhotosContainerResource) deserializedModel;
     Truth.assertThat(deserialized.getAlbums()).hasSize(1);
     Truth.assertThat(deserialized.getPhotos()).hasSize(2);
+    Truth.assertThat(deserialized).isEqualTo(data);
   }
 
   @Test

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/tasks/TaskContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/tasks/TaskContainerResourceTest.java
@@ -25,7 +25,7 @@ public class TaskContainerResourceTest {
     List<TaskModel> tasks =
         ImmutableList.of(
             new TaskModel("id1", "Write Better tests", "Do this soon", null, null),
-            new TaskModel("id1", "Liberate all the data", "do this in stages", null, null));
+            new TaskModel("id2", "Liberate all the data", "do this in stages", null, null));
 
     ContainerResource data = new TaskContainerResource(taskLists, tasks);
 
@@ -39,5 +39,6 @@ public class TaskContainerResourceTest {
     TaskContainerResource deserialized = (TaskContainerResource) deserializedModel;
     Truth.assertThat(deserialized.getLists()).hasSize(1);
     Truth.assertThat(deserialized.getTasks()).hasSize(2);
+    Truth.assertThat(deserialized).isEqualTo(data);
   }
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/tasks/TaskContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/tasks/TaskContainerResourceTest.java
@@ -12,7 +12,7 @@ import org.datatransferproject.types.common.models.tasks.TaskListModel;
 import org.datatransferproject.types.common.models.tasks.TaskModel;
 import org.junit.Test;
 
-public class TasksModelWrapperTest {
+public class TaskContainerResourceTest {
 
   @Test
   public void verifySerializeDeserialize() throws Exception {

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
@@ -52,5 +52,6 @@ public class VideosContainerResourceTest {
     VideosContainerResource deserialized = (VideosContainerResource) deserializedModel;
     Truth.assertThat(deserialized.getAlbums()).hasSize(1);
     Truth.assertThat(deserialized.getVideos()).hasSize(2);
+    Truth.assertThat(deserialized).isEqualTo(data);
   }
 }


### PR DESCRIPTION
Currently serialisation and deserialisation tests checking object equality fail because the VideosContainerResource does not override equals() unlike PhotosContainerResource. This PR updates the VideoContainerResource and Task and Calendar container resources to override equals().

Updated tests so they check object equality between the deserialised object and the original data.