### PR TITLE
Remove copy of prefix for all photos importers

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -112,7 +112,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
         data.getAlbums() != null || data.getPhotos() != null, "Error: There is no data to import");
 
     if (data.getAlbums() != null) {
-      storeAlbumbs(jobId, data.getAlbums());
+      storeAlbums(jobId, data.getAlbums());
     }
 
     if (data.getPhotos() != null) {
@@ -138,7 +138,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
 
   // Store any album data in the cache because Flickr only allows you to create an album with a
   // photo in it, so we have to wait for the first photo to create the album
-  private void storeAlbumbs(UUID jobId, Collection<PhotoAlbum> albums) throws IOException {
+  private void storeAlbums(UUID jobId, Collection<PhotoAlbum> albums) throws IOException {
     for (PhotoAlbum album : albums) {
       jobStore.create(
           jobId,

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -52,7 +52,6 @@ import org.datatransferproject.types.transfer.serviceconfig.TransferServiceConfi
 
 public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerResource> {
 
-  @VisibleForTesting static final String COPY_PREFIX = "Copy of - ";
   @VisibleForTesting static final String ORIGINAL_ALBUM_PREFIX = "original-album-";
 
   private final TemporaryPerJobDataStore jobStore;
@@ -202,9 +201,8 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
         oldAlbumId,
         album.getName(),
         () -> {
-          // TODO: make COPY_PREFIX configurable.
           String albumName =
-              Strings.isNullOrEmpty(album.getName()) ? "untitled" : COPY_PREFIX + album.getName();
+              Strings.isNullOrEmpty(album.getName()) ? "untitled" : album.getName();
           String albumDescription = cleanString(album.getDescription());
 
           perUserRateLimiter.acquire();
@@ -224,9 +222,8 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
       inStream = imageStreamProvider.get(photo.getFetchableUrl());
     }
 
-    // TODO: do we want to keep COPY_PREFIX?  I think not
     String photoTitle =
-        Strings.isNullOrEmpty(photo.getTitle()) ? "" : COPY_PREFIX + photo.getTitle();
+        Strings.isNullOrEmpty(photo.getTitle()) ? "" : photo.getTitle();
     String photoDescription = cleanString(photo.getDescription());
 
     UploadMetaData uploadMetaData =

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
@@ -102,7 +102,7 @@ public class FlickrPhotosImporterTest {
     when(uploader.upload(any(BufferedInputStream.class), any(UploadMetaData.class)))
         .thenReturn(FLICKR_PHOTO_ID);
 
-    String flickrAlbumTitle = FlickrPhotosImporter.COPY_PREFIX + ALBUM_NAME;
+    String flickrAlbumTitle = ALBUM_NAME;
     Photoset photoset =
         FlickrTestUtils.initializePhotoset(FLICKR_ALBUM_ID, ALBUM_DESCRIPTION, FLICKR_PHOTO_ID);
     when(photosetsInterface.create(flickrAlbumTitle, ALBUM_DESCRIPTION, FLICKR_PHOTO_ID))
@@ -127,8 +127,7 @@ public class FlickrPhotosImporterTest {
         ArgumentCaptor.forClass(UploadMetaData.class);
     verify(uploader).upload(eq(bufferedInputStream), uploadMetaDataArgumentCaptor.capture());
     UploadMetaData actualUploadMetaData = uploadMetaDataArgumentCaptor.getValue();
-    assertThat(actualUploadMetaData.getTitle())
-        .isEqualTo(FlickrPhotosImporter.COPY_PREFIX + PHOTO_TITLE);
+    assertThat(actualUploadMetaData.getTitle()).isEqualTo(PHOTO_TITLE);
     assertThat(actualUploadMetaData.getDescription()).isEqualTo(PHOTO_DESCRIPTION);
 
     // Verify the photosets interface got the command to create the correct album

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -177,8 +177,7 @@ public class GooglePhotosImporter
       throws IOException, InvalidTokenException, PermissionDeniedException {
     // Set up album
     GoogleAlbum googleAlbum = new GoogleAlbum();
-    String copyOf = getOrCreateStringDictionary(jobId).get(BaseMultilingualString.CopyOf);
-    String title = MessageFormat.format(copyOf, Strings.nullToEmpty(inputAlbum.getName()));
+    String title = Strings.nullToEmpty(inputAlbum.getName());
 
     // Album titles are restricted to 500 characters
     // https://developers.google.com/photos/library/guides/manage-albums#creating-new-album
@@ -321,8 +320,7 @@ public class GooglePhotosImporter
     if (Strings.isNullOrEmpty(inputPhoto.getDescription())) {
       description = "";
     } else {
-      String copyOf = getOrCreateStringDictionary(jobId).get(BaseMultilingualString.CopyOf);
-      description = MessageFormat.format(copyOf, inputPhoto.getDescription());
+      description = inputPhoto.getDescription();
       // Descriptions are restricted to 1000 characters
       // https://developers.google.com/photos/library/guides/upload-media#creating-media-item
       if (description.length() > 1000) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -82,9 +82,6 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 public class GoogleVideosImporter
     implements Importer<TokensAndUrlAuthData, VideosContainerResource> {
 
-  // TODO: internationalize copy prefix
-  private static final String COPY_PREFIX = "Copy of ";
-
   private final ImageStreamProvider videoStreamProvider;
   private Monitor monitor;
   private final AppCredentials appCredentials;
@@ -174,12 +171,7 @@ public class GoogleVideosImporter
   }
 
   private VideoObject transformVideoName(VideoObject video) {
-    String filename;
-    if (Strings.isNullOrEmpty(video.getName())) {
-      filename = "untitled";
-    } else {
-      filename = COPY_PREFIX + video.getName();
-    }
+    String filename = Strings.isNullOrEmpty(video.getName()) ? "untitled": video.getName();
     video.setName(filename);
     return video;
   }

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -116,7 +116,7 @@ public class GooglePhotosImporterTest {
     // Check results
     ArgumentCaptor<GoogleAlbum> albumArgumentCaptor = ArgumentCaptor.forClass(GoogleAlbum.class);
     Mockito.verify(googlePhotosInterface).createAlbum(albumArgumentCaptor.capture());
-    assertEquals(albumArgumentCaptor.getValue().getTitle(), "Copy of " + albumName);
+    assertEquals(albumArgumentCaptor.getValue().getTitle(), albumName);
     assertNull(albumArgumentCaptor.getValue().getId());
   }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -251,7 +251,7 @@ public class GooglePhotosImporterTest {
     sut.importSingleAlbum(uuid, null, albumModel);
     ArgumentCaptor<GoogleAlbum> albumArgumentCaptor = ArgumentCaptor.forClass(GoogleAlbum.class);
     Mockito.verify(googlePhotosInterface).createAlbum(albumArgumentCaptor.capture());
-    assertEquals(albumArgumentCaptor.getValue().getTitle(), "Copia di " + albumName);
+    assertEquals(albumArgumentCaptor.getValue().getTitle(), albumName);
   }
 
   @Test

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
 
 public class GoogleVideosExporterTest {
 
-  private String VIDEO_URI = "video uri";
+  private String VIDEO_URI = "videouri";
   private String VIDEO_ID = "video id";
   private String VIDEO_TOKEN = "video_token";
 

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java
@@ -95,7 +95,7 @@ public class SmugMugInterface {
     json.put("NiceName", cleanName(albumName));
     // Allow conflicting names to be changed
     json.put("AutoRename", "true");
-    json.put("Title", "Copy of " + albumName);
+    json.put("Title", albumName);
     // All imported content is private by default.
     json.put("Privacy", "Private");
 

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
@@ -42,7 +42,6 @@ public class SmugMugPhotosImporter
     implements Importer<TokenSecretAuthData, PhotosContainerResource> {
 
   private static final String DEFAULT_ALBUM_NAME = "Untitled Album";
-  private static final String COPY_PREFIX = "Copy of ";
   private final TemporaryPerJobDataStore jobStore;
   private final AppCredentials appCredentials;
   private final ObjectMapper mapper;
@@ -112,7 +111,7 @@ public class SmugMugPhotosImporter
     String albumName =
         Strings.isNullOrEmpty(inputAlbum.getName())
             ? DEFAULT_ALBUM_NAME
-            : COPY_PREFIX + inputAlbum.getName();
+            : inputAlbum.getName();
 
     SmugMugAlbumResponse albumResponse = smugMugInterface.createAlbum(albumName);
     SmugMugPhotoTempData tempData =

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/test/java/org/datatransfer/smugmug/photos/SmugMugPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/test/java/org/datatransfer/smugmug/photos/SmugMugPhotosImporterTest.java
@@ -111,12 +111,12 @@ public class SmugMugPhotosImporterTest {
         new SmugMugAlbum(
             "date",
             photoAlbum1.getDescription(),
-            "Copy of " + photoAlbum1.getName(),
+            photoAlbum1.getName(),
             "privacy",
             "albumUri1",
             "urlname",
             "weburi");
-    String overflowAlbumName = "Copy of " + smugMugAlbum1.getName() + " (1)";
+    String overflowAlbumName = smugMugAlbum1.getName() + " (1)";
     SmugMugAlbum smugMugAlbum2 =
         new SmugMugAlbum(
             "date",


### PR DESCRIPTION
This also fixes a bug that was introduced in #981 where the copy of prefix gets added twice for the title of the album here: https://github.com/google/data-transfer-project/blob/9614d543897a5b6235344476922457d57e666914/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugInterface.java#L98