### PR TITLE
Add a user timezone field to PortabilityJob

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/KoofrTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/KoofrTransferExtension.java
@@ -14,7 +14,7 @@ import okhttp3.OkHttpClient;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
-import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -71,7 +71,7 @@ public class KoofrTransferExtension implements TransferExtension {
     // rather than throwing if called multiple times.
     if (initialized) return;
 
-    TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
+    JobStore jobStore = context.getService(JobStore.class);
     HttpTransport httpTransport = context.getService(HttpTransport.class);
     JsonFactory jsonFactory = context.getService(JsonFactory.class);
     OkHttpClient client = new OkHttpClient.Builder().build();

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/KoofrTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/KoofrTransferExtension.java
@@ -35,11 +35,9 @@ public class KoofrTransferExtension implements TransferExtension {
       ImmutableList.of(PHOTOS, VIDEOS);
   private static final ImmutableList<String> SUPPORTED_EXPORT_SERVICES =
       ImmutableList.of(PHOTOS, VIDEOS);
+  private static final String BASE_API_URL = "https://app.koofr.net";
   private ImmutableMap<String, Importer> importerMap;
   private ImmutableMap<String, Exporter> exporterMap;
-
-  private static final String BASE_API_URL = "https://app.koofr.net";
-
   private boolean initialized = false;
 
   // Needed for ServiceLoader to load this class.

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/photos/KoofrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/photos/KoofrPhotosImporter.java
@@ -50,6 +50,7 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 public class KoofrPhotosImporter
     implements Importer<TokensAndUrlAuthData, PhotosContainerResource> {
 
+  private static final String TITLE_DATE_FORMAT = "yyyy-MM-dd HH.mm.ss ";
   private final KoofrClientFactory koofrClientFactory;
   private final JobStore jobStore;
   private final ImageStreamProvider imageStreamProvider;
@@ -229,7 +230,7 @@ public class KoofrPhotosImporter
       return titleDateFormats.get(jobId);
     }
 
-    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH.mm.ss ");
+    SimpleDateFormat dateFormat = new SimpleDateFormat(TITLE_DATE_FORMAT);
     TimeZone userTimeZone = jobStore.findJob(jobId).userTimeZone();
     if (null != userTimeZone) {
       dateFormat.setTimeZone(userTimeZone);

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/photos/KoofrPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/photos/KoofrPhotosImporterTest.java
@@ -10,8 +10,10 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayInputStream;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import okhttp3.mockwebserver.MockResponse;
@@ -19,8 +21,10 @@ import okhttp3.mockwebserver.MockWebServer;
 import okio.Buffer;
 import org.apache.commons.io.IOUtils;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
+import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.transfer.koofr.KoofrTransmogrificationConfig;
 import org.datatransferproject.transfer.koofr.common.KoofrClient;
@@ -44,7 +48,7 @@ public class KoofrPhotosImporterTest {
   private KoofrClientFactory clientFactory;
   private KoofrClient client;
   private Monitor monitor;
-  private TemporaryPerJobDataStore jobStore;
+  private JobStore jobStore;
   private KoofrPhotosImporter importer;
   private IdempotentImportExecutor executor;
   private TokensAndUrlAuthData authData;
@@ -61,7 +65,7 @@ public class KoofrPhotosImporterTest {
     when(clientFactory.create(any())).thenReturn(client);
 
     monitor = mock(Monitor.class);
-    jobStore = mock(TemporaryPerJobDataStore.class);
+    jobStore = mock(JobStore.class);
 
     importer = new KoofrPhotosImporter(clientFactory, monitor, jobStore);
 
@@ -111,6 +115,10 @@ public class KoofrPhotosImporterTest {
     String description1001 = new String(new char[1001]).replace("\0", "a");
 
     UUID jobId = UUID.randomUUID();
+
+    PortabilityJob job = mock(PortabilityJob.class);
+    when(jobStore.findJob(jobId)).thenReturn(job);
+
     Collection<PhotoAlbum> albums =
         ImmutableList.of(
             new PhotoAlbum("id1", "Album 1", "This is a fake album"),
@@ -222,6 +230,10 @@ public class KoofrPhotosImporterTest {
     when(executor.getCachedValue(eq("id1"))).thenReturn("/root/Album 1");
 
     UUID jobId = UUID.randomUUID();
+
+    PortabilityJob job = mock(PortabilityJob.class);
+    when(jobStore.findJob(jobId)).thenReturn(job);
+
     Collection<PhotoAlbum> albums =
         ImmutableList.of(new PhotoAlbum("id1", "Album 1", "This is a fake album"));
 
@@ -249,5 +261,43 @@ public class KoofrPhotosImporterTest {
         .verify(client)
         .uploadFile(
             eq("/root/Album 1"), eq("pic2.png"), any(), eq("image/png"), isNull(), eq("fine art"));
+  }
+
+  @Test
+  public void testImportItemFromJobStoreUserTimeZone() throws Exception {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
+    when(jobStore.getStream(any(), any())).thenReturn(new InputStreamWrapper(inputStream, 5L));
+
+    UUID jobId = UUID.randomUUID();
+
+    PortabilityJob job = mock(PortabilityJob.class);
+    when(job.userTimeZone()).thenReturn(TimeZone.getTimeZone("Europe/Rome"));
+    when(jobStore.findJob(jobId)).thenReturn(job);
+
+    Collection<PhotoAlbum> albums =
+        ImmutableList.of(new PhotoAlbum("id1", "Album 1", "This is a fake album"));
+
+    DateFormat format = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
+    format.setTimeZone(TimeZone.getTimeZone("Europe/Kiev"));
+
+    Collection<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel(
+                "pic1.jpg",
+                "http://fake.com/1.jpg",
+                "A pic",
+                "image/jpeg",
+                "p1",
+                "id1",
+                true,
+                format.parse("2021:02:16 11:55:00")));
+
+    PhotosContainerResource resource = spy(new PhotosContainerResource(albums, photos));
+    importer.importItem(jobId, executor, authData, resource);
+    InOrder clientInOrder = Mockito.inOrder(client);
+
+    clientInOrder
+        .verify(client)
+        .uploadFile(any(), eq("2021-02-16 10.55.00 pic1.jpg"), any(), any(), any(), any());
   }
 }

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
@@ -80,17 +80,15 @@ public abstract class PortabilityJob {
             : null;
 
     State state =
-        properties.containsKey(JOB_STATE) ? State.valueOf((String) properties.get(JOB_STATE))
+        properties.containsKey(JOB_STATE)
+            ? State.valueOf((String) properties.get(JOB_STATE))
             : State.NEW;
 
-
     String failureReason =
-        properties.containsKey(FAILURE_REASON) ? (String) properties.get(FAILURE_REASON)
-            : null;
+        properties.containsKey(FAILURE_REASON) ? (String) properties.get(FAILURE_REASON) : null;
 
     TimeZone userTimeZone =
-        properties.containsKey(USER_TIMEZONE) ? (TimeZone) properties.get(USER_TIMEZONE)
-            : null;
+        properties.containsKey(USER_TIMEZONE) ? (TimeZone) properties.get(USER_TIMEZONE) : null;
 
     return PortabilityJob.builder()
         .setState(state)
@@ -279,9 +277,7 @@ public abstract class PortabilityJob {
           isUnset(jobAuthorization.encryptedAuthData());
           break;
         case CREDS_STORED:
-          isSet(
-              jobAuthorization.authPublicKey(),
-              jobAuthorization.encryptedAuthData());
+          isSet(jobAuthorization.authPublicKey(), jobAuthorization.encryptedAuthData());
           break;
         case TIMED_OUT:
           throw new RuntimeException("Authorization timed out, can't validate.");

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
@@ -10,6 +10,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.util.Map;
+import java.util.TimeZone;
 import javax.annotation.Nullable;
 
 /**
@@ -38,6 +39,7 @@ public abstract class PortabilityJob {
   private static final String JOB_STATE = "JOB_STATE";
   private static final String FAILURE_REASON = "FAILURE_REASON";
   private static final String NUMBER_OF_FAILED_FILES_KEY = "NUM_FAILED_FILES";
+  private static final String USER_TIMEZONE = "USER_TIMEZONE";
 
   public static PortabilityJob.Builder builder() {
     Instant now = Instant.now();
@@ -86,6 +88,10 @@ public abstract class PortabilityJob {
         properties.containsKey(FAILURE_REASON) ? (String) properties.get(FAILURE_REASON)
             : null;
 
+    TimeZone userTimeZone =
+        properties.containsKey(USER_TIMEZONE) ? (TimeZone) properties.get(USER_TIMEZONE)
+            : null;
+
     return PortabilityJob.builder()
         .setState(state)
         .setExportService((String) properties.get(EXPORT_SERVICE_KEY))
@@ -107,6 +113,7 @@ public abstract class PortabilityJob {
                 .setEncryptedInitialExportAuthData(encryptedExportInitialAuthData)
                 .setEncryptedInitialImportAuthData(encryptedImportInitialAuthData)
                 .build())
+        .setUserTimeZone(userTimeZone)
         .build();
   }
 
@@ -152,6 +159,10 @@ public abstract class PortabilityJob {
   @Nullable
   @JsonProperty("failureReason")
   public abstract String failureReason();
+
+  @Nullable
+  @JsonProperty("userTimeZone")
+  public abstract TimeZone userTimeZone();
 
   public abstract PortabilityJob.Builder toBuilder();
 
@@ -202,6 +213,11 @@ public abstract class PortabilityJob {
       builder.put(
           IMPORT_ENCRYPTED_INITIAL_AUTH_DATA, jobAuthorization().encryptedInitialImportAuthData());
     }
+
+    if (null != userTimeZone()) {
+      builder.put(USER_TIMEZONE, userTimeZone());
+    }
+
     return builder.build();
   }
 
@@ -272,6 +288,10 @@ public abstract class PortabilityJob {
       }
       return setJobAuthorization(jobAuthorization);
     }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("userTimeZone")
+    public abstract Builder setUserTimeZone(TimeZone timeZone);
 
     // For internal use only; clients should use setAndValidateJobAuthorization
     protected abstract Builder setJobAuthorization(JobAuthorization jobAuthorization);

--- a/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
+++ b/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
@@ -18,6 +18,7 @@ package org.datatransferproject.spi.cloud.types;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import java.util.TimeZone;
 import org.datatransferproject.spi.cloud.types.PortabilityJob.State;
 import org.datatransferproject.test.types.ObjectMapperFactory;
 import org.datatransferproject.types.common.ExportInformation;
@@ -27,7 +28,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -99,6 +99,33 @@ public class PortabilityJobTest {
     JobAuthorization deserializedJobAuthorization =
         objectMapper.readValue(serializedJobAuthorization, JobAuthorization.class);
     assertThat(deserializedJobAuthorization).isEqualTo(jobAuthorization);
+
+    String serializedJob = objectMapper.writeValueAsString(job);
+    PortabilityJob deserializedJob = objectMapper.readValue(serializedJob, PortabilityJob.class);
+    assertThat(deserializedJob).isEqualTo(job);
+  }
+
+  @Test
+  public void verifySerializeDeserializeUserTimeZone() throws Exception {
+    ObjectMapper objectMapper = ObjectMapperFactory.createObjectMapper();
+    Instant date = Instant.now();
+
+    JobAuthorization jobAuthorization =
+        JobAuthorization.builder()
+            .setState(JobAuthorization.State.INITIAL)
+            .build();
+
+    PortabilityJob job =
+        PortabilityJob.builder()
+            .setState(State.NEW)
+            .setExportService("fooService")
+            .setImportService("barService")
+            .setTransferDataType("PHOTOS")
+            .setCreatedTimestamp(date)
+            .setLastUpdateTimestamp(date.plusSeconds(120))
+            .setJobAuthorization(jobAuthorization)
+            .setUserTimeZone(TimeZone.getTimeZone("America/Costa_Rica"))
+            .build();
 
     String serializedJob = objectMapper.writeValueAsString(job);
     PortabilityJob deserializedJob = objectMapper.readValue(serializedJob, PortabilityJob.class);

--- a/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
+++ b/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
@@ -16,8 +16,12 @@
 
 package org.datatransferproject.spi.cloud.types;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.time.Instant;
 import java.util.TimeZone;
 import org.datatransferproject.spi.cloud.types.PortabilityJob.State;
 import org.datatransferproject.test.types.ObjectMapperFactory;
@@ -25,11 +29,6 @@ import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.time.Instant;
-
-import static com.google.common.truth.Truth.assertThat;
 
 /** Tests serialization and deserialization of a {@link PortabilityJob}. */
 public class PortabilityJobTest {
@@ -83,13 +82,14 @@ public class PortabilityJobTest {
             .setExportService("fooService")
             .setImportService("barService")
             .setTransferDataType("PHOTOS")
-            .setExportInformation(objectMapper.writeValueAsString(
-                new ExportInformation(
-                    null,
-                    new PhotosContainerResource(
-                        Lists.newArrayList(
-                            new PhotoAlbum("album_id", "album name", "album description")),
-                        null))))
+            .setExportInformation(
+                objectMapper.writeValueAsString(
+                    new ExportInformation(
+                        null,
+                        new PhotosContainerResource(
+                            Lists.newArrayList(
+                                new PhotoAlbum("album_id", "album name", "album description")),
+                            null))))
             .setCreatedTimestamp(date)
             .setLastUpdateTimestamp(date.plusSeconds(120))
             .setJobAuthorization(jobAuthorization)
@@ -111,9 +111,7 @@ public class PortabilityJobTest {
     Instant date = Instant.now();
 
     JobAuthorization jobAuthorization =
-        JobAuthorization.builder()
-            .setState(JobAuthorization.State.INITIAL)
-            .build();
+        JobAuthorization.builder().setState(JobAuthorization.State.INITIAL).build();
 
     PortabilityJob job =
         PortabilityJob.builder()


### PR DESCRIPTION
When a user creates a transfer job we do not consider their timezone on the backend worker and instead all dates simply match to the timezone of the server. To fix this we added a field to the job which exporters and importers can use to render dates in the user's time zone.

- Added the user timezone field to PortabilityJob. 
- Used the timezone field in KoofrPhotosImporter. This means that the dates in the titles get formatted to match the user's timezone preference (if the timezone has not been set we default to the system timezone).
