### PR TITLE
Only add exception of error details to retryable exception

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java
@@ -74,7 +74,7 @@ public class CallableImporter implements Callable<ImportResult> {
         throw new IOException(
             "Problem with importer, forcing a retry, "
                 + "first error: "
-                + (errors.iterator().hasNext() ? errors.iterator().next() : "none"));
+                + (errors.iterator().hasNext() ? errors.iterator().next().exception() : "none"));
       }
 
       result = result.copyWithCounts(data.getCounts());


### PR DESCRIPTION
Summary:
Currently we are logging out both id and title of error details to
Retryable Import Exception. However, this makes the log line hard to be
categorized.

Since we are only logging the first error and we log error for
individual transfer item in the end, we can remove id and title from
here.

This commit is to do that.

Test Plan: build and check log line