### PR TITLE
noop(feature) new static APIs on Media classes

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaAlbum.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaAlbum.java
@@ -27,6 +27,22 @@ public class MediaAlbum {
     this.description = description;
   }
 
+  /**
+   * Converts a PhotoAlbum to its counterpart MediaAlbum since these classes are functionally
+   * identical.
+   */
+  public static MediaAlbum photoToMediaAlbum(PhotoAlbum photoAlbum) {
+    return new MediaAlbum(photoAlbum.getId(), photoAlbum.getName(), photoAlbum.getDescription());
+  }
+
+  /**
+   * Extracts photos-specific data from a MediaAlbum and drops anything unsupported by PhotoAlbum
+   * (eg: video content is ignored).
+   */
+  public static PhotoAlbum mediaToPhotoAlbum(MediaAlbum mediaAlbum) {
+    return new PhotoAlbum(mediaAlbum.getId(), mediaAlbum.getName(), mediaAlbum.getDescription());
+  }
+
   public String getName() {
     return name;
   }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
@@ -7,8 +7,10 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.common.models.TransmogrificationConfig;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
@@ -22,7 +24,7 @@ public class MediaContainerResource extends ContainerResource {
   private static final String ROOT_ALBUM = "Transferred Photos";
   private final Collection<PhotoModel> photos;
   private final Collection<VideoModel> videos;
-  private final Collection<MediaAlbum> albums;
+  private Collection<MediaAlbum> albums;
 
   @JsonCreator
   public MediaContainerResource(
@@ -66,7 +68,9 @@ public class MediaContainerResource extends ContainerResource {
   }
 
   public void transmogrify(TransmogrificationConfig config) {
-    ensureRootAlbum(config.getAlbumAllowRootPhotos());
+    if (!config.getAlbumAllowRootPhotos()) {
+      ensureRootAlbum();
+    }
     transmogrifyTitles(config);
 
     // TODO(#1000): This splitting code isn't entirely correct since it assumes all the album items
@@ -103,11 +107,8 @@ public class MediaContainerResource extends ContainerResource {
   }
 
   // Ensures that the model obeys the restrictions of the destination service, grouping all
-  // un-nested photos into their own root album if allowRootPhotos is true, noop otherwise
-  void ensureRootAlbum(boolean allowRootPhotos) {
-    if (allowRootPhotos) {
-      return;
-    }
+  // un-nested photos into their own root album
+  private void ensureRootAlbum() {
     MediaAlbum rootAlbum =
         new MediaAlbum(
             ROOT_ALBUM, ROOT_ALBUM, "A copy of your transferred media that were not in any album");
@@ -128,7 +129,9 @@ public class MediaContainerResource extends ContainerResource {
     }
 
     if (usedRootAlbum) {
-      albums.add(rootAlbum);
+      List<MediaAlbum> tempMutableAlbums = this.albums.stream().collect(Collectors.toList());
+      tempMutableAlbums.add(rootAlbum);
+      this.albums = ImmutableList.copyOf(tempMutableAlbums);
     }
   }
 

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.common.models.TransmogrificationConfig;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 
 @JsonTypeName("MediaContainerResource")
@@ -34,6 +35,31 @@ public class MediaContainerResource extends ContainerResource {
     this.albums = albums == null ? ImmutableList.of() : albums;
     this.photos = photos == null ? ImmutableList.of() : photos;
     this.videos = videos == null ? ImmutableList.of() : videos;
+  }
+
+  /**
+   * Builds a MediaContainerResource without video by mapping a PhotosContainerResource's fields
+   * 1:1 to MediaContainerResource.
+   */
+  public static MediaContainerResource photoToMedia(PhotosContainerResource photosContainer) {
+    return new MediaContainerResource(photosContainer.getAlbums()
+                                          .stream()
+                                          .map(a -> MediaAlbum.photoToMediaAlbum(a))
+                                          .collect(Collectors.toList()),
+        photosContainer.getPhotos(), null /*videos*/
+    );
+  }
+
+  /**
+   * Extracts a new PhotosContainerResource from the relevant matching fields in a given
+   * MediaContainerResource.
+   */
+  public static PhotosContainerResource mediaToPhoto(MediaContainerResource mediaContainer) {
+    return new PhotosContainerResource(mediaContainer.getAlbums()
+                                           .stream()
+                                           .map(a -> MediaAlbum.mediaToPhotoAlbum(a))
+                                           .collect(Collectors.toList()),
+        mediaContainer.getPhotos());
   }
 
   public Collection<MediaAlbum> getAlbums() {

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
@@ -42,12 +42,14 @@ public class MediaContainerResource extends ContainerResource {
    * 1:1 to MediaContainerResource.
    */
   public static MediaContainerResource photoToMedia(PhotosContainerResource photosContainer) {
-    return new MediaContainerResource(photosContainer.getAlbums()
-                                          .stream()
-                                          .map(a -> MediaAlbum.photoToMediaAlbum(a))
-                                          .collect(Collectors.toList()),
-        photosContainer.getPhotos(), null /*videos*/
-    );
+    return new MediaContainerResource(
+        photosContainer
+            .getAlbums()
+            .stream()
+            .map(a -> MediaAlbum.photoToMediaAlbum(a))
+            .collect(Collectors.toList()),
+        photosContainer.getPhotos(),
+        null /*videos*/);
   }
 
   /**
@@ -55,10 +57,12 @@ public class MediaContainerResource extends ContainerResource {
    * MediaContainerResource.
    */
   public static PhotosContainerResource mediaToPhoto(MediaContainerResource mediaContainer) {
-    return new PhotosContainerResource(mediaContainer.getAlbums()
-                                           .stream()
-                                           .map(a -> MediaAlbum.mediaToPhotoAlbum(a))
-                                           .collect(Collectors.toList()),
+    return new PhotosContainerResource(
+        mediaContainer
+            .getAlbums()
+            .stream()
+            .map(a -> MediaAlbum.mediaToPhotoAlbum(a))
+            .collect(Collectors.toList()),
         mediaContainer.getPhotos());
   }
 

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
@@ -1,0 +1,349 @@
+package org.datatransferproject.types.common.models.media;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.truth.Truth;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.datatransferproject.types.common.models.TransmogrificationConfig;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+import java.util.List;
+
+// TODO(zacsh,sihamh) this code was ported over without unit tests; below is a mostly 1:1-port
+// backfill but the new video handling logic in MediaContainerResource should have test coverage
+// too.
+public class MediaContainerResourceTest {
+  @Test
+  public void verifySerializeDeserialize() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerSubtypes(MediaContainerResource.class);
+
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This is a fake albumb"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
+
+    ContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+
+    String serialized = objectMapper.writeValueAsString(data);
+
+    ContainerResource deserializedModel =
+        objectMapper.readValue(serialized, ContainerResource.class);
+
+    Truth.assertThat(deserializedModel).isNotNull();
+    Truth.assertThat(deserializedModel).isInstanceOf(MediaContainerResource.class);
+    MediaContainerResource deserialized = (MediaContainerResource) deserializedModel;
+    Truth.assertThat(deserialized.getAlbums()).hasSize(1);
+    Truth.assertThat(deserialized.getPhotos()).hasSize(2);
+    Truth.assertThat(deserialized).isEqualTo(data);
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_nullName() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig() {
+        public int getAlbumMaxSize() { return 2;}
+    };
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", null, "This is a fake album"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).isEqualTo(null);
+  }
+
+
+  @Test
+  public void verifyTransmogrifyAlbums_NoLimit() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig();
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This is a fake album"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(data.getAlbums()).hasSize(1);
+    Truth.assertThat(data.getPhotos()).hasSize(3);
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_NoRootPhotos() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig() {
+        public boolean getAlbumAllowRootPhotos() { return false;}
+    };
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This is a fake album"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(data.getAlbums()).hasSize(2);
+    Truth.assertThat(data.getPhotos()).hasSize(3);
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_NameForbiddenCharacters() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig() {
+        public String getAlbumNameForbiddenCharacters() {
+            return ":!";
+        }
+        public char getAlbumNameReplacementCharacter() {
+            return '?';
+        }
+    };
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "This:a fake album!", "This:a fake album!"));
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel("Pic2", "https://fake.com/pic2.png", "fine art", "image/png", "p2", null, false),
+            new PhotoModel(
+                "Pic5", "https://fake.com/pic5.png", "fine art", "image/png", "p5", null, false),
+            new PhotoModel(
+                "Pic6", "https://fake.com/pic6.png", "fine art", "image/png", "p6", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).isEqualTo("This?a fake album?");
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_NameNoForbiddenCharacters() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig();
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "This:a fake album!", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).isEqualTo("This:a fake album!");
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_stripName() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig();
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "This:a fake album!   ", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).isEqualTo("This:a fake album!");
+  }
+
+
+  @Test
+  public void verifyTransmogrifyAlbums_NameTooLong() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig() {
+        public int getAlbumNameMaxLength() {
+            return 5;
+        }
+    };
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "This:a fake album!", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).hasLength(5);
+  }
+
+  @Test
+  public void verifyTransmogrifyAlbums_NameNoLengthLimit() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig();
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).hasLength(7);
+  }
+
+  @Test
+  public void verifyTransmogrifyPhotos_TitleForbiddenCharacters() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig() {
+        public String getPhotoTitleForbiddenCharacters() {
+            return ":!";
+        }
+
+        public char getPhotoTitleReplacementCharacter() {
+            return '?';
+        }
+    };
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1!", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic:3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).isEqualTo("Pic1?");
+    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).isEqualTo("Pic?3");
+    Truth.assertThat(Iterables.get(data.getPhotos(),2).getTitle()).isEqualTo("Pic2");
+
+  }
+
+  @Test
+  public void verifyTransmogrifyPhotos_TitleNoForbiddenCharacters() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig();
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic?1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic:3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).isEqualTo("Pic?1");
+    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).isEqualTo("Pic:3");
+    Truth.assertThat(Iterables.get(data.getPhotos(),2).getTitle()).isEqualTo("Pic2");
+}
+
+
+  @Test
+  public void verifyTransmogrifyPhotos_TitleTooLong() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig() {
+        public int getPhotoTitleMaxLength() {
+            return 3;
+        }
+    };
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "P2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).hasLength(3);
+    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).hasLength(3);
+    Truth.assertThat(Iterables.get(data.getPhotos(),2).getTitle()).isEqualTo("P2");
+  }
+
+  @Test
+  public void verifyTransmogrifyPhotos_TitleNoLengthLimit() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig();
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false),
+            new PhotoModel(
+                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).hasLength(4);
+    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).hasLength(4);
+    Truth.assertThat(Iterables.get(data.getPhotos(),2).getTitle()).hasLength(4);
+
+  }
+
+  @Test
+  public void verifyTransmogrifyPhotos_stripTitle() throws Exception {
+    TransmogrificationConfig config = new TransmogrificationConfig();
+    List<MediaAlbum> albums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
+
+    List<PhotoModel> photos =
+        ImmutableList.of(
+            new PhotoModel("Pic1 ", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
+                false),
+            new PhotoModel("Pic3 ", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
+                false));
+
+    MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
+    data.transmogrify(config);
+    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).isEqualTo("Pic1");
+    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).isEqualTo("Pic3");
+
+  }
+}

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
@@ -4,14 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.truth.Truth;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.common.models.TransmogrificationConfig;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import java.util.stream.Collectors;
-import java.util.List;
 
 // TODO(#1060) this code was ported over without unit tests; below is a mostly 1:1-port
 // backfill but the new video handling logic in MediaContainerResource should have test coverage
@@ -25,12 +24,10 @@ public class MediaContainerResourceTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This is a fake albumb"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
 
     ContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
 
@@ -50,21 +47,19 @@ public class MediaContainerResourceTest {
   @Test
   public void verifyTransmogrifyAlbums_nullName() throws Exception {
     TransmogrificationConfig config = new TransmogrificationConfig() {
-        public int getAlbumMaxSize() { return 2;}
+      public int getAlbumMaxSize() {
+        return 2;
+      }
     };
-    List<MediaAlbum> albums =
-        ImmutableList.of(new MediaAlbum("id1", null, "This is a fake album"));
+    List<MediaAlbum> albums = ImmutableList.of(new MediaAlbum("id1", null, "This is a fake album"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).isEqualTo(null);
+    Truth.assertThat(Iterables.get(data.getAlbums(), 0).getName()).isEqualTo(null);
   }
-
 
   @Test
   public void verifyTransmogrifyAlbums_NoLimit() throws Exception {
@@ -72,14 +67,11 @@ public class MediaContainerResourceTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This is a fake album"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", "id1", false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
@@ -90,19 +82,18 @@ public class MediaContainerResourceTest {
   @Test
   public void verifyTransmogrifyAlbums_NoRootPhotos() throws Exception {
     TransmogrificationConfig config = new TransmogrificationConfig() {
-        public boolean getAlbumAllowRootPhotos() { return false;}
+      public boolean getAlbumAllowRootPhotos() {
+        return false;
+      }
     };
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This is a fake album"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
@@ -113,30 +104,28 @@ public class MediaContainerResourceTest {
   @Test
   public void verifyTransmogrifyAlbums_NameForbiddenCharacters() throws Exception {
     TransmogrificationConfig config = new TransmogrificationConfig() {
-        public String getAlbumNameForbiddenCharacters() {
-            return ":!";
-        }
-        public char getAlbumNameReplacementCharacter() {
-            return '?';
-        }
+      public String getAlbumNameForbiddenCharacters() {
+        return ":!";
+      }
+      public char getAlbumNameReplacementCharacter() {
+        return '?';
+      }
     };
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "This:a fake album!", "This:a fake album!"));
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel("Pic2", "https://fake.com/pic2.png", "fine art", "image/png", "p2", null, false),
-            new PhotoModel(
-                "Pic5", "https://fake.com/pic5.png", "fine art", "image/png", "p5", null, false),
-            new PhotoModel(
-                "Pic6", "https://fake.com/pic6.png", "fine art", "image/png", "p6", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic2.png", "fine art", "image/png", "p2", null, false),
+        new PhotoModel(
+            "Pic5", "https://fake.com/pic5.png", "fine art", "image/png", "p5", null, false),
+        new PhotoModel(
+            "Pic6", "https://fake.com/pic6.png", "fine art", "image/png", "p6", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).isEqualTo("This?a fake album?");
+    Truth.assertThat(Iterables.get(data.getAlbums(), 0).getName()).isEqualTo("This?a fake album?");
   }
 
   @Test
@@ -145,18 +134,15 @@ public class MediaContainerResourceTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "This:a fake album!", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).isEqualTo("This:a fake album!");
+    Truth.assertThat(Iterables.get(data.getAlbums(), 0).getName()).isEqualTo("This:a fake album!");
   }
 
   @Test
@@ -165,43 +151,36 @@ public class MediaContainerResourceTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "This:a fake album!   ", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).isEqualTo("This:a fake album!");
+    Truth.assertThat(Iterables.get(data.getAlbums(), 0).getName()).isEqualTo("This:a fake album!");
   }
-
 
   @Test
   public void verifyTransmogrifyAlbums_NameTooLong() throws Exception {
     TransmogrificationConfig config = new TransmogrificationConfig() {
-        public int getAlbumNameMaxLength() {
-            return 5;
-        }
+      public int getAlbumNameMaxLength() {
+        return 5;
+      }
     };
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "This:a fake album!", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).hasLength(5);
+    Truth.assertThat(Iterables.get(data.getAlbums(), 0).getName()).hasLength(5);
   }
 
   @Test
@@ -210,49 +189,42 @@ public class MediaContainerResourceTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getAlbums(),0).getName()).hasLength(7);
+    Truth.assertThat(Iterables.get(data.getAlbums(), 0).getName()).hasLength(7);
   }
 
   @Test
   public void verifyTransmogrifyPhotos_TitleForbiddenCharacters() throws Exception {
     TransmogrificationConfig config = new TransmogrificationConfig() {
-        public String getPhotoTitleForbiddenCharacters() {
-            return ":!";
-        }
+      public String getPhotoTitleForbiddenCharacters() {
+        return ":!";
+      }
 
-        public char getPhotoTitleReplacementCharacter() {
-            return '?';
-        }
+      public char getPhotoTitleReplacementCharacter() {
+        return '?';
+      }
     };
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1!", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic:3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1!", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic:3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).isEqualTo("Pic1?");
-    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).isEqualTo("Pic?3");
-    Truth.assertThat(Iterables.get(data.getPhotos(),2).getTitle()).isEqualTo("Pic2");
-
+    Truth.assertThat(Iterables.get(data.getPhotos(), 0).getTitle()).isEqualTo("Pic1?");
+    Truth.assertThat(Iterables.get(data.getPhotos(), 1).getTitle()).isEqualTo("Pic?3");
+    Truth.assertThat(Iterables.get(data.getPhotos(), 2).getTitle()).isEqualTo("Pic2");
   }
 
   @Test
@@ -261,47 +233,40 @@ public class MediaContainerResourceTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic?1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic:3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic?1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic:3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).isEqualTo("Pic?1");
-    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).isEqualTo("Pic:3");
-    Truth.assertThat(Iterables.get(data.getPhotos(),2).getTitle()).isEqualTo("Pic2");
-}
-
+    Truth.assertThat(Iterables.get(data.getPhotos(), 0).getTitle()).isEqualTo("Pic?1");
+    Truth.assertThat(Iterables.get(data.getPhotos(), 1).getTitle()).isEqualTo("Pic:3");
+    Truth.assertThat(Iterables.get(data.getPhotos(), 2).getTitle()).isEqualTo("Pic2");
+  }
 
   @Test
   public void verifyTransmogrifyPhotos_TitleTooLong() throws Exception {
     TransmogrificationConfig config = new TransmogrificationConfig() {
-        public int getPhotoTitleMaxLength() {
-            return 3;
-        }
+      public int getPhotoTitleMaxLength() {
+        return 3;
+      }
     };
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "P2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "P2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).hasLength(3);
-    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).hasLength(3);
-    Truth.assertThat(Iterables.get(data.getPhotos(),2).getTitle()).isEqualTo("P2");
+    Truth.assertThat(Iterables.get(data.getPhotos(), 0).getTitle()).hasLength(3);
+    Truth.assertThat(Iterables.get(data.getPhotos(), 1).getTitle()).hasLength(3);
+    Truth.assertThat(Iterables.get(data.getPhotos(), 2).getTitle()).isEqualTo("P2");
   }
 
   @Test
@@ -310,21 +275,17 @@ public class MediaContainerResourceTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false),
-            new PhotoModel(
-                "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false),
+        new PhotoModel(
+            "Pic2", "https://fake.com/pic.png", "fine art", "image/png", "p2", null, false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).hasLength(4);
-    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).hasLength(4);
-    Truth.assertThat(Iterables.get(data.getPhotos(),2).getTitle()).hasLength(4);
-
+    Truth.assertThat(Iterables.get(data.getPhotos(), 0).getTitle()).hasLength(4);
+    Truth.assertThat(Iterables.get(data.getPhotos(), 1).getTitle()).hasLength(4);
+    Truth.assertThat(Iterables.get(data.getPhotos(), 2).getTitle()).hasLength(4);
   }
 
   @Test
@@ -333,17 +294,14 @@ public class MediaContainerResourceTest {
     List<MediaAlbum> albums =
         ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
 
-    List<PhotoModel> photos =
-        ImmutableList.of(
-            new PhotoModel("Pic1 ", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1",
-                false),
-            new PhotoModel("Pic3 ", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1",
-                false));
+    List<PhotoModel> photos = ImmutableList.of(
+        new PhotoModel("Pic1 ", "http://fake.com/1.jpg", "A pic", "image/jpg", "p1", "id1", false),
+        new PhotoModel("Pic3 ", "http://fake.com/2.jpg", "A pic", "image/jpg", "p3", "id1", false));
 
     MediaContainerResource data = new MediaContainerResource(albums, photos, null /*video*/);
     data.transmogrify(config);
-    Truth.assertThat(Iterables.get(data.getPhotos(),0).getTitle()).isEqualTo("Pic1");
-    Truth.assertThat(Iterables.get(data.getPhotos(),1).getTitle()).isEqualTo("Pic3");
+    Truth.assertThat(Iterables.get(data.getPhotos(), 0).getTitle()).isEqualTo("Pic1");
+    Truth.assertThat(Iterables.get(data.getPhotos(), 1).getTitle()).isEqualTo("Pic3");
 
   }
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import java.util.stream.Collectors;
 import java.util.List;
 
-// TODO(zacsh,sihamh) this code was ported over without unit tests; below is a mostly 1:1-port
+// TODO(#1060) this code was ported over without unit tests; below is a mostly 1:1-port
 // backfill but the new video handling logic in MediaContainerResource should have test coverage
 // too.
 public class MediaContainerResourceTest {


### PR DESCRIPTION
[this is the sort of not-blatantly-forking][techdebt-dedupe-media-vertical] strategy that _this_ PR is meant to enable with little-to-no throwaway code.

[techdebt-dedupe-media-vertical]: https://github.com/jzacsh/data-transfer-project/compare/msoft-add-media-importer...jzacsh:techdebt-dedupe-media-vertical

---

~Note: I don't _think_ we've setup [any PR-Dependency tooling](https://github.com/github/feedback/discussions/4477#discussioncomment-1039627) for this github project, right? (so beware: don't merge this until 1059 is merged)~


~Depends on #1059~ resolved.