### PR TITLE
 Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ okHttpVersion=3.9.1
 azureKeyVaultVersion=1.0.0
 javaDockerContainer=openjdk:8-jdk
 jerseyVersion=2.26
-log4jVersion=2.16.0
+log4jVersion=2.17.0
 apacheHttpVersion=4.5.6
 
 # ossrhUsername=


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105