### PR TITLE
Update OAuth1Config for additional parameters

### DIFF
--- a/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrOAuthConfig.java
+++ b/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrOAuthConfig.java
@@ -16,17 +16,21 @@
 
 package org.datatransferproject.auth.flickr;
 
-import com.google.api.client.auth.oauth.OAuthHmacSigner;
-import com.google.api.client.auth.oauth.OAuthSigner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.datatransferproject.auth.OAuth1Config;
+import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 
 /**
  * Class that supplies Flickr-specific OAuth1 info
  * See https://www.flickr.com/services/api/auth.oauth.html
  */
 public class FlickrOAuthConfig implements OAuth1Config {
+
+  private static final String PERMS = "perms";
 
   @Override
   public String getServiceName() {
@@ -49,17 +53,28 @@ public class FlickrOAuthConfig implements OAuth1Config {
   }
 
   @Override
-  public Map<String, String> getExportScopes() {
-    return ImmutableMap.of("PHOTOS", "read");
+  public List<String> getExportTypes() {
+    return ImmutableList.of("PHOTOS");
   }
 
   @Override
-  public Map<String, String> getImportScopes() {
-    return ImmutableMap.of("PHOTOS", "write");
+  public List<String> getImportTypes() {
+    return ImmutableList.of("PHOTOS");
   }
 
-  @Override
-  public String getScopeParameterName() {
-    return "perms";
+  public Map<String, String> getAdditionalUrlParameters(
+      String dataType, AuthMode mode, OAuth1Step step) {
+    if (dataType.equals("PHOTOS")) {
+      if (step == OAuth1Step.AUTHORIZATION) {
+        if (mode == AuthMode.EXPORT) {
+          return ImmutableMap.of(PERMS, "read");
+        } else {
+          return ImmutableMap.of(PERMS, "write");
+        }
+      }
+    }
+
+    // default
+    return Collections.emptyMap();
   }
 }

--- a/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrOAuthConfig.java
+++ b/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrOAuthConfig.java
@@ -64,14 +64,11 @@ public class FlickrOAuthConfig implements OAuth1Config {
 
   public Map<String, String> getAdditionalUrlParameters(
       String dataType, AuthMode mode, OAuth1Step step) {
-    if (dataType.equals("PHOTOS")) {
-      if (step == OAuth1Step.AUTHORIZATION) {
-        if (mode == AuthMode.EXPORT) {
-          return ImmutableMap.of(PERMS, "read");
-        } else {
-          return ImmutableMap.of(PERMS, "write");
-        }
-      }
+
+    if (dataType.equals("PHOTOS") && step == OAuth1Step.AUTHORIZATION) {
+      return (mode == AuthMode.EXPORT)
+          ? ImmutableMap.of(PERMS, "read")
+          : ImmutableMap.of(PERMS, "write");
     }
 
     // default

--- a/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugOAuthConfig.java
+++ b/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugOAuthConfig.java
@@ -16,17 +16,22 @@
 
 package org.datatransferproject.auth.smugmug;
 
-import com.google.api.client.auth.oauth.OAuthHmacSigner;
-import com.google.api.client.auth.oauth.OAuthSigner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.datatransferproject.auth.OAuth1Config;
+import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 
 /**
  * Class that supplies SmugMug-specific OAuth1 info
- * See https://smugmug.atlassian.net/wiki/spaces/API/pages/689052/OAuth
+ * See https://api.smugmug.com/api/v2/doc/tutorial/authorization.html
  */
 public class SmugMugOAuthConfig implements OAuth1Config {
+
+  private static final String ACCESS = "Access";
+  private static final String PERMISSIONS = "Permissions";
 
   @Override
   public String getServiceName() {
@@ -49,17 +54,28 @@ public class SmugMugOAuthConfig implements OAuth1Config {
   }
 
   @Override
-  public Map<String, String> getExportScopes() {
-    return ImmutableMap.of("PHOTOS", "Read");
+  public List<String> getExportTypes() {
+    return ImmutableList.of("PHOTOS");
   }
 
   @Override
-  public Map<String, String> getImportScopes() {
-    return ImmutableMap.of("PHOTOS", "Add");
+  public List<String> getImportTypes() {
+    return ImmutableList.of("PHOTOS");
   }
 
-  @Override
-  public String getScopeParameterName() {
-    return "Permissions";
+  public Map<String, String> getAdditionalUrlParameters(
+      String dataType, AuthMode mode, OAuth1Step step) {
+    if (dataType.equals("PHOTOS")) {
+      if (step == OAuth1Step.AUTHORIZATION) {
+        if (mode == AuthMode.EXPORT) {
+          return ImmutableMap.of(ACCESS, "Full", PERMISSIONS, "Read");
+        } else {
+          return ImmutableMap.of(ACCESS, "Full", PERMISSIONS, "Add");
+        }
+      }
+    }
+
+    // default
+    return Collections.emptyMap();
   }
 }

--- a/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugOAuthConfig.java
+++ b/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugOAuthConfig.java
@@ -65,14 +65,11 @@ public class SmugMugOAuthConfig implements OAuth1Config {
 
   public Map<String, String> getAdditionalUrlParameters(
       String dataType, AuthMode mode, OAuth1Step step) {
-    if (dataType.equals("PHOTOS")) {
-      if (step == OAuth1Step.AUTHORIZATION) {
-        if (mode == AuthMode.EXPORT) {
-          return ImmutableMap.of(ACCESS, "Full", PERMISSIONS, "Read");
-        } else {
-          return ImmutableMap.of(ACCESS, "Full", PERMISSIONS, "Add");
-        }
-      }
+
+    if (dataType.equals("PHOTOS") && step == OAuth1Step.AUTHORIZATION) {
+      return (mode == AuthMode.EXPORT)
+          ? ImmutableMap.of(ACCESS, "Full", PERMISSIONS, "Read")
+          : ImmutableMap.of(ACCESS, "Full", PERMISSIONS, "Add");
     }
 
     // default

--- a/extensions/auth/portability-auth-twitter/src/main/java/org/datatransferproject/auth/twitter/TwitterOAuthConfig.java
+++ b/extensions/auth/portability-auth-twitter/src/main/java/org/datatransferproject/auth/twitter/TwitterOAuthConfig.java
@@ -65,14 +65,11 @@ public class TwitterOAuthConfig implements OAuth1Config {
 
   public Map<String, String> getAdditionalUrlParameters(
       String dataType, AuthMode mode, OAuth1Step step) {
-    if (dataType.equals("PHOTOS")) {
-      if (step == OAuth1Step.REQUEST_TOKEN) {
-        if (mode == AuthMode.EXPORT) {
-          return ImmutableMap.of(X_AUTH_ACCESS_TYPE, "read");
-        } else {
-          return ImmutableMap.of(X_AUTH_ACCESS_TYPE, "write");
-        }
-      }
+
+    if (dataType.equals("PHOTOS") && step == OAuth1Step.REQUEST_TOKEN) {
+      return (mode == AuthMode.EXPORT)
+          ? ImmutableMap.of(X_AUTH_ACCESS_TYPE, "read")
+          : ImmutableMap.of(X_AUTH_ACCESS_TYPE, "write");
     }
 
     // default

--- a/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1Config.java
+++ b/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1Config.java
@@ -18,7 +18,10 @@ package org.datatransferproject.auth;
 
 import com.google.api.client.auth.oauth.OAuthHmacSigner;
 import com.google.api.client.auth.oauth.OAuthSigner;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 
 /**
  * Interface for providing information necessary to run OAuth1 flow
@@ -46,31 +49,27 @@ public interface OAuth1Config {
   String getAccessTokenUrl();
 
   /**
-   * Returns a map of scopes needed for export, keyed by data type (e.g., PHOTOS, CALENDAR) as
-   * defined in the auth data generator or elsewhere
-   * Note: this method assumes that scopes are required to use this service
+   * Returns a list of export data types (e.g., PHOTOS, CALENDAR) this config is designed to support.
    */
-  Map<String, String> getExportScopes();
+  List<String> getExportTypes();
 
   /**
-   * Returns a map of scopes needed for import, keyed by data type (e.g., PHOTOS, CALENDAR) as
-   * defined in the auth data generator or elsewhere
-   * Note: this method assumes that scopes are required to use this service
+   * Returns a list of import data types (e.g., PHOTOS, CALENDAR) this config is designed to support.
    */
-  Map<String, String> getImportScopes();
+  List<String> getImportTypes();
 
   /**
-   * Returns the parameter name for scopes
-   * Note: this method assumes that scopes are required to use this service
+   * Return a map of parameters that will be added to the OAuth request.
+   *
+   * <p>The OAuth 1 spec allows service-defined parameters on the request token and authorization
+   * URLs. Typically this is used for token scope, but may have additional uses as well.
+   *
+   * <p>Some services require different parameters (scopes) for different data types. The minimum
+   * privilege for the given mode (EXPORT, IMPORT) should be used.
    */
-  String getScopeParameterName();
-
-  /**
-   * Shows what step the scopes should be requested in
-   * Note: this method assumes that scopes are required to use this service
-   */
-  default OAuth1Step whenAddScopes() {
-    return OAuth1Step.AUTHORIZATION;
+  default Map<String, String> getAdditionalUrlParameters(
+      String dataType, AuthMode mode, OAuth1Step step) {
+    return Collections.emptyMap();
   }
 
   /**

--- a/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1ServiceExtension.java
+++ b/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1ServiceExtension.java
@@ -16,8 +16,14 @@
 
 package org.datatransferproject.auth;
 
+import static java.lang.String.format;
+
 import com.google.api.client.http.HttpTransport;
 import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.api.auth.AuthDataGenerator;
@@ -25,14 +31,6 @@ import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static java.lang.String.format;
 
 /**
  * General implementation of an {@link AuthServiceExtension} for OAuth1. Largely exists to provide
@@ -67,12 +65,12 @@ public class OAuth1ServiceExtension implements AuthServiceExtension {
 
   @Override
   public List<String> getImportTypes() {
-    return new ArrayList<>(oAuth1Config.getImportScopes().keySet());
+    return oAuth1Config.getImportTypes();
   }
 
   @Override
   public List<String> getExportTypes() {
-    return new ArrayList<>(oAuth1Config.getExportScopes().keySet());
+    return oAuth1Config.getExportTypes();
   }
 
   @Override


### PR DESCRIPTION
Updates OAuth1Config and the implementing classes to support additional parameters.

The OAuth1 spec allows parameters on the token request and authorization URLs. The old configs only supported a single "scope" parameter. This allows multiple parameters, based on the combination or URL, data type, and mode.

Adds an additional parameter for SmugMug to allow reading and writing of private albums as necessary.