### PR TITLE
Add unit tests for Daybook importers

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-daybook/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-daybook/build.gradle
@@ -23,10 +23,12 @@ dependencies {
     compile project(':portability-spi-cloud')
     compile project(':portability-spi-transfer')
     compile project(':portability-transfer')
-    
+
     compile("com.google.api-client:google-api-client:${googleApiClient}")
     compile "com.squareup.okhttp3:okhttp:${okHttpVersion}"
     compile("com.google.guava:guava:${guavaVersion}")
-    }
+
+    testCompile("org.mockito:mockito-core:${mockitoVersion}")
+}
 
 configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/main/java/org/datatransferproject/transfer/daybook/DaybookTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/main/java/org/datatransferproject/transfer/daybook/DaybookTransferExtension.java
@@ -28,6 +28,7 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.JobMetadata;
 import org.datatransferproject.transfer.daybook.photos.DaybookPhotosImporter;
 import org.datatransferproject.transfer.daybook.social.DaybookPostsImporter;
 
@@ -40,7 +41,7 @@ public class DaybookTransferExtension implements TransferExtension {
       ImmutableList.of("PHOTOS", "SOCIAL-POSTS");
 
   private boolean initialized = false;
-  private ImmutableMap<String, Importer> importerMap;
+  private ImmutableMap<String, Importer<?, ?>> importerMap;
 
   @Override
   public void initialize(ExtensionContext context) {
@@ -55,11 +56,12 @@ public class DaybookTransferExtension implements TransferExtension {
     OkHttpClient client = context.getService(OkHttpClient.class);
     TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
 
-    ImmutableMap.Builder<String, Importer> importerBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<String, Importer<?, ?>> importerBuilder = ImmutableMap.builder();
+    String exportService = JobMetadata.getExportService();
     importerBuilder.put(
-        "PHOTOS", new DaybookPhotosImporter(monitor, client, mapper, jobStore, BASE_URL));
+        "PHOTOS", new DaybookPhotosImporter(monitor, client, jobStore, BASE_URL, exportService));
     importerBuilder.put(
-        "SOCIAL-POSTS", new DaybookPostsImporter(monitor, client, mapper, BASE_URL));
+        "SOCIAL-POSTS", new DaybookPostsImporter(monitor, client, mapper, BASE_URL, exportService));
     importerMap = importerBuilder.build();
     initialized = true;
   }

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/main/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/main/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporter.java
@@ -16,23 +16,26 @@
 
 package org.datatransferproject.transfer.daybook.photos;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Base64;
 import java.util.UUID;
-import okhttp3.*;
+
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
-import org.datatransferproject.transfer.JobMetadata;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
@@ -43,22 +46,22 @@ public class DaybookPhotosImporter
     implements Importer<TokensAndUrlAuthData, PhotosContainerResource> {
 
   private final OkHttpClient client;
-  private final ObjectMapper objectMapper;
   private final TemporaryPerJobDataStore jobStore;
   private final Monitor monitor;
   private final String baseUrl;
+  private final String exportService;
 
   public DaybookPhotosImporter(
       Monitor monitor,
       OkHttpClient client,
-      ObjectMapper objectMapper,
       TemporaryPerJobDataStore jobStore,
-      String baseUrl) {
+      String baseUrl,
+      String exportService) {
     this.client = client;
-    this.objectMapper = objectMapper;
     this.jobStore = jobStore;
     this.monitor = monitor;
     this.baseUrl = baseUrl;
+    this.exportService = exportService;
   }
 
   @Override
@@ -78,7 +81,7 @@ public class DaybookPhotosImporter
     // Import albums
     for (PhotoAlbum album : resource.getAlbums()) {
       executor.executeAndSwallowIOExceptions(
-          album.getId(), album.getName(), () -> importAlbum(album, authData));
+          album.getId(), album.getName(), () -> importAlbum(album));
     }
 
     // Import photos
@@ -97,10 +100,12 @@ public class DaybookPhotosImporter
           });
     }
 
+    // API to trigger daybook API
+
     return new ImportResult(ImportResult.ResultType.OK);
   }
 
-  private String importAlbum(PhotoAlbum album, TokensAndUrlAuthData authData) throws IOException {
+  private String importAlbum(PhotoAlbum album) {
     String description = album.getDescription();
     String album_name = album.getName();
     monitor.debug(() -> String.format("Album Name: %s", album_name));
@@ -114,8 +119,7 @@ public class DaybookPhotosImporter
   private int importPhoto(
       PhotoModel photoModel, UUID jobId, TokensAndUrlAuthData authData, String newAlbumId)
       throws IOException {
-    InputStream inputStream = null;
-    String albumId = photoModel.getAlbumId();
+    InputStream inputStream;
     String imageDescription = photoModel.getDescription();
     String title = photoModel.getTitle();
 
@@ -134,8 +138,8 @@ public class DaybookPhotosImporter
     Request.Builder requestBuilder = new Request.Builder().url(baseUrl);
     requestBuilder.header("token", authData.getAccessToken());
 
-    FormBody.Builder builder = new FormBody.Builder().add("image", imageData);
-    builder.add("exporter", JobMetadata.getExportService());
+    FormBody.Builder builder =
+        new FormBody.Builder().add("image", imageData).add("exporter", exportService);
 
     if (!Strings.isNullOrEmpty(newAlbumId)) {
       builder.add("album", newAlbumId);

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporterTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 The Data-Portability Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.daybook.photos;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.UUID;
+import okhttp3.*;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempotentImportExecutor;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+
+public class DaybookPhotosImporterTest {
+
+    private Monitor monitor;
+    private TemporaryPerJobDataStore jobStore;
+    private IdempotentImportExecutor executor;
+    private TokensAndUrlAuthData authData;
+    private PhotosContainerResource data;
+    private OkHttpClient client;
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        monitor = mock(Monitor.class);
+        jobStore = mock(TemporaryPerJobDataStore.class);
+        executor = new InMemoryIdempotentImportExecutor(monitor);
+        authData = new TokensAndUrlAuthData("access-token", "refresh-token", "http://example.com");
+        client = mock(OkHttpClient.class);
+    }
+
+    @Test
+    public void testImportSinglePhoto() throws Exception {
+        byte[] expectedImageData = {0xF, 0xA, 0xC, 0xE, 0xB, 0x0, 0x0, 0xC};
+        InputStream inputStream = new ByteArrayInputStream(expectedImageData);
+        TemporaryPerJobDataStore.InputStreamWrapper inputStreamWrapper =
+                new TemporaryPerJobDataStore.InputStreamWrapper(inputStream);
+        File file = folder.newFile();
+        when(jobStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(file);
+        when(jobStore.getStream(any(), any())).thenReturn(inputStreamWrapper);
+
+        PhotoModel photoModel =
+                new PhotoModel("TestingPhotoTitle", "", "description", "", "TestingPhoto", "", true);
+        PhotosContainerResource resource =
+                new PhotosContainerResource(Collections.emptyList(), Collections.singletonList(photoModel));
+
+        Call call = mock(Call.class);
+        Response dummySuccessfulResponse =
+                new Response.Builder()
+                        .code(200)
+                        .request(new Request.Builder().url("http://example.com").build())
+                        .protocol(Protocol.HTTP_1_1)
+                        .message("all good!")
+                        .body(ResponseBody.create(MediaType.parse("text/xml"), "<a>ok!</a>"))
+                        .build();
+        when(call.execute()).thenReturn(dummySuccessfulResponse);
+        when(client.newCall(any())).thenReturn(call);
+
+        DaybookPhotosImporter daybookPhotosImporter =
+                new DaybookPhotosImporter(monitor, client, jobStore, "http://daybook.com", "exporter");
+        daybookPhotosImporter.importItem(UUID.randomUUID(), executor, authData, resource);
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(client, times(1)).newCall(requestCaptor.capture());
+
+        RequestBody untypedBody = requestCaptor.getValue().body();
+        assertTrue(untypedBody instanceof FormBody);
+        FormBody actual = (FormBody) untypedBody;
+        assertEquals("image", actual.name(0));
+
+        String base64Image = actual.value(0);
+        byte[] actualImageData = Base64.getDecoder().decode(base64Image);
+        assertArrayEquals(expectedImageData, actualImageData);
+    }
+}

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/social/DaybookPostsImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/social/DaybookPostsImporterTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 The Data-Portability Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.daybook.social;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.UUID;
+import okhttp3.*;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempotentImportExecutor;
+import org.datatransferproject.types.common.models.social.*;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+
+public class DaybookPostsImporterTest {
+
+    private Monitor monitor;
+    private IdempotentImportExecutor executor;
+    private TokensAndUrlAuthData authData;
+    private OkHttpClient client;
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        monitor = mock(Monitor.class);
+        executor = new InMemoryIdempotentImportExecutor(monitor);
+        authData = new TokensAndUrlAuthData("access-token", "refresh-token", "http://example.com");
+        client = mock(OkHttpClient.class);
+    }
+
+    @Test
+    public void testImportSingleActivity() throws Exception {
+        String postContent = "activityContent";
+        SocialActivityModel activity =
+                new SocialActivityModel(
+                        "activityId",
+                        Instant.now(),
+                        SocialActivityType.POST,
+                        Collections.emptyList(),
+                        new SocialActivityLocation("test", 1.1, 2.2),
+                        "activityTitle",
+                        postContent,
+                        "activityUrl");
+        SocialActivityContainerResource resource =
+                new SocialActivityContainerResource(
+                        "123",
+                        new SocialActivityActor("321", "John Doe", "url"),
+                        Collections.singletonList(activity));
+
+        Call call = mock(Call.class);
+        Response dummySuccessfulResponse =
+                new Response.Builder()
+                        .code(200)
+                        .request(new Request.Builder().url("http://example.com").build())
+                        .protocol(Protocol.HTTP_1_1)
+                        .message("all good!")
+                        .body(ResponseBody.create(MediaType.parse("text/xml"), "<a>ok!</a>"))
+                        .build();
+        when(call.execute()).thenReturn(dummySuccessfulResponse);
+        when(client.newCall(any())).thenReturn(call);
+
+        DaybookPostsImporter importer =
+                new DaybookPostsImporter(
+                        monitor, client, new ObjectMapper(), "http://example.com", "export-service");
+        importer.importItem(UUID.randomUUID(), executor, authData, resource);
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(client, times(1)).newCall(requestCaptor.capture());
+
+        RequestBody untypedBody = requestCaptor.getValue().body();
+        assertTrue(untypedBody instanceof FormBody);
+        FormBody actual = (FormBody) untypedBody;
+        assertEquals(
+                "DaybookPostsImporter changed the order of fields in the body.", "content", actual.name(2));
+        assertEquals(postContent, actual.value(2));
+    }
+}


### PR DESCRIPTION
Summary:
1. Added 2 basic non-exhaustive test suites for both Daybook importers.
2. Moved direct calls to `JobMetadata` upstream to make the importers testable.
3. Removed unused paratermers here and there.
4. Some other minor refactorings such as better generics.

Test Plan: `./gradlew ':extensions:data-transfer:portability-data-transfer-daybook:test'`