### PR TITLE
Switch BackblazeTransferClientFactory from using 1 single client for every job to keeping a map of clients based on JobId

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
@@ -72,7 +72,7 @@ public class BackblazeTransferExtension implements TransferExtension {
 
     ImmutableMap.Builder<String, Importer> importerBuilder = ImmutableMap.builder();
     BackblazeDataTransferClientFactory backblazeDataTransferClientFactory =
-            new BackblazeDataTransferClientFactory();
+            new BackblazeDataTransferClientFactory(monitor);
     ImageStreamProvider isProvider = new ImageStreamProvider();
 
     importerBuilder.put(

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientFactory.java
@@ -17,20 +17,30 @@
 package org.datatransferproject.datatransfer.backblaze.common;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.backblaze.exception.BackblazeCredentialsException;
 import org.datatransferproject.transfer.JobMetadata;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
 
 public class BackblazeDataTransferClientFactory {
-  private BackblazeDataTransferClient b2Client;
+  private final Map<UUID, BackblazeDataTransferClient> backblazeDataTransferClientMap;
+  private final Monitor monitor;
+
   private static final long SIZE_THRESHOLD_FOR_MULTIPART_UPLOAD = 20 * 1024 * 1024; // 20 MB.
   private static final long PART_SIZE_FOR_MULTIPART_UPLOAD = 5 * 1024 * 1024; // 5 MB.
 
-  public BackblazeDataTransferClient getOrCreateB2Client(
-      Monitor monitor, TokenSecretAuthData authData)
+  public BackblazeDataTransferClientFactory(Monitor monitor) {
+    this.monitor = monitor;
+    this.backblazeDataTransferClientMap = new HashMap<>();
+  }
+
+  public BackblazeDataTransferClient getOrCreateB2Client( UUID jobId,
+      TokenSecretAuthData authData)
       throws BackblazeCredentialsException, IOException {
-    if (b2Client == null) {
+    if (!backblazeDataTransferClientMap.containsKey(jobId)) {
       BackblazeDataTransferClient backblazeDataTransferClient =
               new BackblazeDataTransferClient(
                       monitor,
@@ -39,8 +49,8 @@ public class BackblazeDataTransferClientFactory {
                       PART_SIZE_FOR_MULTIPART_UPLOAD);
       String exportService = JobMetadata.getExportService();
       backblazeDataTransferClient.init(authData.getToken(), authData.getSecret(), exportService);
-      b2Client = backblazeDataTransferClient;
+      backblazeDataTransferClientMap.put(jobId, backblazeDataTransferClient);
     }
-    return b2Client;
+    return backblazeDataTransferClientMap.get(jobId);
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
@@ -68,7 +68,7 @@ public class BackblazePhotosImporter
       return ImportResult.OK;
     }
 
-    BackblazeDataTransferClient b2Client = b2ClientFactory.getOrCreateB2Client(monitor, authData);
+    BackblazeDataTransferClient b2Client = b2ClientFactory.getOrCreateB2Client(jobId, authData);
 
     if (data.getAlbums() != null && data.getAlbums().size() > 0) {
       for (PhotoAlbum album : data.getAlbums()) {

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -64,7 +64,7 @@ public class BackblazeVideosImporter
       return ImportResult.OK;
     }
 
-    BackblazeDataTransferClient b2Client = b2ClientFactory.getOrCreateB2Client(monitor, authData);
+    BackblazeDataTransferClient b2Client = b2ClientFactory.getOrCreateB2Client(jobId, authData);
 
     if (data.getVideos() != null && data.getVideos().size() > 0) {
       for (VideoModel video : data.getVideos()) {

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
@@ -104,7 +104,7 @@ public class BackblazePhotosImporterTest {
         String albumName = "albumName";
         String albumId = "albumId";
         String response = "response";
-
+        UUID jobId = UUID.randomUUID();
         PhotoModel photoModel = new PhotoModel(title, photoUrl, "", "", dataId, albumId, false, null);
         ArrayList<PhotoModel> photos = new ArrayList<>();
         photos.add(photoModel);
@@ -118,11 +118,11 @@ public class BackblazePhotosImporterTest {
         when(streamProvider.getConnection(photoUrl)).thenReturn(connection);
 
         when(client.uploadFile(eq("Photo Transfer/albumName/dataId.jpg"), any())).thenReturn(response);
-        when(clientFactory.getOrCreateB2Client(monitor, authData)).thenReturn(client);
+        when(clientFactory.getOrCreateB2Client(jobId, authData)).thenReturn(client);
 
         BackblazePhotosImporter sut =
                 new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
-        sut.importItem(UUID.randomUUID(), executor, authData, data);
+        sut.importItem(jobId, executor, authData, data);
 
         ArgumentCaptor<Callable<String>> importCapture = ArgumentCaptor.forClass(Callable.class);
         verify(executor, times(1))

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
@@ -103,6 +103,7 @@ public class BackblazeVideosImporterTest {
         String albumName = "albumName";
         String albumId = "albumId";
         String response = "response";
+        UUID jobId = UUID.randomUUID();
 
         VideoModel videoObject =
                 new VideoModel(title, videoUrl, description, encodingFormat, dataId, albumId, false);
@@ -118,11 +119,11 @@ public class BackblazeVideosImporterTest {
         when(streamProvider.getConnection(videoUrl)).thenReturn(connection);
 
         when(client.uploadFile(eq("Video Transfer/dataId.mp4"), any())).thenReturn(response);
-        when(clientFactory.getOrCreateB2Client(monitor, authData)).thenReturn(client);
+        when(clientFactory.getOrCreateB2Client(jobId, authData)).thenReturn(client);
 
         BackblazeVideosImporter sut =
                 new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
-        sut.importItem(UUID.randomUUID(), executor, authData, data);
+        sut.importItem(jobId, executor, authData, data);
 
         ArgumentCaptor<Callable<String>> importCapture = ArgumentCaptor.forClass(Callable.class);
         verify(executor, times(1))


### PR DESCRIPTION
this prevents the race condition where we need to use a different set of auth data for a different job but use the old client factory 