### PR TITLE
Readd log lines for first retryable error

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java
@@ -71,10 +71,10 @@ public class CallableImporter implements Callable<ImportResult> {
       success = result.getType() == ImportResult.ResultType.OK && errors.isEmpty();
 
       if (!success) {
-        // No need to log out individual errors
-        // since IdempotentImportExecutor already logs them out
         throw new IOException(
-            "Encountered errors in idempotentImportExecutor, forcing a retry");
+            "Problem with importer, forcing a retry, "
+                + "first error: "
+                + (errors.iterator().hasNext() ? errors.iterator().next() : "none"));
       }
 
       result = result.copyWithCounts(data.getCounts());


### PR DESCRIPTION
Summary:
We removed the error details from the logline in previous commit.
However, this log line is essential to our retry logic since we are
doing string matching to determine how worker is going to do the retry.

This commit is to add the first error back to the log line.

Test Plan: Build and verify the logline
