### PR TITLE
Handle empty album names in the Smugmug Importer.

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -92,8 +92,7 @@ public class SmugMugInterface {
   SmugMugAlbumResponse createAlbum(String albumName) throws IOException {
     // Set up album
     Map<String, String> json = new HashMap<>();
-    String niceName = "Copy-of-" + cleanName(albumName);
-    json.put("NiceName", niceName);
+    json.put("NiceName", cleanName(albumName));
     // Allow conflicting names to be changed
     json.put("AutoRename", "true");
     json.put("Title", "Copy of " + albumName);


### PR DESCRIPTION
During test imports we would see this error caused by the album name being null. This handles the empty photo album name the same way that the Flickr Importer does, at the Importer level instead of at the interface level. This would allow us then to use some of the language support that was added in #972 more easily 

```
RetryingCallable caught an exception
java.io.IOException: Problem with importer, forcing a retry, first error: java.lang.NullPointerException
	at org.datatransferproject.transfer.smugmug.photos.SmugMugInterface.cleanName(SmugMugInterface.java:251)
	at org.datatransferproject.transfer.smugmug.photos.SmugMugInterface.createAlbum(SmugMugInterface.java:94)
	at org.datatransferproject.transfer.smugmug.photos.SmugMugPhotosImporter.importSingleAlbum(SmugMugPhotosImporter.java:109)
	at org.datatransferproject.transfer.smugmug.photos.SmugMugPhotosImporter.lambda$importItem$0(SmugMugPhotosImporter.java:91)
	at com.google.dataliberation.transfer.worker.extensions.cloud.T2XIdempotentImportExecutor.executeOrThrowException(T2XIdempotentImportExecutor.java:105)
	at com.google.dataliberation.transfer.worker.extensions.cloud.T2XIdempotentImportExecutor.executeAndSwallowIOExceptions(T2XIdempotentImportExecutor.java:84)
	at org.datatransferproject.transfer.smugmug.photos.SmugMugPhotosImporter.importItem(SmugMugPhotosImporter.java:88)
```