### PR TITLE
Add uploadedTime property to PhotoModel

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/photos/FacebookPhotosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/photos/FacebookPhotosExporter.java
@@ -227,7 +227,8 @@ public class FacebookPhotosExporter
                 "image/jpg",
                 photo.getId(),
                 albumId,
-                true));
+                true,
+                photo.getCreatedTime()));
       }
 
       String token = photoConnection.getAfterCursor();

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/photos/FacebookPhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/photos/FacebookPhotosExporterTest.java
@@ -59,6 +59,7 @@ public class FacebookPhotosExporterTest {
   private static final String PHOTO_ID = "937644721";
   private static final String PHOTO_SOURCE = "https://www.example.com/photo.jpg";
   private static final String PHOTO_NAME = "Example photo";
+  private static final Date PHOTO_TIME = new Date(1234567890123L);
 
   private FacebookPhotosExporter facebookPhotosExporter;
   private UUID uuid = UUID.randomUUID();
@@ -84,7 +85,7 @@ public class FacebookPhotosExporterTest {
     // Set up example photo
     Photo photo = new Photo();
     photo.setId(PHOTO_ID);
-    photo.setCreatedTime(new Date());
+    photo.setCreatedTime(PHOTO_TIME);
     Photo.Image image = new Photo.Image();
     image.setSource(PHOTO_SOURCE);
     photo.addImage(image);
@@ -146,7 +147,14 @@ public class FacebookPhotosExporterTest {
     assertEquals(1, exportedData.getPhotos().size());
     assertEquals(
         new PhotoModel(
-            PHOTO_ID + ".jpg", PHOTO_ID, PHOTO_NAME, "image/jpg", PHOTO_ID, ALBUM_ID, false),
+            PHOTO_ID + ".jpg",
+            PHOTO_ID,
+            PHOTO_NAME,
+            "image/jpg",
+            PHOTO_ID,
+            ALBUM_ID,
+            false,
+            PHOTO_TIME),
         exportedData.getPhotos().toArray()[0]);
   }
 

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoModel.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import java.util.Date;
 import java.util.stream.Collectors;
 
 public class PhotoModel {
@@ -31,6 +32,7 @@ public class PhotoModel {
   private String albumId;
   private final boolean inTempStore;
   private String dataId;
+  private Date uploadedTime;
 
   @JsonCreator
   public PhotoModel(
@@ -40,7 +42,8 @@ public class PhotoModel {
       @JsonProperty("mediaType") String mediaType,
       @JsonProperty("dataId") String dataId,
       @JsonProperty("albumId") String albumId,
-      @JsonProperty("inTempStore") boolean inTempStore) {
+      @JsonProperty("inTempStore") boolean inTempStore,
+      @JsonProperty("uploadedTime") Date uploadedTime) {
     this.title = title;
     this.fetchableUrl = fetchableUrl;
     this.description = description;
@@ -51,6 +54,28 @@ public class PhotoModel {
     this.dataId = dataId;
     this.albumId = albumId;
     this.inTempStore = inTempStore;
+    this.uploadedTime = uploadedTime;
+  }
+
+  public PhotoModel(
+      String title,
+      String fetchableUrl,
+      String description,
+      String mediaType,
+      String dataId,
+      String albumId,
+      boolean inTempStore) {
+    this.title = title;
+    this.fetchableUrl = fetchableUrl;
+    this.description = description;
+    this.mediaType = mediaType;
+    if (dataId == null || dataId.isEmpty()) {
+      throw new IllegalArgumentException("dataID must be set");
+    }
+    this.dataId = dataId;
+    this.albumId = albumId;
+    this.inTempStore = inTempStore;
+    this.uploadedTime = null;
   }
 
   public String getTitle() {
@@ -75,6 +100,10 @@ public class PhotoModel {
 
   public String getDataId() {
     return dataId;
+  }
+
+  public Date getUploadedTime() {
+    return uploadedTime;
   }
 
   // remove all forbidden characters
@@ -102,6 +131,7 @@ public class PhotoModel {
         .add("dataId", dataId)
         .add("albumId", albumId)
         .add("inTempStore", inTempStore)
+        .add("uploadedTime", uploadedTime)
         .toString();
   }
 
@@ -115,7 +145,8 @@ public class PhotoModel {
             Objects.equal(getDescription(), that.getDescription()) &&
             Objects.equal(getMediaType(), that.getMediaType()) &&
             Objects.equal(getDataId(), that.getDataId()) &&
-            Objects.equal(getAlbumId(), that.getAlbumId());
+            Objects.equal(getAlbumId(), that.getAlbumId()) &&
+            Objects.equal(getUploadedTime(), that.getUploadedTime());
   }
 
   @Override


### PR DESCRIPTION
We want to be able to pass a time property straight through to adapters who can then use it for media sorting or setting properties. Ideally we will use this with the Google Photos API if https://issuetracker.google.com/issues/133782941 is resolved.