### PR TITLE
Switching gradle release publishing to maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,13 +44,14 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "io.spring.gradle:spring-bintray-plugin:0.11.1"
         classpath 'org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r'
     }
 }
 
 plugins {
     id 'java'
+    id 'maven'
+    id 'signing'
 }
 
 ext.nodeType = hasProperty('nodeType') ? nodeType : 'local'
@@ -102,96 +103,65 @@ def addCloudExtensionDependency(proj) {
 }
 
 /**
- * Configures the project to publish Maven artifacts to BinTray.
+ * Configures the project to publish Maven artifacts to Maven Central.
  */
-def configurePublication(project) {
-    // Configure artifact publication
+def configurePublication(Project project) {
+    project.artifacts {
+        archives project.javadocJar, project.sourcesJar
+    }
 
-    project.publishing {
-        publications {
-            mavenJava(MavenPublication) {
-                from project.components.java
-                artifact project.sourcesJar
-                artifact project.javadocJar
-                pom.withXml {
-                    def root = asNode()
-                    root.appendNode('description', 'The Data Transfer Project')
-                    root.appendNode('name', 'DTP')
-                    root.appendNode('url', 'https://datatransferproject.dev/')
-                    root.appendNode('properties').appendNode('build-commit', project.rootProject.ext.gitVersion)
-                    root.children().last() + getPomConfig()
+
+    // Configure artifact publication
+    project.uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                    authentication(userName: hasProperty('ossrhUsername') ? ossrhUsername : '', password: hasProperty('ossrhPassword') ? ossrhPassword : '')
+                }
+
+                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                    authentication(userName: hasProperty('ossrhUsername') ? ossrhUsername : '', password: hasProperty('ossrhPassword') ? ossrhPassword : '')
+                }
+
+                pom.project {
+                    name 'DTP'
+                    packaging 'jar'
+                    description 'The Data Transfer Project'
+                    url 'https://datatransferproject.dev/'
+
+                    scm {
+                        url 'https://github.com/google/data-transfer-project'
+                        developerConnection 'scm:git:ssh://git@github.com:google/data-transfer-project.git'
+                        connection 'scm:git:git://github.com/google/data-transfer-project.git'
+                    }
+
+                    licenses {
+                        license {
+                            name 'Apache 2.0'
+                            url 'https://www.apache.org/licenses/LICENSE-2.0.html'
+                            distribution 'repo'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id 'dtp'
+                            name 'Data Transfer Project'
+                            email "portability-maintainers@googlegroups.com"
+                        }
+                    }
                 }
             }
         }
     }
 
-    configBinTray(project)
-
-}
-
-/**
- * Configures the project to upload artifacts to BinTray.
- */
-def configBinTray(project) {
-    // Configuration for uploading to BinTray and signing artifacts
-    // secrets stored in ~/.gradle/gradle.properties
-    def bUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : 'undefined'
-    def bKey = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : 'undefined'
-    def gpgPhrase = project.hasProperty('gpgPassphrase') ? project.property('gpgPassphrase') : 'undefined'
-
-    project.bintray {
-
-        bintrayUser = bUser
-        bintrayKey = bKey
-        gpgPassphrase = gpgPhrase
-        publication = 'mavenJava'
-
-        org = 'test-dtp'   // TODO currently publish to a test org and repo - these will be changed when permanents ones are established
-        repo = 'DTP'
-        labels = ['data transfer']
-        licenses = ['Apache-2.0']
-        overrideOnUpload = false // upload task should not override existing artifacts
-
-        websiteUrl = 'https://datatransferproject.dev/'
-        issueTrackerUrl = 'https://github.com/google/data-transfer-project/issues'
-        vcsUrl = 'https://github.com/google/data-transfer-project'
-
-        // if syncing to Maven Central
-        // ossrhUser =
-        // ossrhPassword =
-        // gpgPassphrase =
-    }
-
-}
-
-/**
- * Returns the sections of a Maven POM required for publication.
- */
-def getPomConfig() {
-    return {
-        licenses {
-            license {
-                name 'Apache 2.0'
-                url 'https://www.apache.org/licenses/LICENSE-2.0.html'
-                distribution 'repo'
-            }
-        }
-        developers {
-            developer {
-                id 'dtp'
-                name 'Data Transfer Project'
-                email "portability-maintainers@googlegroups.com"
-            }
-        }
-
-        scm {
-            url 'https://github.com/google/data-transfer-project'
-            developerConnection 'scm:git:ssh://git@github.com:google/data-transfer-project.git'
-            connection 'scm:git:git://github.com/google/data-transfer-project.git'
-
+    if (project.hasProperty("signing.keyId")) {
+        project.signing {
+            sign project.configurations.archives
         }
     }
-
 }
 
 

--- a/client-rest/build.gradle
+++ b/client-rest/build.gradle
@@ -17,7 +17,6 @@
 plugins {
     id "com.moowork.node" version "1.2.0"
     id 'maven-publish'
-    id 'io.spring.bintray'
 }
 
 task installLocalAngularCli(type: NpmTask) {
@@ -123,8 +122,6 @@ project.publishing {
         }
     }
 }
-
-configBinTray(project)
 
 // link the publish task to archive creation to ensure the latter is present
 tasks.findAll { it.name.startsWith('publish') }*.dependsOn(createDistribution)

--- a/extensions/auth/portability-auth-deezer/build.gradle
+++ b/extensions/auth/portability-auth-deezer/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-facebook/build.gradle
+++ b/extensions/auth/portability-auth-facebook/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-flickr/build.gradle
+++ b/extensions/auth/portability-auth-flickr/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-google/build.gradle
+++ b/extensions/auth/portability-auth-google/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-harness-microsoft/build.gradle
+++ b/extensions/auth/portability-auth-harness-microsoft/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-imgur/build.gradle
+++ b/extensions/auth/portability-auth-imgur/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-instagram/build.gradle
+++ b/extensions/auth/portability-auth-instagram/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-koofr/build.gradle
+++ b/extensions/auth/portability-auth-koofr/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-microsoft/build.gradle
+++ b/extensions/auth/portability-auth-microsoft/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-offline-demo/build.gradle
+++ b/extensions/auth/portability-auth-offline-demo/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-rememberthemilk/build.gradle
+++ b/extensions/auth/portability-auth-rememberthemilk/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-smugmug/build.gradle
+++ b/extensions/auth/portability-auth-smugmug/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-spotify/build.gradle
+++ b/extensions/auth/portability-auth-spotify/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/auth/portability-auth-twitter/build.gradle
+++ b/extensions/auth/portability-auth-twitter/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/cloud/portability-cloud-google/build.gradle
+++ b/extensions/cloud/portability-cloud-google/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/cloud/portability-cloud-local/build.gradle
+++ b/extensions/cloud/portability-cloud-local/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/cloud/portability-cloud-microsoft/build.gradle
+++ b/extensions/cloud/portability-cloud-microsoft/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/config/portability-config-yaml/build.gradle
+++ b/extensions/config/portability-config-yaml/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/copier/portability-stack-copier/build.gradle
+++ b/extensions/copier/portability-stack-copier/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-deezer/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-deezer/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 repositories {

--- a/extensions/data-transfer/portability-data-transfer-facebook/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-facebook/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-flickr/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-flickr/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-google/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-google/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-imgur/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-imgur/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-instagram/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-instagram/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-koofr/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-koofr/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-mastodon/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-mastodon/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 repositories {

--- a/extensions/data-transfer/portability-data-transfer-microsoft/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-smugmug/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/data-transfer/portability-data-transfer-solid/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-solid/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 

--- a/extensions/data-transfer/portability-data-transfer-spotify/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-spotify/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 repositories {

--- a/extensions/data-transfer/portability-data-transfer-twitter/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-twitter/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/security/portability-security-cleartext/build.gradle
+++ b/extensions/security/portability-security-cleartext/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/security/portability-security-jwe/build.gradle
+++ b/extensions/security/portability-security-jwe/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/extensions/transport/portability-transport-jettyrest/build.gradle
+++ b/extensions/transport/portability-transport-jettyrest/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectGroup=org.datatransferproject
-projectVersion=0.1
+projectVersion=0.3.58-SNAPSHOT
 annotationApiVersion=1.2
 autoValueVersion=1.6.2
 commonsLangVersion=3.4
@@ -39,3 +39,10 @@ javaDockerContainer=openjdk:8-jdk
 jerseyVersion=2.26
 log4jVersion=2.11.0
 apacheHttpVersion=4.5.6
+
+# ossrhUsername=
+# ossrhPassword=
+
+# signing.keyId=F022E8B0
+# signing.password=
+# signing.secretKeyRingFile=

--- a/libraries/auth/build.gradle
+++ b/libraries/auth/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/libraries/config/build.gradle
+++ b/libraries/config/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/libraries/security/build.gradle
+++ b/libraries/security/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/libraries/transfer/build.gradle
+++ b/libraries/transfer/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/portability-api-launcher/build.gradle
+++ b/portability-api-launcher/build.gradle
@@ -5,8 +5,8 @@ buildscript {
 }
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 configurePublication(project)

--- a/portability-api/build.gradle
+++ b/portability-api/build.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/portability-bootstrap-vm/build.gradle
+++ b/portability-bootstrap-vm/build.gradle
@@ -16,8 +16,8 @@
 
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/portability-spi-api/build.gradle
+++ b/portability-spi-api/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/portability-spi-cloud/build.gradle
+++ b/portability-spi-cloud/build.gradle
@@ -16,8 +16,8 @@
 
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/portability-spi-service/build.gradle
+++ b/portability-spi-service/build.gradle
@@ -16,8 +16,8 @@
 
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/portability-spi-transfer/build.gradle
+++ b/portability-spi-transfer/build.gradle
@@ -16,8 +16,8 @@
 
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/portability-transfer/build.gradle
+++ b/portability-transfer/build.gradle
@@ -16,8 +16,8 @@
 
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 group = "${projectGroup}"

--- a/portability-types-client/build.gradle
+++ b/portability-types-client/build.gradle
@@ -16,8 +16,8 @@
 
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {

--- a/portability-types-common/build.gradle
+++ b/portability-types-common/build.gradle
@@ -16,8 +16,8 @@
 
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 dependencies {
     compile("com.google.auto.value:auto-value:${autoValueVersion}")

--- a/portability-types-transfer/build.gradle
+++ b/portability-types-transfer/build.gradle
@@ -15,8 +15,8 @@
  */
 
 plugins {
-    id 'maven-publish'
-    id 'io.spring.bintray'
+    id 'maven'
+    id 'signing'
 }
 
 dependencies {


### PR DESCRIPTION
We are switching to publishing directly to Maven Central now that Bintray is sunsetting https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter