### PR TITLE
Unifying photo import idempotent id calculation

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
@@ -25,6 +25,7 @@ import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransf
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.transfer.ImageStreamProvider;
@@ -82,7 +83,7 @@ public class BackblazePhotosImporter
     if (data.getPhotos() != null && data.getPhotos().size() > 0) {
       for (PhotoModel photo : data.getPhotos()) {
         idempotentExecutor.executeAndSwallowIOExceptions(
-            photo.getDataId(),
+            IdempotentImportExecutorHelper.getPhotoIdempotentId(photo),
             photo.getTitle(),
             () -> importSinglePhoto(idempotentExecutor, b2Client, jobId, photo));
       }

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
@@ -126,7 +126,7 @@ public class BackblazePhotosImporterTest {
 
         ArgumentCaptor<Callable<String>> importCapture = ArgumentCaptor.forClass(Callable.class);
         verify(executor, times(1))
-                .executeAndSwallowIOExceptions(eq(dataId), eq(title), importCapture.capture());
+                .executeAndSwallowIOExceptions(eq(String.format("%s-%s", albumId, dataId)), eq(title), importCapture.capture());
 
         String actual = importCapture.getValue().call();
         assertEquals(response, actual);

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/main/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/main/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporter.java
@@ -29,6 +29,7 @@ import okhttp3.*;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.transfer.JobMetadata;
@@ -83,7 +84,7 @@ public class DaybookPhotosImporter
     // Import photos
     for (PhotoModel photo : resource.getPhotos()) {
       executor.executeAndSwallowIOExceptions(
-          photo.getDataId(),
+          IdempotentImportExecutorHelper.getPhotoIdempotentId(photo),
           photo.getTitle(),
           () -> {
             String albumId;

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporter.java
@@ -40,6 +40,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
@@ -149,8 +150,7 @@ public class FlickrPhotosImporter implements Importer<AuthData, PhotosContainerR
   private void importSinglePhoto(
       IdempotentImportExecutor idempotentExecutor, UUID id, PhotoModel photo) throws Exception {
     String photoId =
-        idempotentExecutor.executeAndSwallowIOExceptions(
-            photo.getAlbumId() + "-" + photo.getDataId(),
+        idempotentExecutor.executeAndSwallowIOExceptions(IdempotentImportExecutorHelper.getPhotoIdempotentId(photo),
             photo.getTitle(),
             () -> uploadPhoto(photo, id));
     if (photoId == null) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporterTest.java
@@ -160,8 +160,8 @@ public class GooglePhotosImporterTest {
             NEW_ALBUM_ID);
     // Two photos of 32L each imported
     assertEquals(64L, length);
-    assertTrue(executor.isKeyCached(googlePhotosImporter.getIdempotentId(photoModel1)));
-    assertTrue(executor.isKeyCached(googlePhotosImporter.getIdempotentId(photoModel2)));
+    assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1")));
+    assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID2")));
   }
 
   private NewMediaItemResult buildMediaItemResult(String uploadToken, int code) {
@@ -218,8 +218,8 @@ public class GooglePhotosImporterTest {
             NEW_ALBUM_ID);
     // Only one photo of 32L imported
     assertEquals(32L, length);
-    assertTrue(executor.isKeyCached(googlePhotosImporter.getIdempotentId(photoModel1)));
-    String failedDataId = googlePhotosImporter.getIdempotentId(photoModel2);
+    assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1")));
+    String failedDataId = String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID2");
     assertFalse(executor.isKeyCached(failedDataId));
     ErrorDetail errorDetail = executor.getErrors().iterator().next();
     assertEquals(failedDataId, errorDetail.id());
@@ -321,7 +321,7 @@ public class GooglePhotosImporterTest {
             Lists.newArrayList(photoModel),
             executor,
             NEW_ALBUM_ID);
-    assertTrue(executor.isKeyCached(googlePhotosImporter.getIdempotentId(photoModel)));
+    assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1")));
     Mockito.verify(jobStore, Mockito.times(1)).removeData(any(), anyString());
     Mockito.verify(jobStore, Mockito.times(1)).getStream(any(), anyString());
   }

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/photos/KoofrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/photos/KoofrPhotosImporter.java
@@ -33,6 +33,7 @@ import org.apache.commons.io.IOUtils;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
@@ -102,7 +103,7 @@ public class KoofrPhotosImporter
 
     for (PhotoModel photoModel : resource.getPhotos()) {
       idempotentImportExecutor.executeAndSwallowIOExceptions(
-          photoModel.getAlbumId() + "-" + photoModel.getDataId(),
+          IdempotentImportExecutorHelper.getPhotoIdempotentId(photoModel),
           photoModel.getTitle(),
           () -> importSinglePhoto(photoModel, jobId, idempotentImportExecutor, koofrClient));
     }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosImporter.java
@@ -36,6 +36,7 @@ import okhttp3.ResponseBody;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason;
@@ -123,7 +124,7 @@ public class MicrosoftPhotosImporter
 
     for (PhotoModel photoModel : resource.getPhotos()) {
       idempotentImportExecutor.executeAndSwallowIOExceptions(
-        photoModel.getAlbumId() + "-" + photoModel.getDataId(),
+          IdempotentImportExecutorHelper.getPhotoIdempotentId(photoModel),
         photoModel.getTitle(),
         () -> importSinglePhoto(photoModel, jobId, idempotentImportExecutor));
     }

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/photos/SmugMugPhotosImporter.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.transfer.smugmug.SmugMugTransmogrificationConfig;
@@ -94,7 +95,7 @@ public class SmugMugPhotosImporter
       }
       for (PhotoModel photo : data.getPhotos()) {
         idempotentExecutor.executeAndSwallowIOExceptions(
-            photo.getAlbumId() + "-" + photo.getDataId(),
+            IdempotentImportExecutorHelper.getPhotoIdempotentId(photo),
             photo.getTitle(),
             () -> importSinglePhoto(jobId, idempotentExecutor, photo, smugMugInterface));
       }

--- a/extensions/data-transfer/portability-data-transfer-twitter/src/main/java/org/datatransferproject/transfer/twitter/TwitterPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-twitter/src/main/java/org/datatransferproject/transfer/twitter/TwitterPhotosImporter.java
@@ -19,6 +19,7 @@ package org.datatransferproject.transfer.twitter;
 import com.google.api.client.http.InputStreamContent;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.ImportResult.ResultType;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -62,7 +63,7 @@ final class TwitterPhotosImporter
         update.media(image.getTitle(), content.getInputStream());
 
         idempotentExecutor.executeAndSwallowIOExceptions(
-            image.getDataId(),
+            IdempotentImportExecutorHelper.getPhotoIdempotentId(image),
             image.getTitle(),
             () -> twitterApi.tweets().updateStatus(update));
       } catch (IOException e) {

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutorHelper.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/IdempotentImportExecutorHelper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.spi.transfer.idempotentexecutor;
+
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+
+public class IdempotentImportExecutorHelper {
+  public static String getPhotoIdempotentId(PhotoModel photo) {
+      return photo.getAlbumId() + "-" + photo.getDataId();
+  }
+}


### PR DESCRIPTION
We want to update the item (photo in this case) transfer state that we can report to the users in the IdempotentImportExecutor. It's easier to accomplish in case we have a unique way of calculating idempotentId among photo import services.