### PR TITLE
Added getCounts implementation to SocialActivityContainerResource

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResource.java
@@ -19,9 +19,10 @@ package org.datatransferproject.types.common.models.social;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
-
 import org.datatransferproject.types.common.models.ContainerResource;
 
 /**
@@ -29,10 +30,13 @@ import org.datatransferproject.types.common.models.ContainerResource;
  * (https://www.w3.org/TR/activitystreams-core/)
  *
  * <p>The wrapper is needed to allow DTP to page through large collections of items. DTP doesn't
- * know how to parse SocialActivityModel, only extensions that process social data will understand this
- * data, so it needs to by split up to allow DTP to efficiently process it.
+ * know how to parse SocialActivityModel, only extensions that process social data will understand
+ * this data, so it needs to by split up to allow DTP to efficiently process it.
  */
 public class SocialActivityContainerResource extends ContainerResource {
+
+  public static final String ACTIVITIES_COUNT_DATA_NAME = "activitiesCount";
+
   private final String id;
   private final Collection<SocialActivityModel> activities;
   private SocialActivityActor actor;
@@ -64,13 +68,20 @@ public class SocialActivityContainerResource extends ContainerResource {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     SocialActivityContainerResource that = (SocialActivityContainerResource) o;
-    return Objects.equals(getId(), that.getId()) &&
-            Objects.equals(getActivities(), that.getActivities()) &&
-            Objects.equals(getActor(), that.getActor());
+    return Objects.equals(getId(), that.getId())
+        && Objects.equals(getActivities(), that.getActivities())
+        && Objects.equals(getActor(), that.getActor());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getId(), getActivities(), getActor());
+  }
+
+  @Override
+  public Map<String, Integer> getCounts() {
+    return new ImmutableMap.Builder<String, Integer>()
+        .put(ACTIVITIES_COUNT_DATA_NAME, activities.size())
+        .build();
   }
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResourceTest.java
@@ -20,13 +20,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
-import org.datatransferproject.types.common.models.ContainerResource;
-import org.junit.Test;
-
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.junit.Test;
 
 public class SocialActivityContainerResourceTest {
 
@@ -94,5 +93,10 @@ public class SocialActivityContainerResourceTest {
         (SocialActivityContainerResource) deserializedModel;
     Truth.assertThat(deserialized.getActivities()).hasSize(3);
     Truth.assertThat(deserialized).isEqualTo(data);
+    Truth.assertThat(
+            deserialized
+                .getCounts()
+                .get(SocialActivityContainerResource.ACTIVITIES_COUNT_DATA_NAME))
+        .isEqualTo(activities.size());
   }
 }


### PR DESCRIPTION
Summary: Added getCounts implementation which returns an immutable map containing count for the activities.

Test Plan: 1. Added Test Case for the getCounts methods. 
                 2. ./gradlew build test - Successful
                 
Reviewers: @wmorland 

Subscribers:

Tasks: T83723263

Tags:

Blame Revision:

Differential Revision: https://phabricator.intern.facebook.com/D26174322