### PR TITLE
Adding extension context to idempotent executor

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleCloudIdempotentImportExecutorExtension.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleCloudIdempotentImportExecutorExtension.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import java.io.IOException;
+import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorExtension;
@@ -14,7 +15,8 @@ public class GoogleCloudIdempotentImportExecutorExtension implements
   private Datastore datastore;
 
   @Override
-  public IdempotentImportExecutor getIdempotentImportExecutor(Monitor monitor) {
+  public IdempotentImportExecutor getIdempotentImportExecutor(ExtensionContext extensionContext) {
+    Monitor monitor = extensionContext.getMonitor();
     try {
       return new GoogleCloudIdempotentImportExecutor(getDatastore(), monitor);
     } catch (IOException e) {
@@ -25,7 +27,6 @@ public class GoogleCloudIdempotentImportExecutorExtension implements
 
   @Override
   public void initialize() {
-
   }
 
   private synchronized Datastore getDatastore() throws IOException {

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutorExtension.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutorExtension.java
@@ -1,8 +1,9 @@
 package org.datatransferproject.spi.transfer.idempotentexecutor;
 
 import org.datatransferproject.api.launcher.BootExtension;
+import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 
 public interface IdempotentImportExecutorExtension extends BootExtension {
-  IdempotentImportExecutor getIdempotentImportExecutor(Monitor monitor);
+  IdempotentImportExecutor getIdempotentImportExecutor(ExtensionContext extensionContext);
 }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutorLoader.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutorLoader.java
@@ -2,22 +2,23 @@ package org.datatransferproject.spi.transfer.idempotentexecutor;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ServiceLoader;
+import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 
 public class IdempotentImportExecutorLoader {
 
-  public static IdempotentImportExecutor load(Monitor monitor) {
+  public static IdempotentImportExecutor load(ExtensionContext extensionContext) {
     ImmutableList.Builder<IdempotentImportExecutorExtension> builder = ImmutableList.builder();
     ServiceLoader.load(IdempotentImportExecutorExtension.class)
         .iterator()
         .forEachRemaining(builder::add);
     ImmutableList<IdempotentImportExecutorExtension> executors = builder.build();
     if (executors.isEmpty()) {
-      return new InMemoryIdempotentImportExecutor(monitor);
+      return new InMemoryIdempotentImportExecutor(extensionContext.getMonitor());
     } else if (executors.size() == 1) {
       IdempotentImportExecutorExtension extension = executors.get(0);
       extension.initialize();
-      return extension.getIdempotentImportExecutor(monitor);
+      return extension.getIdempotentImportExecutor(extensionContext);
     } else {
       throw new IllegalStateException("Cannot load multiple IdempotentImportExecutors");
     }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
@@ -103,7 +103,7 @@ public class WorkerMain {
     monitor.info(() -> "Using SecurityExtension: " + securityExtension.getClass().getName());
 
     IdempotentImportExecutor idempotentImportExecutor =
-        IdempotentImportExecutorLoader.load(monitor);
+        IdempotentImportExecutorLoader.load(extensionContext);
     monitor.info(
         () -> "Using IdempotentImportExecutor: " + idempotentImportExecutor.getClass().getName());
 


### PR DESCRIPTION
We want to keep track of a single item transfer state for giving users more visibility of what photo/video/etc. were transferred successfully. One possible solution could be adding transfer item state management logic to the IdempotentImportExecutor. In this case, we will need to add ExtensionContext dependency to the IdempotentImportExecutor, so we can use JobStore to update item state.