### PR TITLE
Fix casting error for JobHooks array

### DIFF
--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/hooks/JobHooksLoader.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/hooks/JobHooksLoader.java
@@ -33,7 +33,7 @@ public class JobHooksLoader {
             });
     return jobHooks.isEmpty()
         ? new DefaultJobHooks()
-        : new MultiplexJobHooks((JobHooks[]) jobHooks.toArray());
+        : new MultiplexJobHooks(jobHooks.toArray(new JobHooks[0]));
   }
 
   private JobHooksLoader() {}


### PR DESCRIPTION
When trying to implement a `JobHooksExtension` the following error is thrown:
```
java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class [Lorg.datatransferproject.spi.transfer.hooks.JobHooks;
```

This fixes the casting error by using the typed form of `toArray()`.