### PR TITLE
Rename `VideoObject` to `VideoModel` to follow the naming convention we use for most of the other data models

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -27,7 +27,7 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportE
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.transfer.ImageStreamProvider;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
 
@@ -62,7 +62,7 @@ public class BackblazeVideosImporter
     BackblazeDataTransferClient b2Client = b2ClientFactory.getOrCreateB2Client(monitor, authData);
 
     if (data.getVideos() != null && data.getVideos().size() > 0) {
-      for (VideoObject video : data.getVideos()) {
+      for (VideoModel video : data.getVideos()) {
         idempotentExecutor.executeAndSwallowIOExceptions(
             video.getDataId(), video.getName(), () -> importSingleVideo(b2Client, video));
       }
@@ -71,7 +71,7 @@ public class BackblazeVideosImporter
     return ImportResult.OK;
   }
 
-  private String importSingleVideo(BackblazeDataTransferClient b2Client, VideoObject video)
+  private String importSingleVideo(BackblazeDataTransferClient b2Client, VideoModel video)
       throws IOException {
     InputStream videoFileStream =
         imageStreamProvider.getConnection(video.getContentUrl().toString()).getInputStream();

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporter.java
@@ -34,7 +34,7 @@ import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.PaginationData;
 import org.datatransferproject.types.common.StringPaginationToken;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
@@ -84,7 +84,7 @@ public class FacebookVideosExporter
         return new ExportResult<>(ExportResult.ResultType.END, null);
       }
 
-      ArrayList<VideoObject> exportVideos = new ArrayList<>();
+      ArrayList<VideoModel> exportVideos = new ArrayList<>();
       for (Video video : videos) {
         final String url = video.getSource();
         final String fbid = video.getId();
@@ -93,7 +93,7 @@ public class FacebookVideosExporter
           continue;
         }
         exportVideos.add(
-            new VideoObject(
+            new VideoModel(
                 String.format("%s.mp4", fbid),
                 url,
                 video.getDescription(),

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosImporter.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
@@ -51,14 +51,14 @@ public class FacebookVideosImporter
         new DefaultFacebookClient(
             authData.getAccessToken(), appCredentials.getSecret(), Version.VERSION_3_0);
 
-    for (VideoObject video : data.getVideos()) {
+    for (VideoModel video : data.getVideos()) {
       importSingleVideo(client, video);
     }
 
     return ImportResult.OK;
   }
 
-  void importSingleVideo(FacebookClient client, VideoObject video) {
+  void importSingleVideo(FacebookClient client, VideoModel video) {
     ArrayList<Parameter> params = new ArrayList<>();
     params.add(Parameter.with("file_url", video.getContentUrl().toString()));
     if (video.getDescription() != null)

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporterTest.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason;
 import org.datatransferproject.types.common.ExportInformation;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
@@ -79,7 +79,7 @@ public class FacebookVideosExporterTest {
     VideosContainerResource exportedData = result.getExportedData();
     assertEquals(1, exportedData.getVideos().size());
     assertEquals(
-        new VideoObject(
+        new VideoModel(
             VIDEO_ID + ".mp4", VIDEO_SOURCE, VIDEO_NAME, "video/mp4", VIDEO_ID, null, false),
         exportedData.getVideos().toArray()[0]);
   }

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosImporterTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import com.restfb.FacebookClient;
 import com.restfb.Parameter;
 import com.restfb.types.GraphResponse;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -40,7 +40,7 @@ public class FacebookVideosImporterTest {
   public void testImportSingleVideo() {
     importer.importSingleVideo(
         client,
-        new VideoObject(
+        new VideoModel(
             "title", VIDEO_URL, VIDEO_DESCRIPTION, "video/mp4", "videoId", null, false));
 
     Parameter[] params = {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporter.java
@@ -31,7 +31,7 @@ import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.PaginationData;
 import org.datatransferproject.types.common.StringPaginationToken;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
@@ -89,7 +89,7 @@ public class GoogleVideosExporter
     VideosContainerResource containerResource = null;
     GoogleMediaItem[] mediaItems = mediaItemSearchResponse.getMediaItems();
     if (mediaItems != null && mediaItems.length > 0) {
-      List<VideoObject> videos = convertVideosList(mediaItems);
+      List<VideoModel> videos = convertVideosList(mediaItems);
       containerResource = new VideosContainerResource(null, videos);
     }
 
@@ -101,8 +101,8 @@ public class GoogleVideosExporter
     return new ExportResult<>(resultType, containerResource, continuationData);
   }
 
-  private List<VideoObject> convertVideosList(GoogleMediaItem[] mediaItems) {
-    List<VideoObject> videos = new ArrayList<>(mediaItems.length);
+  private List<VideoModel> convertVideosList(GoogleMediaItem[] mediaItems) {
+    List<VideoModel> videos = new ArrayList<>(mediaItems.length);
 
     for (GoogleMediaItem mediaItem : mediaItems) {
       if (mediaItem.getMediaMetadata().getVideo() != null) {
@@ -113,10 +113,10 @@ public class GoogleVideosExporter
     return videos;
   }
 
-  private VideoObject convertToVideoObject(GoogleMediaItem mediaItem) {
+  private VideoModel convertToVideoObject(GoogleMediaItem mediaItem) {
     Preconditions.checkArgument(mediaItem.getMediaMetadata().getVideo() != null);
 
-    return new VideoObject(
+    return new VideoModel(
             "", // TODO: no title?
             //            dv = download video otherwise you only get a thumbnail
             mediaItem.getBaseUrl() + "=dv",

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -74,7 +74,7 @@ import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException
 import org.datatransferproject.spi.transfer.types.UploadErrorException;
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.MediaObject;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
@@ -140,16 +140,16 @@ public class GoogleVideosImporter
 
     long bytes = 0L;
     //     Uploads videos
-    final Collection<VideoObject> videos = data.getVideos();
+    final Collection<VideoModel> videos = data.getVideos();
     if (videos != null && videos.size() > 0) {
-      Stream<VideoObject> stream =
+      Stream<VideoModel> stream =
           videos.stream()
               .filter(video -> shouldImport(video, executor))
               .map(this::transformVideoName);
       // We partition into groups of 49 as 50 is the maximum number of items that can be created in
       // one call. (We use 49 to avoid potential off by one errors)
       // https://developers.google.com/photos/library/guides/upload-media#creating-media-item
-      final UnmodifiableIterator<List<VideoObject>> batches =
+      final UnmodifiableIterator<List<VideoModel>> batches =
           Iterators.partition(stream.iterator(), 49);
       while (batches.hasNext()) {
         long batchBytes = importVideoBatch(batches.next(), client, executor);
@@ -160,7 +160,7 @@ public class GoogleVideosImporter
     return result.copyWithBytes(bytes);
   }
 
-  private boolean shouldImport(VideoObject video, IdempotentImportExecutor executor) {
+  private boolean shouldImport(VideoModel video, IdempotentImportExecutor executor) {
     if (video.getContentUrl() == null) {
       monitor.info(() -> "Content Url is empty. Make sure that you provide a valid content Url.");
       return false;
@@ -170,24 +170,24 @@ public class GoogleVideosImporter
     }
   }
 
-  private VideoObject transformVideoName(VideoObject video) {
+  private VideoModel transformVideoName(VideoModel video) {
     String filename = Strings.isNullOrEmpty(video.getName()) ? "untitled": video.getName();
     video.setName(filename);
     return video;
   }
 
   long importVideoBatch(
-      List<VideoObject> batchedVideos,
+      List<VideoModel> batchedVideos,
       PhotosLibraryClient client,
       IdempotentImportExecutor executor)
       throws Exception {
     final ArrayList<NewMediaItem> mediaItems = new ArrayList<>();
-    final HashMap<String, VideoObject> uploadTokenToDataId = new HashMap<>();
+    final HashMap<String, VideoModel> uploadTokenToDataId = new HashMap<>();
     final HashMap<String, Long> uploadTokenToLength = new HashMap<>();
     // The PhotosLibraryClient can throw InvalidArgumentException and this try block wraps the two
     // calls of the client to handle the InvalidArgumentException when the user's storage is full.
     try {
-      for (VideoObject video : batchedVideos) {
+      for (VideoModel video : batchedVideos) {
         try {
           Pair<String, Long> pair = uploadMediaItem(video, client);
           final String uploadToken = pair.getLeft();
@@ -222,7 +222,7 @@ public class GoogleVideosImporter
         String uploadToken = result.getUploadToken();
         Status status = result.getStatus();
 
-        final VideoObject video = uploadTokenToDataId.get(uploadToken);
+        final VideoModel video = uploadTokenToDataId.get(uploadToken);
         Preconditions.checkNotNull(video);
         final int code = status.getCode();
         if (code == Code.OK_VALUE) {
@@ -246,7 +246,7 @@ public class GoogleVideosImporter
         uploadTokenToDataId.remove(uploadToken);
       }
       if (!uploadTokenToDataId.isEmpty()) {
-        for (VideoObject video : uploadTokenToDataId.values()) {
+        for (VideoModel video : uploadTokenToDataId.values()) {
           executor.executeAndSwallowIOExceptions(
               video.getDataId(),
               video.getName(),
@@ -308,7 +308,7 @@ public class GoogleVideosImporter
   }
 
   @VisibleForTesting
-  NewMediaItem buildMediaItem(VideoObject inputVideo, String uploadToken) {
+  NewMediaItem buildMediaItem(VideoModel inputVideo, String uploadToken) {
     NewMediaItem newMediaItem;
     String videoDescription = inputVideo.getDescription();
     if (Strings.isNullOrEmpty(videoDescription)) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
@@ -26,11 +26,10 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.types.common.StringPaginationToken;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.io.IOException;
 import java.net.URI;
@@ -102,7 +101,7 @@ public class GoogleVideosExporterTest {
     assertThat(paginationToken.getToken()).isEqualTo(VIDEO_TOKEN);
 
     // Check videos field of container
-    Collection<VideoObject> actualVideos = result.getExportedData().getVideos();
+    Collection<VideoModel> actualVideos = result.getExportedData().getVideos();
 
     URI video_uri_object = null;
     try {
@@ -111,10 +110,10 @@ public class GoogleVideosExporterTest {
       e.printStackTrace();
     }
 
-    assertThat(actualVideos.stream().map(VideoObject::getContentUrl).collect(Collectors.toList()))
+    assertThat(actualVideos.stream().map(VideoModel::getContentUrl).collect(Collectors.toList()))
             .containsExactly(video_uri_object);
     // Since albums are not supported atm, this should be null
-    assertThat(actualVideos.stream().map(VideoObject::getAlbumId).collect(Collectors.toList()))
+    assertThat(actualVideos.stream().map(VideoModel::getAlbumId).collect(Collectors.toList()))
             .containsExactly((Object) null);
   }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
@@ -41,7 +41,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempotentImportExecutor;
 import org.datatransferproject.transfer.ImageStreamProvider;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
@@ -114,7 +114,7 @@ public class GoogleVideosImporterTest {
     long length =
         googleVideosImporter.importVideoBatch(
             Lists.newArrayList(
-                new VideoObject(
+                new VideoModel(
                     VIDEO_TITLE,
                     VIDEO_URI,
                     VIDEO_DESCRIPTION,
@@ -122,7 +122,7 @@ public class GoogleVideosImporterTest {
                     VIDEO_ID,
                     null,
                     false),
-                new VideoObject(
+                new VideoModel(
                     VIDEO_TITLE,
                     VIDEO_URI,
                     VIDEO_DESCRIPTION,
@@ -171,7 +171,7 @@ public class GoogleVideosImporterTest {
     long length =
         googleVideosImporter.importVideoBatch(
             Lists.newArrayList(
-                new VideoObject(
+                new VideoModel(
                     VIDEO_TITLE,
                     VIDEO_URI,
                     VIDEO_DESCRIPTION,
@@ -179,7 +179,7 @@ public class GoogleVideosImporterTest {
                     VIDEO_ID,
                     null,
                     false),
-                new VideoObject(
+                new VideoModel(
                     VIDEO_TITLE,
                     VIDEO_URI,
                     VIDEO_DESCRIPTION,
@@ -211,7 +211,7 @@ public class GoogleVideosImporterTest {
     long length =
         googleVideosImporter.importVideoBatch(
             Lists.newArrayList(
-                new VideoObject(
+                new VideoModel(
                     VIDEO_TITLE,
                     VIDEO_URI,
                     VIDEO_DESCRIPTION,
@@ -240,12 +240,12 @@ public class GoogleVideosImporterTest {
             + "QPP2vKFFED90jUvbqkhesYYGvrvSq0t12LoMTFqkckRbxj7tODIUco9FFf9U5MQV40q6jgrKup19BSR9NUI58Y0GpI5ZqPgSaNhoJ5V"
             + "vsPhjrywUo6s9oOnolihQYq6lXZzwhESS8diG34oFLEwq9msSsrRtUSjgH50mNGogOlgEtbaFlMgXstzOWtUk2CwFEHZ9Y2qv123456"
             + "7890";
-    final VideoObject videoObject =
-        new VideoObject(
+    final VideoModel videoModel =
+        new VideoModel(
             VIDEO_TITLE, VIDEO_URI, videoDescriptionOver1k, MP4_MEDIA_TYPE, VIDEO_ID, null, false);
 
     String uploadToken = "token";
-    NewMediaItem newMediaItemResult = googleVideosImporter.buildMediaItem(videoObject, uploadToken);
+    NewMediaItem newMediaItemResult = googleVideosImporter.buildMediaItem(videoModel, uploadToken);
     assertFalse(
         "Expected the length of the description to be truncated to 1000 chars.",
         (newMediaItemResult.getDescription().length() > 1000));

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/common/KoofrMediaExport.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/common/KoofrMediaExport.java
@@ -11,7 +11,7 @@ import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.videos.VideoAlbum;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 
 public class KoofrMediaExport {
 
@@ -97,11 +97,11 @@ public class KoofrMediaExport {
     return exportAlbums;
   }
 
-  public List<VideoObject> getVideos() throws IOException, InvalidTokenException {
-    ArrayList<VideoObject> exportVideos = new ArrayList<>();
+  public List<VideoModel> getVideos() throws IOException, InvalidTokenException {
+    ArrayList<VideoModel> exportVideos = new ArrayList<>();
 
     for (VideoObjectContainer container : videos) {
-      VideoObject video = container.videoObject;
+      VideoModel video = container.videoModel;
 
       String fetchableUrl = getFetchableUrl(container.fullPath);
 
@@ -110,7 +110,7 @@ public class KoofrMediaExport {
       }
 
       exportVideos.add(
-          new VideoObject(
+          new VideoModel(
               video.getName(),
               fetchableUrl,
               video.getDescription(),
@@ -198,8 +198,8 @@ public class KoofrMediaExport {
     albumsWithVideos.add(albumId);
 
     VideoObjectContainer container = new VideoObjectContainer();
-    container.videoObject =
-        new VideoObject(name, "", description, contentType, videoId, albumId, false);
+    container.videoModel =
+        new VideoModel(name, "", description, contentType, videoId, albumId, false);
     container.fullPath = fullPath;
 
     videos.add(container);
@@ -247,7 +247,7 @@ public class KoofrMediaExport {
   }
 
   public static class VideoObjectContainer {
-    VideoObject videoObject;
+    VideoModel videoModel;
     String fullPath;
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosExporter.java
@@ -29,7 +29,7 @@ import org.datatransferproject.transfer.koofr.common.KoofrClientFactory;
 import org.datatransferproject.transfer.koofr.common.KoofrMediaExport;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.models.videos.VideoAlbum;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
@@ -58,7 +58,7 @@ public class KoofrVideosExporter
       export.export();
 
       List<VideoAlbum> exportAlbums = export.getVideoAlbums();
-      List<VideoObject> exportVideos = export.getVideos();
+      List<VideoModel> exportVideos = export.getVideos();
 
       VideosContainerResource containerResource =
           new VideosContainerResource(exportAlbums, exportVideos);

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporter.java
@@ -30,7 +30,7 @@ import org.datatransferproject.transfer.koofr.KoofrTransmogrificationConfig;
 import org.datatransferproject.transfer.koofr.common.KoofrClient;
 import org.datatransferproject.transfer.koofr.common.KoofrClientFactory;
 import org.datatransferproject.types.common.models.videos.VideoAlbum;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
@@ -71,17 +71,17 @@ public class KoofrVideosImporter
           album.getId(), album.getName(), () -> createAlbumFolder(album, koofrClient));
     }
 
-    for (VideoObject videoObject : resource.getVideos()) {
+    for (VideoModel videoModel : resource.getVideos()) {
       String id;
-      if (videoObject.getAlbumId() == null) {
-        id = videoObject.getDataId();
+      if (videoModel.getAlbumId() == null) {
+        id = videoModel.getDataId();
       } else {
-        id = videoObject.getAlbumId() + "-" + videoObject.getDataId();
+        id = videoModel.getAlbumId() + "-" + videoModel.getDataId();
       }
       idempotentImportExecutor.executeAndSwallowIOExceptions(
           id,
-          videoObject.getName(),
-          () -> importSingleVideo(videoObject, jobId, idempotentImportExecutor, koofrClient));
+          videoModel.getName(),
+          () -> importSingleVideo(videoModel, jobId, idempotentImportExecutor, koofrClient));
     }
     return ImportResult.OK;
   }
@@ -107,7 +107,7 @@ public class KoofrVideosImporter
   }
 
   private String importSingleVideo(
-      VideoObject video,
+      VideoModel video,
       UUID jobId,
       IdempotentImportExecutor idempotentImportExecutor,
       KoofrClient koofrClient)

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosExporterTest.java
@@ -16,7 +16,7 @@ import org.datatransferproject.transfer.koofr.common.Fixtures;
 import org.datatransferproject.transfer.koofr.common.KoofrClient;
 import org.datatransferproject.transfer.koofr.common.KoofrClientFactory;
 import org.datatransferproject.types.common.models.videos.VideoAlbum;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.junit.Before;
@@ -71,9 +71,9 @@ public class KoofrVideosExporterTest {
             new VideoAlbum("/Videos", "Videos", null));
     assertEquals(expectedAlbums, exportedData.getAlbums());
 
-    List<VideoObject> expectedVideos =
+    List<VideoModel> expectedVideos =
         ImmutableList.of(
-            new VideoObject(
+            new VideoModel(
                 "Video 1.mp4",
                 "https://app-1.koofr.net/content/files/get/Video+1.mp4?base=TESTBASE",
                 null,
@@ -81,7 +81,7 @@ public class KoofrVideosExporterTest {
                 "/Album 2 :heart:/Video 1.mp4",
                 "/Album 2 :heart:",
                 false),
-            new VideoObject(
+            new VideoModel(
                 "Video 2.mp4",
                 "https://app-1.koofr.net/content/files/get/Video+2.mp4?base=TESTBASE",
                 "Video 3 description",

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporterTest.java
@@ -18,7 +18,7 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportE
 import org.datatransferproject.transfer.koofr.common.KoofrClient;
 import org.datatransferproject.transfer.koofr.common.KoofrClientFactory;
 import org.datatransferproject.types.common.models.videos.VideoAlbum;
-import org.datatransferproject.types.common.models.videos.VideoObject;
+import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.junit.After;
@@ -93,9 +93,9 @@ public class KoofrVideosImporterTest {
             new VideoAlbum("id1", "Album 1", "This is a fake album"),
             new VideoAlbum("id2", "", description1001));
 
-    Collection<VideoObject> videos =
+    Collection<VideoModel> videos =
         ImmutableList.of(
-            new VideoObject(
+            new VideoModel(
                 "video1.mp4",
                 server.url("/1.mp4").toString(),
                 "A video 1",
@@ -103,7 +103,7 @@ public class KoofrVideosImporterTest {
                 "video1",
                 "id1",
                 false),
-            new VideoObject(
+            new VideoModel(
                 "video2.mp4",
                 server.url("/2.mp4").toString(),
                 "A video 2",
@@ -111,7 +111,7 @@ public class KoofrVideosImporterTest {
                 "video2",
                 "id1",
                 false),
-            new VideoObject(
+            new VideoModel(
                 "video3.mp4",
                 server.url("/3.mp4").toString(),
                 description1001,
@@ -165,9 +165,9 @@ public class KoofrVideosImporterTest {
     UUID jobId = UUID.randomUUID();
     Collection<VideoAlbum> albums = ImmutableList.of();
 
-    Collection<VideoObject> videos =
+    Collection<VideoModel> videos =
         ImmutableList.of(
-            new VideoObject(
+            new VideoModel(
                 "video1.mp4",
                 server.url("/1.mp4").toString(),
                 "A video 1",
@@ -175,7 +175,7 @@ public class KoofrVideosImporterTest {
                 "video1",
                 null,
                 false),
-            new VideoObject(
+            new VideoModel(
                 "video2.mp4",
                 server.url("/2.mp4").toString(),
                 "A video 2",

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideoModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideoModel.java
@@ -22,14 +22,14 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.datatransferproject.types.common.models.MediaObject;
 
-public class VideoObject extends MediaObject {
+public class VideoModel extends MediaObject {
 
   private String dataId;
   private String albumId;
   private boolean inTempStore;
 
   @JsonCreator
-  public VideoObject(
+  public VideoModel(
           @JsonProperty("name") String name,
           @JsonProperty("contentUrl") String contentUrl,
           @JsonProperty("description") String description,
@@ -76,7 +76,7 @@ public class VideoObject extends MediaObject {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    VideoObject that = (VideoObject) o;
+    VideoModel that = (VideoModel) o;
     return Objects.equal(getName(), that.getName()) &&
             Objects.equal(getContentUrl(), that.getContentUrl()) &&
             Objects.equal(getDescription(), that.getDescription()) &&

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideosContainerResource.java
@@ -30,12 +30,12 @@ public class VideosContainerResource extends ContainerResource {
   private static final String ALBUMS_COUNT_DATA_NAME = "albumsCount";
 
   private final Collection<VideoAlbum> albums;
-  private final Collection<VideoObject> videos;
+  private final Collection<VideoModel> videos;
 
   @JsonCreator
   public VideosContainerResource(
       @JsonProperty("albums") Collection<VideoAlbum> albums,
-      @JsonProperty("videos") Collection<VideoObject> videos) {
+      @JsonProperty("videos") Collection<VideoModel> videos) {
     this.albums = albums == null ? ImmutableList.of() : albums;
     this.videos = videos == null ? ImmutableList.of() : videos;
   }
@@ -44,7 +44,7 @@ public class VideosContainerResource extends ContainerResource {
     return albums;
   }
 
-  public Collection<VideoObject> getVideos() {
+  public Collection<VideoModel> getVideos() {
     return videos;
   }
 

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
@@ -33,11 +33,11 @@ public class VideosContainerResourceTest {
     List<VideoAlbum> albums =
             ImmutableList.of(new VideoAlbum("id1", "album1", "This is a fake album"));
 
-    List<VideoObject> videos =
+    List<VideoModel> videos =
             ImmutableList.of(
-                    new VideoObject("Vid1", "http://example.com/1.mp4", "A video", "video/mp4", "v1", "id1",
+                    new VideoModel("Vid1", "http://example.com/1.mp4", "A video", "video/mp4", "v1", "id1",
                             false),
-                    new VideoObject(
+                    new VideoModel(
                             "Vid2", "https://example.com/2.mpeg", "A 2. video", "video/mpeg", "v2", "id1", false));
     
     ContainerResource data = new VideosContainerResource(albums, videos);


### PR DESCRIPTION
Ex, we have `PhotosModel` , `TaskModel`, `SocialActivityModel` and several others.