### PR TITLE
Fix an issue where we fetched an inaccurate field for the description

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporter.java
@@ -96,7 +96,7 @@ public class FacebookVideosExporter
             new VideoObject(
                 String.format("%s.mp4", fbid),
                 url,
-                video.getName(),
+                video.getDescription(),
                 "video/mp4",
                 fbid,
                 null,

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/RestFbFacebookVideos.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/RestFbFacebookVideos.java
@@ -41,7 +41,7 @@ public class RestFbFacebookVideos implements FacebookVideosInterface {
   public Connection<Video> getVideos(Optional<String> paginationToken)
       throws CopyExceptionWithFailureReason {
     ArrayList<Parameter> parameters = new ArrayList<>();
-    parameters.add(Parameter.with("fields", "title,source"));
+    parameters.add(Parameter.with("fields", "description,source"));
     paginationToken.ifPresent(token -> parameters.add(Parameter.with("after", token)));
     try {
       return client.fetchConnection(

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporterTest.java
@@ -52,7 +52,7 @@ public class FacebookVideosExporterTest {
     Video video = new Video();
     video.setId(VIDEO_ID);
     video.setSource(VIDEO_SOURCE);
-    video.setName(VIDEO_NAME);
+    video.setDescription(VIDEO_NAME);
 
     ArrayList<Video> videos = new ArrayList<>();
     videos.add(video);


### PR DESCRIPTION
This was previously returning blank descriptions as the string is now available through the API as the field 'description'. See https://developers.facebook.com/docs/graph-api/reference/v7.0/video/#fields for reference