### PR TITLE
Properly categorize and throw PermissionDeniedException in MicrosoftPhotosImporter

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -163,7 +163,7 @@ public class MicrosoftPhotosImporter
         body = newResponse.body();
       }
 
-      if (code == 403 && response.message() == "Access Denied") {
+      if (code == 403 && response.message().contains("Access Denied")) {
         throw new PermissionDeniedException(
             "User access to microsoft onedrive was denied",
             new IOException(
@@ -280,7 +280,7 @@ public class MicrosoftPhotosImporter
       responseBody = newResponse.body();
     }
 
-    if (code == 403 && response.message() == "Access Denied") {
+    if (code == 403 && response.message().contains("Access Denied")) {
       throw new PermissionDeniedException(
           "User access to Microsoft One Drive was denied",
           new IOException(

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
@@ -141,7 +141,7 @@ public class MicrosoftPhotosImporterTest {
 
     Call call = mock(Call.class);
     doReturn(call).when(client).newCall(argThat((Request r) ->
-        r.url().toString().equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children");
+        r.url().toString().equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
     ));
     Response response = mock(Response.class);
     ResponseBody body = mock(ResponseBody.class);

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
@@ -131,7 +131,7 @@ public class MicrosoftPhotosImporterTest {
   }
 
   @Test(expected = PermissionDeniedException.class)
-  public void testImportItemPermissionDenied throws Exception
+  public void testImportItemPermissionDenied() throws Exception
 
   {
     List<PhotoAlbum> albums =

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporterTest.java
@@ -141,7 +141,7 @@ public class MicrosoftPhotosImporterTest {
 
     Call call = mock(Call.class);
     doReturn(call).when(client).newCall(argThat((Request r) ->
-        r.url().toString().equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")));
+        r.url().toString().equals("https://www.baseurl.com/v1.0/me/drive/special/photos/children")
     ));
     Response response = mock(Response.class);
     ResponseBody body = mock(ResponseBody.class);

--- a/portability-test-utilities/src/main/java/org/datatransferproject/test/types/FakeIdempotentImportExecutor.java
+++ b/portability-test-utilities/src/main/java/org/datatransferproject/test/types/FakeIdempotentImportExecutor.java
@@ -2,17 +2,17 @@ package org.datatransferproject.test.types;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import java.util.UUID;
-import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
-import org.datatransferproject.types.transfer.errors.ErrorDetail;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.UUID;
 import java.util.concurrent.Callable;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.types.transfer.errors.ErrorDetail;
 
 public class FakeIdempotentImportExecutor implements IdempotentImportExecutor {
+
   private HashMap<String, Serializable> knownValues = new HashMap<>();
 
   @Override
@@ -38,7 +38,7 @@ public class FakeIdempotentImportExecutor implements IdempotentImportExecutor {
       System.out.println("Storing key " + idempotentId + " in cache");
       return result;
     } catch (Exception e) {
-      throw new IOException("Problem executing callable for: " + idempotentId, e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
We were comparing strings using == which was leading to this error not properly being categorized 

When writing the tests, this also uncovered that the fake idempotent executor was wrapping all exceptions as IOExceptions, causing failures to not propagate in tests. Ive fixed that and updated the test