### PR TITLE
Adding DateRangeContainerResource for filter by date usecase

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/ContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/ContainerResource.java
@@ -25,6 +25,7 @@ import org.datatransferproject.types.common.models.videos.VideosContainerResourc
         @JsonSubTypes.Type(TaskContainerResource.class),
         @JsonSubTypes.Type(PlaylistContainerResource.class),
         @JsonSubTypes.Type(SocialActivityContainerResource.class),
-        @JsonSubTypes.Type(IdOnlyContainerResource.class)
+        @JsonSubTypes.Type(IdOnlyContainerResource.class),
+        @JsonSubTypes.Type(DateRangeContainerResource.class)
 })
 public abstract class ContainerResource extends DataModel {}

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/DateRangeContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/DateRangeContainerResource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Objects;
+
+/** A date range container containing start and end date for filtering. */
+@JsonTypeName("org.dataportability:DateRangeContainerResource")
+public class DateRangeContainerResource extends ContainerResource {
+  private final Integer startDate;
+  private final Integer endDate;
+
+  @JsonCreator
+  public DateRangeContainerResource(
+          @JsonProperty("startDate") Integer startDate,
+          @JsonProperty("endDate") Integer endDate) {
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+
+  public Integer getStartDate() {
+    return startDate;
+  }
+  public Integer getEndDate() { return endDate; }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DateRangeContainerResource that = (DateRangeContainerResource) o;
+    return Objects.equals(startDate, that.startDate)
+            && Objects.equals(endDate, that.endDate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(startDate, endDate);
+  }
+}

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/DateRangeContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/DateRangeContainerResourceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.truth.Truth;
+import org.junit.Test;
+
+public class DateRangeContainerResourceTest {
+  @Test
+  public void verifySerializeDeserialize() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerSubtypes(DateRangeContainerResource.class);
+
+    int startDate = 1607784466;
+    int endDate = 1608648466;
+
+    ContainerResource data = new DateRangeContainerResource(startDate, endDate);
+
+    String serialized = objectMapper.writeValueAsString(data);
+
+    ContainerResource deserializedModel =
+            objectMapper.readValue(serialized, ContainerResource.class);
+
+    Truth.assertThat(deserializedModel).isNotNull();
+    Truth.assertThat(deserializedModel).isInstanceOf(DateRangeContainerResource.class);
+    DateRangeContainerResource deserialized = (DateRangeContainerResource) deserializedModel;
+    Truth.assertThat(deserialized.getStartDate()).isEqualTo(startDate);
+    Truth.assertThat(deserialized.getEndDate()).isEqualTo(endDate);
+    Truth.assertThat(deserialized).isEqualTo(data);
+  }
+}


### PR DESCRIPTION
We are adding this container resource so that we can pass a Date Range between which we want to transfer the data. Basically we will only query and transfer the data that lies between the start and end date passed in the date range container resource.

The start and end date passed will be unix timestamps, hence we thought it would be best to pass them as integers.

The container resource will be passed initially along with job creation. Though currently we are creating this as a stand-alone filtering option, we might allow the users to couple this filter with additional filters like Album selection (via Photos Container Resource).

We will be changing the existing exporters to support this new container resource.