### PR TITLE
Throw generic copy exceptions to mark transfers as failed when copy iteration fails in importer

### DIFF
--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityAbstractInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityAbstractInMemoryDataCopier.java
@@ -163,6 +163,7 @@ public abstract class PortabilityAbstractInMemoryDataCopier implements InMemoryD
                 && CopyExceptionWithFailureReason.class.isAssignableFrom(e.getCause().getClass())) {
           throw (CopyExceptionWithFailureReason) e.getCause();
         }
+        throw new CopyException(jobIdPrefix + "Error happened during import", e);
       } finally {
         metricRecorder.importPageFinished(
                 JobMetadata.getDataType(),


### PR DESCRIPTION
Currently when copy iteration fails in the importer and when the exception thrown is not assignable from CopyExceptionWithFailureReason we mark transfers as successful. Throwing generic copy exception will make sure that transfers are marked as failed. 