### PR TITLE
Add VIDEO as acceptable social attachment type

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java
@@ -71,9 +71,10 @@ public class CallableImporter implements Callable<ImportResult> {
       success = result.getType() == ImportResult.ResultType.OK && errors.isEmpty();
 
       if (!success) {
-        throw new IOException("Problem with importer, forcing a retry, "
-            + errors.size() + " errors, first one: " +
-            (errors.iterator().hasNext() ? errors.iterator().next() : "none"));
+        // No need to log out individual errors
+        // since IdempotentImportExecutor already logs them out
+        throw new IOException(
+            "Encountered errors in idempotentImportExecutor, forcing a retry");
       }
 
       result = result.copyWithCounts(data.getCounts());

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/social/SocialActivityAttachmentType.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/social/SocialActivityAttachmentType.java
@@ -18,5 +18,6 @@ package org.datatransferproject.types.common.models.social;
 
 public enum SocialActivityAttachmentType {
   LINK,
-  IMAGE
+  IMAGE,
+  VIDEO
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResourceTest.java
@@ -48,6 +48,9 @@ public class SocialActivityContainerResourceTest {
             "some image url",
             "some image",
             "this is the image description");
+    SocialActivityAttachment videoAttachment =
+            new SocialActivityAttachment(
+                    SocialActivityAttachmentType.LINK, "some url", "some video", "this is the video text");
     List<SocialActivityModel> activities =
         ImmutableList.of(
             new SocialActivityModel(
@@ -63,7 +66,7 @@ public class SocialActivityContainerResourceTest {
                 "id2",
                 timePublished,
                 SocialActivityType.POST,
-                ImmutableList.of(linkAttachment, imageAttachment),
+                ImmutableList.of(linkAttachment, imageAttachment, videoAttachment),
                 null,
                 "Write Some more tests",
                 "Here's some sample post content",

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResourceTest.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class SocialActivityContainerResourceTest {
 
@@ -50,7 +51,7 @@ public class SocialActivityContainerResourceTest {
             "this is the image description");
     SocialActivityAttachment videoAttachment =
             new SocialActivityAttachment(
-                    SocialActivityAttachmentType.LINK, "some url", "some video", "this is the video text");
+                    SocialActivityAttachmentType.VIDEO, "some url", "some video", "this is the video text");
     List<SocialActivityModel> activities =
         ImmutableList.of(
             new SocialActivityModel(
@@ -94,8 +95,30 @@ public class SocialActivityContainerResourceTest {
     Truth.assertThat(deserializedModel).isNotNull();
     Truth.assertThat(deserializedModel).isInstanceOf(SocialActivityContainerResource.class);
     SocialActivityContainerResource deserialized =
-        (SocialActivityContainerResource) deserializedModel;
+                (SocialActivityContainerResource) deserializedModel;
     Truth.assertThat(deserialized.getActivities()).hasSize(3);
+    SocialActivityModel postModel = deserialized.getActivities()
+                .stream()
+                .filter(socialActivityModel -> socialActivityModel.getType() == SocialActivityType.POST)
+                .collect(Collectors.toList()).get(0);
+    List<SocialActivityAttachment> imageActivityAttachment = postModel
+                .getAttachments()
+                .stream()
+                .filter(socialActivityAttachment -> socialActivityAttachment.getType() == SocialActivityAttachmentType.IMAGE)
+                .collect(Collectors.toList());
+    List<SocialActivityAttachment> linkActivityAttachment = postModel
+                .getAttachments()
+                .stream()
+                .filter(socialActivityAttachment -> socialActivityAttachment.getType() == SocialActivityAttachmentType.LINK)
+                .collect(Collectors.toList());
+    List<SocialActivityAttachment> videoActivityAttachment = postModel
+                .getAttachments()
+                .stream()
+                .filter(socialActivityAttachment -> socialActivityAttachment.getType() == SocialActivityAttachmentType.VIDEO)
+                .collect(Collectors.toList());
+    Truth.assertThat(imageActivityAttachment).hasSize(1);
+    Truth.assertThat(linkActivityAttachment).hasSize(1);
+    Truth.assertThat(videoActivityAttachment).hasSize(1);
     Truth.assertThat(deserialized).isEqualTo(data);
-  }
+    }
 }


### PR DESCRIPTION
Adding new enum value - VIDEO to SocialActivityAttachmentType. This will allow working with Social activity entities which contains videos. 