### PR TITLE
Change job cancellation polling logging to info

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobPollingService.java
@@ -235,7 +235,7 @@ class JobPollingService extends AbstractScheduledService {
           EventCode.WORKER_JOB_ERRORED);
       this.stopAsync();
     } else if (job.state() == PortabilityJob.State.CANCELED) {
-      monitor.severe(
+      monitor.info(
           () -> format("Could not poll job %s, it was cancelled", jobId),
           EventCode.WORKER_JOB_CANCELED);
       this.stopAsync();


### PR DESCRIPTION
Summary:
Job being cancelled is a perfectly valid action. When that happens, java
worker should not log a severe log line.

Change the log line to info

Test Plan: Did a transfer on cancelled job and checked the log line.