### PR TITLE
Add period `.` to list of forbidden album name characters

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftTransmogrificationConfig.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftTransmogrificationConfig.java
@@ -4,23 +4,23 @@ import org.datatransferproject.types.common.models.TransmogrificationConfig;
 
 // This class defines transmogrification paramaters for Microsoft imports
 public class MicrosoftTransmogrificationConfig extends TransmogrificationConfig {
-    /** 
-    OneDrive has forbidden characters for file names:
-        https://support.office.com/en-us/article/invalid-file-names-and-file-types-in-onedrive-onedrive-for-business-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa#invalidcharacters
-    */  
-    private static final String    PHOTO_TITLE_FORBIDDEN_CHARACTERS    = "~\"#%&*:<>?/\\{|}";
-    private static final String    ALBUM_NAME_FORBIDDEN_CHARACTERS     = "~\"#%&*:<>?/\\{|}";
 
-    /**
-        We need to override the methods
-    */
-    @Override
-    public String getPhotoTitleForbiddenCharacters() {
-        return PHOTO_TITLE_FORBIDDEN_CHARACTERS;
-    }
+  /**
+   * OneDrive has forbidden characters for file names: https://support.office.com/en-us/article/invalid-file-names-and-file-types-in-onedrive-onedrive-for-business-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa#invalidcharacters
+   */
+  private static final String PHOTO_TITLE_FORBIDDEN_CHARACTERS = "~\"#%&*:<>?/\\{|}";
+  private static final String ALBUM_NAME_FORBIDDEN_CHARACTERS = ".~\"#%&*:<>?/\\{|}";
 
-    @Override
-    public String getAlbumNameForbiddenCharacters() {
-        return ALBUM_NAME_FORBIDDEN_CHARACTERS;
-    }
+  /**
+   * We need to override the methods
+   */
+  @Override
+  public String getPhotoTitleForbiddenCharacters() {
+    return PHOTO_TITLE_FORBIDDEN_CHARACTERS;
+  }
+
+  @Override
+  public String getAlbumNameForbiddenCharacters() {
+    return ALBUM_NAME_FORBIDDEN_CHARACTERS;
+  }
 }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -138,8 +138,11 @@ public class MicrosoftPhotosImporter
     // Note that PhotoAlbum.getName() can return an empty string or null depending
     // on the results of PhotoAlbum.cleanName(), e.g. if a Google Photos album has
     // title=" ", its cleaned name will be "". See PhotoAlbum.cleanName for further
-    // details on what forms the name can take .
+    // details on what forms the name can take . In addition, the album name can not end in a period
+    // so we manually have to check for that as well
     String albumName = Strings.isNullOrEmpty(album.getName()) ? "Untitled" : album.getName();
+    albumName.replaceAll(".", " ");
+
     rawFolder.put("name", albumName);
     rawFolder.put("folder", new LinkedHashMap());
     rawFolder.put("@microsoft.graph.conflictBehavior", "rename");

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -138,11 +138,8 @@ public class MicrosoftPhotosImporter
     // Note that PhotoAlbum.getName() can return an empty string or null depending
     // on the results of PhotoAlbum.cleanName(), e.g. if a Google Photos album has
     // title=" ", its cleaned name will be "". See PhotoAlbum.cleanName for further
-    // details on what forms the name can take . In addition, the album name can not end in a period
-    // so we manually have to check for that as well
+    // details on what forms the name can take.
     String albumName = Strings.isNullOrEmpty(album.getName()) ? "Untitled" : album.getName();
-    albumName.replaceAll(".", " ");
-
     rawFolder.put("name", albumName);
     rawFolder.put("folder", new LinkedHashMap());
     rawFolder.put("@microsoft.graph.conflictBehavior", "rename");


### PR DESCRIPTION
We were getting errors for certain albums like this: 

```
org.datatransferproject.types.transfer.retry.RetryException: java.io.IOException: Problem with importer, forcing a retry, 2 errors, first one: ErrorDetail{id=ANUH2qoydPFKocl1xJ7RJ56lLhVrLm4j-Q1jl3DLkhMcwjvwuXHzB1gzMxONyACx8ljAvbbBfSjw, title=REDACTED, exception=java.io.IOException: Got error code: 400 message: Bad Request body: {
  "error": {
    "code": "invalidRequest",
    "message": "Path (REDACTED) contains invalid trailing character.",
    "innerError": {
      "code": "nameContainsInvalidCharacters",
      "date": "2020-08-04T15:16:36",
      "request-id": "a2f1831e-e40f-4103-acee-67b858193482"
    }
  }
}
```

I've removed the album title, but for all the cases we've seen this was when the title ended in a period. I cant find any official documentation on this from Microsoft (forbidden characters are documented here: https://support.microsoft.com/en-us/office/invalid-file-names-and-file-types-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa?ui=en-us&rs=en-us&ad=us#invalidcharacters) but there have been several reports on github of this happening due to a period or a space at the end. In addition this article suggests the same thing: https://support.tresorit.com/hc/en-us/articles/216114167-Fixing-invalid-characters-and-colliding-file-names - `The filename can’t end with a space or a period`

rather than putting in special logic to check if the last character is a period, opt'd to just add it to the list of album forbidden characters. 


