### PR TITLE
Backblaze import adapters for photos and videos

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 plugins {
     id 'maven-publish'
     id 'io.spring.bintray'

--- a/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     compile project(':portability-spi-cloud')
     compile project(':portability-spi-transfer')
+    compile project(':portability-transfer')
     compile project(':libraries:transfer')
 
     compile('software.amazon.awssdk:s3:2.15.24')

--- a/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile project(':portability-spi-transfer')
     compile project(':libraries:transfer')
 
-    compile('software.amazon.awssdk:s3:2.8.5')
+    compile('software.amazon.awssdk:s3:2.15.24')
     compile('org.apache.commons:commons-lang3:3.11')
 }
 

--- a/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'maven-publish'
+    id 'io.spring.bintray'
+}
+
+dependencies {
+    compile project(':portability-spi-cloud')
+    compile project(':portability-spi-transfer')
+    compile project(':libraries:transfer')
+
+    compile('software.amazon.awssdk:s3:2.8.5')
+    compile('org.apache.commons:commons-lang3:3.11')
+}
+
+configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.datatransferproject.datatransfer.backblaze;
 
 import com.google.common.base.Preconditions;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
@@ -43,6 +43,7 @@ public class BackblazeTransferExtension implements TransferExtension {
 
   @Override
   public Exporter<?, ?> getExporter(String transferDataType) {
+    //TODO: Implement exporters as per https://github.com/google/data-transfer-project/issues/960
     throw new IllegalArgumentException();
   }
 

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
@@ -1,0 +1,55 @@
+package org.datatransferproject.datatransfer.backblaze;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.datatransferproject.api.launcher.ExtensionContext;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.photos.BackblazePhotosImporter;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.extension.TransferExtension;
+import org.datatransferproject.spi.transfer.provider.Exporter;
+import org.datatransferproject.spi.transfer.provider.Importer;
+
+public class BackblazeTransferExtension implements TransferExtension {
+  public static final String SERVICE_ID = "Backblaze";
+  private static final List<String> SUPPORTED_TYPES = ImmutableList.of("PHOTOS");
+
+  private BackblazePhotosImporter importer;
+  private boolean initialized = false;
+
+  @Override
+  public String getServiceId() {
+    return SERVICE_ID;
+  }
+
+  @Override
+  public Exporter<?, ?> getExporter(String transferDataType) {
+    throw new IllegalArgumentException();
+  }
+
+  @Override
+  public Importer<?, ?> getImporter(String transferDataType) {
+    Preconditions.checkArgument(
+        initialized, "Trying to call getImporter before initalizing BackblazeTransferExtension");
+    Preconditions.checkArgument(
+        SUPPORTED_TYPES.contains(transferDataType),
+        "Import of " + transferDataType + " not supported by Backblaze");
+    return importer;
+  }
+
+  @Override
+  public void initialize(ExtensionContext context) {
+    Monitor monitor = context.getMonitor();
+    monitor.debug(() -> "Starting Backblaze initialization");
+    if (initialized) {
+      monitor.severe(() -> "BackblazeTransferExtension already initialized.");
+      return;
+    }
+
+    TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
+
+    importer = new BackblazePhotosImporter(monitor, jobStore);
+    initialized = true;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
@@ -76,6 +76,7 @@ public class BackblazeDataTransferClient {
           return 0;
         });
 
+    Throwable s3Exception = null;
     for (String region : BACKBLAZE_REGIONS) {
       try {
         s3Client = getOrCreateS3Client(keyId, applicationKey, region);
@@ -84,6 +85,7 @@ public class BackblazeDataTransferClient {
         userRegion = region;
         break;
       } catch (S3Exception e) {
+        s3Exception = e;
         if (s3Client != null) {
           s3Client.close();
         }
@@ -95,7 +97,7 @@ public class BackblazeDataTransferClient {
 
     if (listBucketsResponse == null || userRegion == null) {
       throw new BackblazeCredentialsException(
-          "User's credentials or permissions are not valid for any regions available");
+          "User's credentials or permissions are not valid for any regions available", s3Exception);
     }
 
     bucketName = getOrCreateBucket(s3Client, listBucketsResponse, userRegion);

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
@@ -1,0 +1,139 @@
+package org.datatransferproject.datatransfer.backblaze.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.exception.BackblazeCredentialsException;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+public class BackblazeDataTransferClient {
+  private static final String DATA_TRANSFER_BUCKET_PREFIX = "facebook-data-transfer";
+  private static final String S3_ENDPOINT_FORMAT_STRING = "https://s3.%s.backblazeb2.com";
+  private static final int MAX_BUCKET_CREATION_ATTEMPTS = 10;
+  private static final List<String> BACKBLAZE_REGIONS =
+      Arrays.asList("us-west-000", "us-west-001", "us-west-002", "eu-central-003");
+
+  private final Monitor monitor;
+  private S3Client s3Client;
+  private String bucketName;
+
+  public BackblazeDataTransferClient(Monitor monitor) {
+    this.monitor = monitor;
+  }
+
+  public void init(String keyId, String applicationKey)
+      throws BackblazeCredentialsException, IOException {
+    // Fetch all the available buckets and use that to find which region the user is in
+    ListBucketsResponse listBucketsResponse = null;
+    String userRegion = null;
+    for (String region : BACKBLAZE_REGIONS) {
+      try {
+        s3Client = getOrCreateS3Client(keyId, applicationKey, region);
+
+        listBucketsResponse = s3Client.listBuckets();
+        userRegion = region;
+        break;
+      } catch (S3Exception e) {
+        if (s3Client != null) {
+          s3Client.close();
+        }
+        if (e.statusCode() == 403) {
+          monitor.debug(() -> String.format("User is not in region %s", region));
+        }
+      }
+    }
+
+    if (listBucketsResponse == null || userRegion == null) {
+      throw new BackblazeCredentialsException(
+          "User's credentials or permissions are not valid for any regions available");
+    }
+
+    bucketName = getOrCreateBucket(s3Client, listBucketsResponse, userRegion);
+  }
+
+  public String uploadFile(String fileKey, File file) throws IOException {
+    if (s3Client == null || bucketName == null) {
+      throw new IllegalStateException("BackblazeDataTransferClient has not been initialised");
+    }
+
+    try {
+      PutObjectRequest putObjectRequest =
+          PutObjectRequest.builder().bucket(bucketName).key(fileKey).build();
+
+      PutObjectResponse putObjectResponse =
+          s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
+
+      return putObjectResponse.versionId();
+    } catch (AwsServiceException | SdkClientException e) {
+      throw new IOException("Error while uploading file", e);
+    }
+  }
+
+  private static String getOrCreateBucket(
+      S3Client s3Client, ListBucketsResponse listBucketsResponse, String region)
+      throws IOException {
+    try {
+      for (Bucket bucket : listBucketsResponse.buckets()) {
+        if (bucket.name().startsWith(DATA_TRANSFER_BUCKET_PREFIX)) {
+          return bucket.name();
+        }
+      }
+
+      for (int i = 0; i < MAX_BUCKET_CREATION_ATTEMPTS; i++) {
+        String bucketName =
+            String.format(
+                "%s-%s",
+                DATA_TRANSFER_BUCKET_PREFIX, RandomStringUtils.randomAlphanumeric(8).toLowerCase());
+        try {
+          CreateBucketConfiguration createBucketConfiguration =
+              CreateBucketConfiguration.builder().locationConstraint(region).build();
+          CreateBucketRequest createBucketRequest =
+              CreateBucketRequest.builder()
+                  .bucket(bucketName)
+                  .createBucketConfiguration(createBucketConfiguration)
+                  .build();
+          s3Client.createBucket(createBucketRequest);
+          return bucketName;
+        } catch (BucketAlreadyExistsException | BucketAlreadyOwnedByYouException e) {
+          System.out.print("Bucket name already exists");
+        }
+      }
+      throw new IOException(
+          String.format(
+              "Failed to create a uniquely named bucket after %d attempts",
+              MAX_BUCKET_CREATION_ATTEMPTS));
+
+    } catch (AwsServiceException | SdkClientException e) {
+      throw new IOException("Error while creating bucket", e);
+    }
+  }
+
+  private static S3Client getOrCreateS3Client(String accessKey, String secretKey, String region) {
+    AwsSessionCredentials awsCreds = AwsSessionCredentials.create(accessKey, secretKey, "");
+
+    ClientOverrideConfiguration clientOverrideConfiguration =
+        ClientOverrideConfiguration.builder().putHeader("User-Agent", "Facebook-DTP").build();
+
+    // Use any AWS region for the client, the Backblaze API does not care about it
+    Region awsRegion = Region.US_EAST_1;
+
+    return S3Client.builder()
+        .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+        .overrideConfiguration(clientOverrideConfiguration)
+        .endpointOverride(URI.create(String.format(S3_ENDPOINT_FORMAT_STRING, region)))
+        .region(awsRegion)
+        .build();
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
@@ -5,7 +5,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,8 +17,6 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Bucket;
@@ -49,7 +46,6 @@ public class BackblazeDataTransferClient {
 
   private static final long SIZE_THRESHOLD_FOR_MULTIPART_UPLOAD = 20 * 1024 * 1024; // 20 MB.
   private static final long PART_SIZE_FOR_MULTIPART_UPLOAD = 5 * 1024 * 1024; // 5 MB.
-  private static final Duration HTTP_CLIENT_SOCKET_TIMEOUT = Duration.ofMinutes(5);
 
   private final Monitor monitor;
   private S3Client s3Client;
@@ -227,12 +223,7 @@ public class BackblazeDataTransferClient {
     // Use any AWS region for the client, the Backblaze API does not care about it
     Region awsRegion = Region.US_EAST_1;
 
-    // TODO(T77168807) - Remove the following when AWS SDK is upgraded to 2.14.x or later
-    SdkHttpClient httpClient =
-        ApacheHttpClient.builder().socketTimeout(HTTP_CLIENT_SOCKET_TIMEOUT).build();
-
     return S3Client.builder()
-        .httpClient(httpClient)
         .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
         .overrideConfiguration(clientOverrideConfiguration)
         .endpointOverride(URI.create(String.format(S3_ENDPOINT_FORMAT_STRING, region)))

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
@@ -1,4 +1,18 @@
-// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.datatransferproject.datatransfer.backblaze.common;
 

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClient.java
@@ -179,7 +179,7 @@ public class BackblazeDataTransferClient {
     return completeMultipartUploadResponse.versionId();
   }
 
-  private static String getOrCreateBucket(
+  private String getOrCreateBucket(
       S3Client s3Client, ListBucketsResponse listBucketsResponse, String region)
       throws IOException {
     try {
@@ -205,7 +205,7 @@ public class BackblazeDataTransferClient {
           s3Client.createBucket(createBucketRequest);
           return bucketName;
         } catch (BucketAlreadyExistsException | BucketAlreadyOwnedByYouException e) {
-          System.out.print("Bucket name already exists");
+          monitor.info(() -> "Bucket name already exists");
         }
       }
       throw new IOException(
@@ -218,7 +218,7 @@ public class BackblazeDataTransferClient {
     }
   }
 
-  private static S3Client getOrCreateS3Client(String accessKey, String secretKey, String region) {
+  private S3Client getOrCreateS3Client(String accessKey, String secretKey, String region) {
     AwsSessionCredentials awsCreds = AwsSessionCredentials.create(accessKey, secretKey, "");
 
     ClientOverrideConfiguration clientOverrideConfiguration =

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
@@ -1,0 +1,22 @@
+package org.datatransferproject.datatransfer.backblaze.common;
+
+import java.io.IOException;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.exception.BackblazeCredentialsException;
+import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
+
+public class BackblazeDataTransferClientFactory {
+  private BackblazeDataTransferClient b2Client;
+
+  public BackblazeDataTransferClient getOrCreateB2Client(
+      Monitor monitor, TokenSecretAuthData authData)
+      throws BackblazeCredentialsException, IOException {
+    if (b2Client == null) {
+      BackblazeDataTransferClient backblazeDataTransferClient =
+          new BackblazeDataTransferClient(monitor);
+      backblazeDataTransferClient.init(authData.getToken(), authData.getSecret());
+      b2Client = backblazeDataTransferClient;
+    }
+    return b2Client;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.datatransferproject.datatransfer.backblaze.common;
 
 import java.io.IOException;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/exception/BackblazeCredentialsException.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/exception/BackblazeCredentialsException.java
@@ -1,7 +1,14 @@
 package org.datatransferproject.datatransfer.backblaze.exception;
 
-public final class BackblazeCredentialsException extends Exception {
-  public BackblazeCredentialsException(String message) {
-    super(message);
+import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason;
+
+public final class BackblazeCredentialsException extends CopyExceptionWithFailureReason {
+  public BackblazeCredentialsException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Override
+  public String getFailureReason() {
+    return "INVALID_MANUAL_CREDENTIALS";
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/exception/BackblazeCredentialsException.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/exception/BackblazeCredentialsException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.datatransferproject.datatransfer.backblaze.exception;
 
 import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/exception/BackblazeCredentialsException.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/exception/BackblazeCredentialsException.java
@@ -1,0 +1,7 @@
+package org.datatransferproject.datatransfer.backblaze.exception;
+
+public final class BackblazeCredentialsException extends Exception {
+  public BackblazeCredentialsException(String message) {
+    super(message);
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/package-info.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/package-info.java
@@ -1,1 +1,17 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.datatransferproject.datatransfer.backblaze;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/package-info.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/package-info.java
@@ -1,0 +1,1 @@
+package org.datatransferproject.datatransfer.backblaze;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.datatransferproject.datatransfer.backblaze.photos;
 
 import java.io.IOException;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
@@ -1,0 +1,100 @@
+package org.datatransferproject.datatransfer.backblaze.photos;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.UUID;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
+import org.datatransferproject.datatransfer.backblaze.exception.BackblazeCredentialsException;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.ImageStreamProvider;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
+
+public class BackblazePhotosImporter
+    implements Importer<TokenSecretAuthData, PhotosContainerResource> {
+
+  private static final String PHOTO_TRANSFER_MAIN_FOLDER = "Photo Transfer";
+
+  private final TemporaryPerJobDataStore jobStore;
+  private final ImageStreamProvider imageStreamProvider = new ImageStreamProvider();
+  private final Monitor monitor;
+  private BackblazeDataTransferClient b2Client;
+
+  public BackblazePhotosImporter(Monitor monitor, TemporaryPerJobDataStore jobStore) {
+    this.monitor = monitor;
+    this.jobStore = jobStore;
+  }
+
+  @Override
+  public ImportResult importItem(
+      UUID jobId,
+      IdempotentImportExecutor idempotentExecutor,
+      TokenSecretAuthData authData,
+      PhotosContainerResource data)
+      throws Exception {
+    if (data == null) {
+      // Nothing to do
+      return ImportResult.OK;
+    }
+
+    b2Client = getOrCreateB2Client(monitor, authData);
+
+    if (data.getAlbums() != null && data.getAlbums().size() > 0) {
+      for (PhotoAlbum album : data.getAlbums()) {
+        idempotentExecutor.executeAndSwallowIOExceptions(
+            album.getId(),
+            String.format("Caching album name for album '%s'", album.getId()),
+            () -> album.getName());
+      }
+    }
+
+    if (data.getPhotos() != null && data.getPhotos().size() > 0) {
+      for (PhotoModel photo : data.getPhotos()) {
+        idempotentExecutor.executeAndSwallowIOExceptions(
+            photo.getDataId(),
+            photo.getTitle(),
+            () -> importSinglePhoto(idempotentExecutor, b2Client, jobId, photo));
+      }
+    }
+
+    return ImportResult.OK;
+  }
+
+  private String importSinglePhoto(
+      IdempotentImportExecutor idempotentExecutor,
+      BackblazeDataTransferClient b2Client,
+      UUID jobId,
+      PhotoModel photo)
+      throws IOException {
+    String albumName = idempotentExecutor.getCachedValue(photo.getAlbumId());
+
+    InputStream inputStream;
+    if (photo.isInTempStore()) {
+      inputStream = jobStore.getStream(jobId, photo.getFetchableUrl()).getStream();
+    } else {
+      HttpURLConnection conn = imageStreamProvider.getConnection(photo.getFetchableUrl());
+      inputStream = conn.getInputStream();
+    }
+
+    return b2Client.uploadFile(
+        String.format("%s/%s/%s.jpg", PHOTO_TRANSFER_MAIN_FOLDER, albumName, photo.getDataId()),
+        jobStore.getTempFileFromInputStream(inputStream, photo.getDataId(), ".jpg"));
+  }
+
+  private BackblazeDataTransferClient getOrCreateB2Client(
+      Monitor monitor, TokenSecretAuthData authData)
+      throws BackblazeCredentialsException, IOException {
+    if (b2Client == null) {
+      b2Client = new BackblazeDataTransferClient(monitor);
+      b2Client.init(authData.getToken(), authData.getSecret());
+    }
+    return b2Client;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.datatransferproject.datatransfer.backblaze.videos;
 
 import java.io.IOException;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -1,0 +1,65 @@
+package org.datatransferproject.datatransfer.backblaze.videos;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.ImageStreamProvider;
+import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
+
+public class BackblazeVideosImporter
+    implements Importer<TokenSecretAuthData, VideosContainerResource> {
+
+  private static final String VIDEO_TRANSFER_MAIN_FOLDER = "Video Transfer";
+
+  private final TemporaryPerJobDataStore jobStore;
+  private final ImageStreamProvider imageStreamProvider = new ImageStreamProvider();
+  private final Monitor monitor;
+
+  public BackblazeVideosImporter(Monitor monitor, TemporaryPerJobDataStore jobStore) {
+    this.monitor = monitor;
+    this.jobStore = jobStore;
+  }
+
+  @Override
+  public ImportResult importItem(
+      UUID jobId,
+      IdempotentImportExecutor idempotentExecutor,
+      TokenSecretAuthData authData,
+      VideosContainerResource data)
+      throws Exception {
+    if (data == null) {
+      // Nothing to do
+      return ImportResult.OK;
+    }
+
+    BackblazeDataTransferClient b2Client = new BackblazeDataTransferClient(monitor);
+    b2Client.init(authData.getToken(), authData.getSecret());
+
+    if (data.getVideos() != null && data.getVideos().size() > 0) {
+      for (VideoObject video : data.getVideos()) {
+        idempotentExecutor.executeAndSwallowIOExceptions(
+            video.getDataId(), video.getName(), () -> importSingleVideo(b2Client, video));
+      }
+    }
+
+    return ImportResult.OK;
+  }
+
+  private String importSingleVideo(BackblazeDataTransferClient b2Client, VideoObject video)
+      throws IOException {
+    InputStream videoFileStream =
+        imageStreamProvider.getConnection(video.getContentUrl().toString()).getInputStream();
+
+    return b2Client.uploadFile(
+        String.format("%s/%s.mp4", VIDEO_TRANSFER_MAIN_FOLDER, video.getDataId()),
+        jobStore.getTempFileFromInputStream(videoFileStream, video.getDataId(), ".mp4"));
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
@@ -22,10 +23,12 @@ public class BackblazeVideosImporter
   private final TemporaryPerJobDataStore jobStore;
   private final ImageStreamProvider imageStreamProvider = new ImageStreamProvider();
   private final Monitor monitor;
+  private final BackblazeDataTransferClientFactory b2ClientFactory;
 
   public BackblazeVideosImporter(Monitor monitor, TemporaryPerJobDataStore jobStore) {
     this.monitor = monitor;
     this.jobStore = jobStore;
+    this.b2ClientFactory = new BackblazeDataTransferClientFactory();
   }
 
   @Override
@@ -40,8 +43,7 @@ public class BackblazeVideosImporter
       return ImportResult.OK;
     }
 
-    BackblazeDataTransferClient b2Client = new BackblazeDataTransferClient(monitor);
-    b2Client.init(authData.getToken(), authData.getSecret());
+    BackblazeDataTransferClient b2Client = b2ClientFactory.getOrCreateB2Client(monitor, authData);
 
     if (data.getVideos() != null && data.getVideos().size() > 0) {
       for (VideoObject video : data.getVideos()) {

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/resources/META-INF/services/org.datatransferproject.spi.transfer.extension.TransferExtension
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/resources/META-INF/services/org.datatransferproject.spi.transfer.extension.TransferExtension
@@ -1,0 +1,1 @@
+org.datatransferproject.datatransfer.backblaze.BackblazeTransferExtension

--- a/settings.gradle
+++ b/settings.gradle
@@ -74,6 +74,9 @@ include ':extensions:data-transfer:portability-data-transfer-facebook'
 include ':extensions:auth:portability-auth-koofr'
 include ':extensions:data-transfer:portability-data-transfer-koofr'
 
+// Backblaze
+include ':extensions:data-transfer:portability-data-transfer-backblaze'
+
 include ':extensions:auth:portability-auth-offline-demo'
 include ':extensions:data-transfer:portability-data-transfer-offline-demo'
 


### PR DESCRIPTION
Facebook and Backblaze teams worked together last year to enable Photos and Videos transfers from Facebook to Backblaze. And it was [launched in October 2020](https://about.fb.com/news/2020/09/expanding-photo-and-video-transfer-tool-to-dropbox-and-koofr/).

This PR adds the Backblaze transfer extension to the project and currently includes a photos importer and a videos importer.

The code is tested, and is deployed in production for all Facebook users at https://www.facebook.com/dtp