### PR TITLE
bump log4j from 2.11.0 to 2.15.0 in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ okHttpVersion=3.9.1
 azureKeyVaultVersion=1.0.0
 javaDockerContainer=openjdk:8-jdk
 jerseyVersion=2.26
-log4jVersion=2.11.0
+log4jVersion=2.15.0
 apacheHttpVersion=4.5.6
 
 # ossrhUsername=


### PR DESCRIPTION
see e.g. https://github.com/vorburger/Log4j_CVE-2021-44228/