### PR TITLE
Refactor BackblazePhotosImporter to enable unit testing

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 
     compile('software.amazon.awssdk:s3:2.15.24')
     compile('org.apache.commons:commons-lang3:3.11')
+    compile("commons-io:commons-io:2.6")
+
+    testCompile("org.mockito:mockito-core:${mockitoVersion}")
 }
 
 configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
@@ -75,8 +75,14 @@ public class BackblazeTransferExtension implements TransferExtension {
             new BackblazeDataTransferClientFactory();
     ImageStreamProvider isProvider = new ImageStreamProvider();
 
-    importerBuilder.put("PHOTOS", new BackblazePhotosImporter(monitor, jobStore, isProvider, backblazeDataTransferClientFactory));
-    importerBuilder.put("VIDEOS", new BackblazeVideosImporter(monitor, jobStore));
+    importerBuilder.put(
+            "PHOTOS",
+            new BackblazePhotosImporter(
+                    monitor, jobStore, isProvider, backblazeDataTransferClientFactory));
+    importerBuilder.put(
+            "VIDEOS",
+            new BackblazeVideosImporter(
+                    monitor, jobStore, isProvider, backblazeDataTransferClientFactory));
     importerMap = importerBuilder.build();
     initialized = true;
   }

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
@@ -22,12 +22,14 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
 import org.datatransferproject.datatransfer.backblaze.photos.BackblazePhotosImporter;
 import org.datatransferproject.datatransfer.backblaze.videos.BackblazeVideosImporter;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.ImageStreamProvider;
 
 public class BackblazeTransferExtension implements TransferExtension {
   public static final String SERVICE_ID = "Backblaze";
@@ -69,7 +71,11 @@ public class BackblazeTransferExtension implements TransferExtension {
     TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
 
     ImmutableMap.Builder<String, Importer> importerBuilder = ImmutableMap.builder();
-    importerBuilder.put("PHOTOS", new BackblazePhotosImporter(monitor, jobStore));
+    BackblazeDataTransferClientFactory backblazeDataTransferClientFactory =
+            new BackblazeDataTransferClientFactory();
+    ImageStreamProvider isProvider = new ImageStreamProvider();
+
+    importerBuilder.put("PHOTOS", new BackblazePhotosImporter(monitor, jobStore, isProvider, backblazeDataTransferClientFactory));
     importerBuilder.put("VIDEOS", new BackblazeVideosImporter(monitor, jobStore));
     importerMap = importerBuilder.build();
     initialized = true;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
@@ -19,18 +19,26 @@ package org.datatransferproject.datatransfer.backblaze.common;
 import java.io.IOException;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.backblaze.exception.BackblazeCredentialsException;
+import org.datatransferproject.transfer.JobMetadata;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
 
 public class BackblazeDataTransferClientFactory {
   private BackblazeDataTransferClient b2Client;
+  private static final long SIZE_THRESHOLD_FOR_MULTIPART_UPLOAD = 20 * 1024 * 1024; // 20 MB.
+  private static final long PART_SIZE_FOR_MULTIPART_UPLOAD = 5 * 1024 * 1024; // 5 MB.
 
   public BackblazeDataTransferClient getOrCreateB2Client(
       Monitor monitor, TokenSecretAuthData authData)
       throws BackblazeCredentialsException, IOException {
     if (b2Client == null) {
       BackblazeDataTransferClient backblazeDataTransferClient =
-          new BackblazeDataTransferClient(monitor);
-      backblazeDataTransferClient.init(authData.getToken(), authData.getSecret());
+              new BackblazeDataTransferClient(
+                      monitor,
+                      new BaseBackblazeS3Client(),
+                      SIZE_THRESHOLD_FOR_MULTIPART_UPLOAD,
+                      PART_SIZE_FOR_MULTIPART_UPLOAD);
+      String exportService = JobMetadata.getExportService();
+      backblazeDataTransferClient.init(authData.getToken(), authData.getSecret(), exportService);
       b2Client = backblazeDataTransferClient;
     }
     return b2Client;

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeS3Client.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeS3Client.java
@@ -1,0 +1,9 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.datatransferproject.datatransfer.backblaze.common;
+
+import software.amazon.awssdk.services.s3.S3Client;
+
+public interface BackblazeS3Client {
+    S3Client createS3Client(String accessKey, String secretKey, String region);
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BaseBackblazeS3Client.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BaseBackblazeS3Client.java
@@ -1,0 +1,31 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.datatransferproject.datatransfer.backblaze.common;
+
+import java.net.URI;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class BaseBackblazeS3Client implements BackblazeS3Client {
+    private static final String S3_ENDPOINT_FORMAT_STRING = "https://s3.%s.backblazeb2.com";
+
+    public S3Client createS3Client(String accessKey, String secretKey, String region) {
+        AwsSessionCredentials awsCreds = AwsSessionCredentials.create(accessKey, secretKey, "");
+
+        ClientOverrideConfiguration clientOverrideConfiguration =
+                ClientOverrideConfiguration.builder().putHeader("User-Agent", "Facebook-DTP").build();
+
+        // Use any AWS region for the client, the Backblaze API does not care about it
+        Region awsRegion = Region.US_EAST_1;
+
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .overrideConfiguration(clientOverrideConfiguration)
+                .endpointOverride(URI.create(String.format(S3_ENDPOINT_FORMAT_STRING, region)))
+                .region(awsRegion)
+                .build();
+    }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
@@ -41,14 +41,19 @@ public class BackblazePhotosImporter
   private static final String PHOTO_TRANSFER_MAIN_FOLDER = "Photo Transfer";
 
   private final TemporaryPerJobDataStore jobStore;
-  private final ImageStreamProvider imageStreamProvider = new ImageStreamProvider();
+  private final ImageStreamProvider imageStreamProvider;
   private final Monitor monitor;
   private final BackblazeDataTransferClientFactory b2ClientFactory;
 
-  public BackblazePhotosImporter(Monitor monitor, TemporaryPerJobDataStore jobStore) {
+  public BackblazePhotosImporter(
+          Monitor monitor,
+          TemporaryPerJobDataStore jobStore,
+          ImageStreamProvider imageStreamProvider,
+          BackblazeDataTransferClientFactory b2ClientFactory) {
     this.monitor = monitor;
     this.jobStore = jobStore;
-    this.b2ClientFactory = new BackblazeDataTransferClientFactory();
+    this.imageStreamProvider = imageStreamProvider;
+    this.b2ClientFactory = b2ClientFactory;
   }
 
   @Override

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -37,14 +37,19 @@ public class BackblazeVideosImporter
   private static final String VIDEO_TRANSFER_MAIN_FOLDER = "Video Transfer";
 
   private final TemporaryPerJobDataStore jobStore;
-  private final ImageStreamProvider imageStreamProvider = new ImageStreamProvider();
+  private final ImageStreamProvider imageStreamProvider;
   private final Monitor monitor;
   private final BackblazeDataTransferClientFactory b2ClientFactory;
 
-  public BackblazeVideosImporter(Monitor monitor, TemporaryPerJobDataStore jobStore) {
+  public BackblazeVideosImporter(
+          Monitor monitor,
+          TemporaryPerJobDataStore jobStore,
+          ImageStreamProvider imageStreamProvider,
+          BackblazeDataTransferClientFactory b2ClientFactory) {
     this.monitor = monitor;
     this.jobStore = jobStore;
-    this.b2ClientFactory = new BackblazeDataTransferClientFactory();
+    this.imageStreamProvider = imageStreamProvider;
+    this.b2ClientFactory = b2ClientFactory;
   }
 
   @Override

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientTest.java
@@ -1,0 +1,235 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.datatransferproject.datatransfer.backblaze.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.exception.BackblazeCredentialsException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BackblazeDataTransferClientTest {
+    @Mock private Monitor monitor;
+    @Mock private BackblazeS3Client backblazeS3Client;
+    @Mock private S3Client s3Client;
+    private static File testFile;
+    private static String KEY_ID = "keyId";
+    private static String APP_KEY = "appKey";
+    private static String EXPORT_SERVICE = "exp-serv";
+    private static String FILE_KEY = "fileKey";
+    private static String VALID_BUCKET_NAME = EXPORT_SERVICE + "-data-transfer-bucket";
+
+    @BeforeClass
+    public static void setUpClass() {
+        String prefix = "fbjava/data-transfer-project/portability-data-transfer-backblaze/";
+        testFile = new File(prefix + "src/test/resources/test.txt");
+    }
+
+    @Before
+    public void setUp() {
+        reset(monitor);
+        reset(backblazeS3Client);
+        reset(s3Client);
+        when(backblazeS3Client.createS3Client(anyString(), anyString(), anyString()))
+                .thenReturn(s3Client);
+    }
+
+    private void createValidBucketList() {
+        Bucket bucket = Bucket.builder().name(VALID_BUCKET_NAME).build();
+        when(s3Client.listBuckets()).thenReturn(ListBucketsResponse.builder().buckets(bucket).build());
+    }
+
+    private void createEmptyBucketList() {
+        when(s3Client.listBuckets()).thenReturn(ListBucketsResponse.builder().build());
+    }
+
+    private BackblazeDataTransferClient createDefaultClient() {
+        return new BackblazeDataTransferClient(monitor, backblazeS3Client, 1000, 500);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWrongPartSize() {
+        // Act
+        new BackblazeDataTransferClient(monitor, backblazeS3Client, 10, 0);
+        // Assert: expected exception
+    }
+
+    @Test
+    public void testInitBucketNameMatches() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        createValidBucketList();
+        BackblazeDataTransferClient client = createDefaultClient();
+        // Act
+        client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        // Assert: no bucket is created
+        verify(s3Client, times(0)).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test
+    public void testInitBucketCreated() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        Bucket bucket = Bucket.builder().name("invalid-name").build();
+        when(s3Client.listBuckets()).thenReturn(ListBucketsResponse.builder().buckets(bucket).build());
+        BackblazeDataTransferClient client = createDefaultClient();
+        // Act
+        client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        // Assert: bucket created once
+        verify(s3Client, times(1)).createBucket(any(CreateBucketRequest.class));
+    }
+
+    @Test(expected = IOException.class)
+    public void testInitBucketNameExists() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        createEmptyBucketList();
+        when(s3Client.createBucket(any(CreateBucketRequest.class)))
+                .thenThrow(BucketAlreadyExistsException.builder().build());
+        BackblazeDataTransferClient client = createDefaultClient();
+        // Act
+        try {
+            client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        } catch (Exception ex) {
+            // Assert
+            verify(monitor, atLeast(1)).info(any());
+            throw ex;
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testInitErrorCreatingBucket() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        createEmptyBucketList();
+        when(s3Client.createBucket(any(CreateBucketRequest.class)))
+                .thenThrow(AwsServiceException.builder().build());
+        BackblazeDataTransferClient client = createDefaultClient();
+        // Act
+        client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        // Assert: expected exception
+    }
+
+    @Test(expected = BackblazeCredentialsException.class)
+    public void testInitListBucketException() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        when(s3Client.listBuckets()).thenThrow(S3Exception.builder().statusCode(403).build());
+        BackblazeDataTransferClient client = createDefaultClient();
+        // Act
+        try {
+            client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        } catch (Exception ex) {
+            // Assert: closed client
+            verify(s3Client, atLeast(1)).close();
+            verify(monitor, atLeast(1)).debug(any());
+            throw ex;
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testUploadFileNonInitialized() throws IOException {
+        // Arrange
+        BackblazeDataTransferClient client = createDefaultClient();
+        // Act
+        client.uploadFile(FILE_KEY, testFile);
+        // Assert: expected exception
+    }
+
+    @Test
+    public void testUploadFileSingle() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        final String expectedVersionId = "123";
+        createValidBucketList();
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().versionId(expectedVersionId).build());
+        BackblazeDataTransferClient client = createDefaultClient();
+        client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        // Act
+        String actualVersionId = client.uploadFile(FILE_KEY, testFile);
+        // Assert
+        verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        assertEquals(expectedVersionId, actualVersionId);
+    }
+
+    @Test(expected = IOException.class)
+    public void testUploadFileSingleException() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        createValidBucketList();
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(AwsServiceException.builder().build());
+        BackblazeDataTransferClient client = createDefaultClient();
+        client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        // Act
+        client.uploadFile(FILE_KEY, testFile);
+        // Assert: expected exception
+    }
+
+    @Test
+    public void testUploadFileMultipart() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        final String expectedVersionId = "123";
+        createValidBucketList();
+        when(s3Client.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+                .thenReturn(CreateMultipartUploadResponse.builder().uploadId("xyz").build());
+        when(s3Client.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
+                .thenReturn(UploadPartResponse.builder().build());
+        when(s3Client.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+                .thenReturn(CompleteMultipartUploadResponse.builder().versionId(expectedVersionId).build());
+        final long partSize = 10;
+        final long fileSize = testFile.length();
+        final long expectedParts = fileSize / partSize + (fileSize % partSize == 0 ? 0 : 1);
+        BackblazeDataTransferClient client =
+                new BackblazeDataTransferClient(monitor, backblazeS3Client, fileSize / 2, partSize);
+        client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        // Act
+        String actualVersionId = client.uploadFile(FILE_KEY, testFile);
+        // Assert: uploaded in 8 parts
+        verify(s3Client, times((int) expectedParts))
+                .uploadPart(any(UploadPartRequest.class), any(RequestBody.class));
+        assertEquals(expectedVersionId, actualVersionId);
+    }
+
+    @Test(expected = IOException.class)
+    public void testUploadFileMultipartException() throws BackblazeCredentialsException, IOException {
+        // Arrange
+        createValidBucketList();
+        when(s3Client.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+                .thenReturn(CreateMultipartUploadResponse.builder().uploadId("xyz").build());
+        when(s3Client.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
+                .thenThrow(AwsServiceException.builder().build());
+        final long fileSize = testFile.length();
+        BackblazeDataTransferClient client =
+                new BackblazeDataTransferClient(monitor, backblazeS3Client, fileSize / 2, fileSize / 8);
+        client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
+        // Act
+        client.uploadFile(FILE_KEY, testFile);
+        // Assert: expected exception
+    }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
@@ -1,0 +1,138 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.datatransferproject.datatransfer.backblaze.photos;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import org.apache.commons.io.IOUtils;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.transfer.ImageStreamProvider;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class BackblazePhotosImporterTest {
+    Monitor monitor;
+    TemporaryPerJobDataStore dataStore;
+    ImageStreamProvider streamProvider;
+    BackblazeDataTransferClientFactory clientFactory;
+    IdempotentImportExecutor executor;
+    TokenSecretAuthData authData;
+    BackblazeDataTransferClient client;
+
+    @Before
+    public void setUp() {
+        monitor = mock(Monitor.class);
+        dataStore = mock(TemporaryPerJobDataStore.class);
+        streamProvider = mock(ImageStreamProvider.class);
+        clientFactory = mock(BackblazeDataTransferClientFactory.class);
+        executor = mock(IdempotentImportExecutor.class);
+        authData = mock(TokenSecretAuthData.class);
+        client = mock(BackblazeDataTransferClient.class);
+    }
+
+    @Test
+    public void testNullData() throws Exception {
+        BackblazePhotosImporter sut =
+                new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
+        ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, null);
+        assertEquals(ImportResult.OK, result);
+    }
+
+    @Test
+    public void testNullPhotosAndAlbums() throws Exception {
+        PhotosContainerResource data = mock(PhotosContainerResource.class);
+        when(data.getAlbums()).thenReturn(null);
+        when(data.getPhotos()).thenReturn(null);
+
+        BackblazePhotosImporter sut =
+                new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
+        ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, data);
+        assertEquals(ImportResult.OK, result);
+    }
+
+    @Test
+    public void testEmptyPhotosAndAlbums() throws Exception {
+        PhotosContainerResource data = mock(PhotosContainerResource.class);
+        when(data.getAlbums()).thenReturn(new ArrayList<>());
+        when(data.getPhotos()).thenReturn(new ArrayList<>());
+
+        BackblazePhotosImporter sut =
+                new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
+        ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, data);
+        assertEquals(ImportResult.OK, result);
+    }
+
+    @Test
+    public void testImportPhoto() throws Exception {
+        String dataId = "dataId";
+        String title = "title";
+        String photoUrl = "photoUrl";
+        String albumName = "albumName";
+        String albumId = "albumId";
+        String response = "response";
+
+        PhotoModel photoModel = new PhotoModel(title, photoUrl, "", "", dataId, albumId, false, null);
+        ArrayList<PhotoModel> photos = new ArrayList<>();
+        photos.add(photoModel);
+        PhotosContainerResource data = mock(PhotosContainerResource.class);
+        when(data.getPhotos()).thenReturn(photos);
+
+        when(executor.getCachedValue(albumId)).thenReturn(albumName);
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getInputStream()).thenReturn(IOUtils.toInputStream("photo content", "UTF-8"));
+        when(streamProvider.getConnection(photoUrl)).thenReturn(connection);
+
+        when(client.uploadFile(eq("Photo Transfer/albumName/dataId.jpg"), any())).thenReturn(response);
+        when(clientFactory.getOrCreateB2Client(monitor, authData)).thenReturn(client);
+
+        BackblazePhotosImporter sut =
+                new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
+        sut.importItem(UUID.randomUUID(), executor, authData, data);
+
+        ArgumentCaptor<Callable<String>> importCapture = ArgumentCaptor.forClass(Callable.class);
+        verify(executor, times(1))
+                .executeAndSwallowIOExceptions(eq(dataId), eq(title), importCapture.capture());
+
+        String actual = importCapture.getValue().call();
+        assertEquals(response, actual);
+    }
+
+    @Test
+    public void testImportAlbum() throws Exception {
+        String albumId = "albumId";
+        PhotoAlbum album = new PhotoAlbum(albumId, "", "");
+        ArrayList<PhotoAlbum> albums = new ArrayList<>();
+        albums.add(album);
+        PhotosContainerResource data = mock(PhotosContainerResource.class);
+        when(data.getAlbums()).thenReturn(albums);
+
+        BackblazePhotosImporter sut =
+                new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
+        sut.importItem(UUID.randomUUID(), executor, authData, data);
+
+        verify(executor, times(1))
+                .executeAndSwallowIOExceptions(
+                        eq(albumId), eq("Caching album name for album 'albumId'"), any());
+    }
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
@@ -1,0 +1,120 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+package org.datatransferproject.datatransfer.backblaze.videos;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import org.apache.commons.io.IOUtils;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.transfer.ImageStreamProvider;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class BackblazeVideosImporterTest {
+    Monitor monitor;
+    TemporaryPerJobDataStore dataStore;
+    ImageStreamProvider streamProvider;
+    BackblazeDataTransferClientFactory clientFactory;
+    IdempotentImportExecutor executor;
+    TokenSecretAuthData authData;
+    BackblazeDataTransferClient client;
+
+    @Before
+    public void setUp() {
+        monitor = mock(Monitor.class);
+        dataStore = mock(TemporaryPerJobDataStore.class);
+        streamProvider = mock(ImageStreamProvider.class);
+        clientFactory = mock(BackblazeDataTransferClientFactory.class);
+        executor = mock(IdempotentImportExecutor.class);
+        authData = mock(TokenSecretAuthData.class);
+        client = mock(BackblazeDataTransferClient.class);
+    }
+
+    @Test
+    public void testNullData() throws Exception {
+        BackblazeVideosImporter sut =
+                new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
+        ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, null);
+        assertEquals(ImportResult.OK, result);
+    }
+
+    @Test
+    public void testNullVideos() throws Exception {
+        VideosContainerResource data = mock(VideosContainerResource.class);
+        when(data.getVideos()).thenReturn(null);
+
+        BackblazeVideosImporter sut =
+                new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
+        ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, data);
+        assertEquals(ImportResult.OK, result);
+    }
+
+    @Test
+    public void testEmptyVideos() throws Exception {
+        VideosContainerResource data = mock(VideosContainerResource.class);
+        when(data.getVideos()).thenReturn(new ArrayList<>());
+
+        BackblazeVideosImporter sut =
+                new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
+        ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, data);
+        assertEquals(ImportResult.OK, result);
+    }
+
+    @Test
+    public void testImportVideo() throws Exception {
+        String dataId = "dataId";
+        String title = "title";
+        String videoUrl = "videoUrl";
+        String description = "description";
+        String encodingFormat = "UTF-8";
+        String albumName = "albumName";
+        String albumId = "albumId";
+        String response = "response";
+
+        VideoModel videoObject =
+                new VideoModel(title, videoUrl, description, encodingFormat, dataId, albumId, false);
+        ArrayList<VideoModel> videos = new ArrayList<>();
+        videos.add(videoObject);
+        VideosContainerResource data = mock(VideosContainerResource.class);
+        when(data.getVideos()).thenReturn(videos);
+
+        when(executor.getCachedValue(albumId)).thenReturn(albumName);
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getInputStream()).thenReturn(IOUtils.toInputStream("video content", "UTF-8"));
+        when(streamProvider.getConnection(videoUrl)).thenReturn(connection);
+
+        when(client.uploadFile(eq("Video Transfer/dataId.mp4"), any())).thenReturn(response);
+        when(clientFactory.getOrCreateB2Client(monitor, authData)).thenReturn(client);
+
+        BackblazeVideosImporter sut =
+                new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
+        sut.importItem(UUID.randomUUID(), executor, authData, data);
+
+        ArgumentCaptor<Callable<String>> importCapture = ArgumentCaptor.forClass(Callable.class);
+        verify(executor, times(1))
+                .executeAndSwallowIOExceptions(eq(dataId), eq(title), importCapture.capture());
+
+        String actual = importCapture.getValue().call();
+        assertEquals(response, actual);
+    }
+}


### PR DESCRIPTION
Summary:  Changing constructor to enable unit testing in the next PR

Test Plan: ./gradlew test

Reviewers: seehamrun, KseniiaPelykh

Subscribers: 

Tasks: 

Tags: 

Blame Revision: 