### PR TITLE
Add hook for Job Cancellations

### DIFF
--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStore.java
@@ -153,4 +153,12 @@ public interface JobStore extends TemporaryPerJobDataStore {
    * transfer.
    */
   default void storeJobStack(UUID jobId, Stack<ExportInformation> stack) {}
+
+  /**
+   * Called by a transfer worker when abandoning the job matching {@code jobId}, and do cleanup at their end.
+   * Accepts the {@code reason} for abandoning the job (can be derived from but not limited to {@link State})
+   *
+   * @throws IllegalStateException if failed to successfully abandon the job.
+   */
+  default void abandonJob(UUID jobId, String reason) {}
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobCancelWatchingService.java
@@ -58,6 +58,7 @@ class JobCancelWatchingService extends AbstractScheduledService {
             JobMetadata.getImportService(),
             JobMetadata.getStopWatch().elapsed());
         monitor.flushLogs();
+        store.abandonJob(JobMetadata.getJobId(), PortabilityJob.State.CANCELED.toString());
         System.exit(0);
         break;
       case ERROR:
@@ -66,6 +67,7 @@ class JobCancelWatchingService extends AbstractScheduledService {
             EventCode.WATCHING_SERVICE_JOB_ERRORED);
         recordGeneralMetric(PortabilityJob.State.ERROR.toString());
         monitor.flushLogs();
+        store.abandonJob(JobMetadata.getJobId(), PortabilityJob.State.ERROR.toString());
         System.exit(0);
         break;
       case PREEMPTED:
@@ -74,6 +76,7 @@ class JobCancelWatchingService extends AbstractScheduledService {
             EventCode.WATCHING_SERVICE_JOB_PREEMPTED);
         recordGeneralMetric(PortabilityJob.State.PREEMPTED.toString());
         monitor.flushLogs();
+        store.abandonJob(JobMetadata.getJobId(), PortabilityJob.State.PREEMPTED.toString());
         System.exit(0);
         break;
       default:


### PR DESCRIPTION
This change adds capability to add hooks for Job workers to do some clean up at their end when Jobs are intentionally/abruptly cancelled or fail. 
The new addition will allow JobStore implementations to provide their choice of handling for workers when Jobs are abandoned.