### PR TITLE
fix #1052 constructors' ternary has copy-pasta bug

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
@@ -31,7 +31,7 @@ public class MediaContainerResource extends ContainerResource {
       @JsonProperty("videos") Collection<VideoModel> videos) {
     this.albums = albums == null ? ImmutableList.of() : albums;
     this.photos = photos == null ? ImmutableList.of() : photos;
-    this.videos = photos == null ? ImmutableList.of() : videos;
+    this.videos = videos == null ? ImmutableList.of() : videos;
   }
 
   public Collection<MediaAlbum> getAlbums() {


### PR DESCRIPTION
Proof of fix is in my `msoft-add-media-importer` branch tests passing.
There's no unit tests for this class, so I'm punting on that issue for
now.