### PR TITLE
Include encrypted salt as intended

### DIFF
--- a/libraries/security/src/main/java/org/datatransferproject/security/EncrypterImpl.java
+++ b/libraries/security/src/main/java/org/datatransferproject/security/EncrypterImpl.java
@@ -69,8 +69,11 @@ final class EncrypterImpl implements Encrypter {
       byte[] salt = new byte[cipher.getBlockSize()];
       SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
       random.nextBytes(salt);
-      cipher.update(salt);
-      byte[] encrypted = cipher.doFinal(data.getBytes(UTF_8));
+      byte[] encryptedSalt = cipher.update(salt);
+      byte[] encryptedData = cipher.doFinal(data.getBytes(UTF_8));
+      byte[] encrypted = new byte[encryptedSalt.length + encryptedData.length];
+      System.arraycopy(encryptedSalt, 0, encrypted, 0, encryptedSalt.length);
+      System.arraycopy(encryptedData, 0, encrypted, encryptedSalt.length, encryptedData.length);
       return BaseEncoding.base64Url().encode(encrypted);
     } catch (BadPaddingException
         | IllegalBlockSizeException


### PR DESCRIPTION
EncrypterImpl is encrypting a salt to avoid needing to store the IV, but currently throws it away instead of returning it with the ciphertext. DecrypterImpl then throws away the first decrypted block, intending to throw away the salt, but instead it's part of the plaintext.

This includes the first encrypted block in the return as intended.

This was discovered while testing #961 but the fix is separate.