### PR TITLE
Fix a wrong package name of blob models

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveExporter.java
@@ -17,10 +17,10 @@ import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.StringPaginationToken;
+import org.datatransferproject.types.common.models.blob.BlobbyStorageContainerResource;
+import org.datatransferproject.types.common.models.blob.DigitalDocumentWrapper;
+import org.datatransferproject.types.common.models.blob.DtpDigitalDocument;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.datatransferproject.types.transfer.models.blob.BlobbyStorageContainerResource;
-import org.datatransferproject.types.transfer.models.blob.DigitalDocumentWrapper;
-import org.datatransferproject.types.transfer.models.blob.DtpDigitalDocument;
 
 import java.io.InputStream;
 import java.util.ArrayList;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/drive/DriveImporter.java
@@ -16,10 +16,10 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.types.common.models.blob.BlobbyStorageContainerResource;
+import org.datatransferproject.types.common.models.blob.DigitalDocumentWrapper;
+import org.datatransferproject.types.common.models.blob.DtpDigitalDocument;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.datatransferproject.types.transfer.models.blob.BlobbyStorageContainerResource;
-import org.datatransferproject.types.transfer.models.blob.DigitalDocumentWrapper;
-import org.datatransferproject.types.transfer.models.blob.DtpDigitalDocument;
 
 /** An {@link Importer} to import data to Google Drive. */
 public final class DriveImporter

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/blob/BlobbyStorageContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/blob/BlobbyStorageContainerResource.java
@@ -1,4 +1,4 @@
-package org.datatransferproject.types.transfer.models.blob;
+package org.datatransferproject.types.common.models.blob;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/blob/DigitalDocumentWrapper.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/blob/DigitalDocumentWrapper.java
@@ -1,4 +1,4 @@
-package org.datatransferproject.types.transfer.models.blob;
+package org.datatransferproject.types.common.models.blob;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/blob/DtpDigitalDocument.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/blob/DtpDigitalDocument.java
@@ -1,4 +1,4 @@
-package org.datatransferproject.types.transfer.models.blob;
+package org.datatransferproject.types.common.models.blob;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;


### PR DESCRIPTION
I've seen the compilation problem of blob models so fixed to "types.common":
* Its package is "types.transfer" but located under "types.common" directory.
* 85ca4b2 commit maybe means to move the models from "types.transfer" to "types.common" package.