### PR TITLE
Remove usage of old Pair in GooglePhotosImporter

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-google/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     compile("com.googlecode.ez-vcard:ez-vcard:${ezVcardVersion}")
     compile("com.google.apis:google-api-services-plus:${googlePlusVersion}")
     compile("com.google.photos.library:google-photos-library-client:1.5.0")
-    compile("com.google.auto.value:auto-value:${autoValueVersion}")
 
     testCompile("org.mockito:mockito-core:${mockitoVersion}")
     testCompile project(':extensions:cloud:portability-cloud-local')

--- a/extensions/data-transfer/portability-data-transfer-google/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-google/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     compile("com.googlecode.ez-vcard:ez-vcard:${ezVcardVersion}")
     compile("com.google.apis:google-api-services-plus:${googlePlusVersion}")
     compile("com.google.photos.library:google-photos-library-client:1.5.0")
+    compile("com.google.auto.value:auto-value:${autoValueVersion}")
 
     testCompile("org.mockito:mockito-core:${mockitoVersion}")
     testCompile project(':extensions:cloud:portability-cloud-local')

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -19,6 +19,7 @@ import static java.lang.String.format;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.json.JsonFactory;
+import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -334,7 +334,7 @@ public class GooglePhotosImporter
   }
 
   @AutoValue
-  public abstract class InputStreamWithBytes {
+  public abstract static class InputStreamWithBytes {
     public abstract InputStream getInputStream();
     public abstract long getBytes();
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -24,7 +24,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.UnmodifiableIterator;
-import com.google.gdata.util.common.base.Pair;
 import com.google.rpc.Code;
 import java.io.IOException;
 import java.io.InputStream;
@@ -215,15 +214,23 @@ public class GooglePhotosImporter
     //  this however, seems to require knowledge of the total file size.
     for (PhotoModel photo : photos) {
       try {
-        Pair<InputStream, Long> inputStreamBytesPair =
-            getInputStreamForUrl(jobId, photo.getFetchableUrl(), photo.isInTempStore());
+        InputStream stream;
+        Long bytes;
 
-        try (InputStream s = inputStreamBytesPair.getFirst()) {
-          String uploadToken = getOrCreatePhotosInterface(jobId, authData).uploadPhotoContent(s);
-          mediaItems.add(new NewMediaItem(cleanDescription(photo.getDescription()), uploadToken));
-          uploadTokenToDataId.put(uploadToken, photo);
-          uploadTokenToLength.put(uploadToken, inputStreamBytesPair.getSecond());
+        if (photo.isInTempStore()) {
+          final InputStreamWrapper streamWrapper = jobStore.getStream(jobId, fetchableUrl);
+          stream = streamWrapper.getStream();
+          bytes = streamWrapper.getBytes();
+        } else {
+          HttpURLConnection conn = imageStreamProvider.getConnection(fetchableUrl);
+          stream = conn.getInputStream();
+          bytes = conn.getContentLengthLong() != -1 ? conn.getContentLengthLong() : 0;
         }
+
+        String uploadToken = getOrCreatePhotosInterface(jobId, authData).uploadPhotoContent(stream);
+        mediaItems.add(new NewMediaItem(cleanDescription(photo.getDescription()), uploadToken));
+        uploadTokenToDataId.put(uploadToken, photo);
+        uploadTokenToLength.put(uploadToken, bytes);
 
         try {
           if (photo.isInTempStore()) {
@@ -319,18 +326,6 @@ public class GooglePhotosImporter
           });
       return 0;
     }
-  }
-
-  private Pair<InputStream, Long> getInputStreamForUrl(
-      UUID jobId, String fetchableUrl, boolean inTempStore) throws IOException {
-    if (inTempStore) {
-      final InputStreamWrapper streamWrapper = jobStore.getStream(jobId, fetchableUrl);
-      return Pair.of(streamWrapper.getStream(), streamWrapper.getBytes());
-    }
-
-    HttpURLConnection conn = imageStreamProvider.getConnection(fetchableUrl);
-    return Pair.of(
-        conn.getInputStream(), conn.getContentLengthLong() != -1 ? conn.getContentLengthLong() : 0);
   }
 
   private String cleanDescription(String origDescription) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -20,7 +20,6 @@ import static java.lang.String.format;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.json.JsonFactory;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Pair;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterators;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -321,7 +321,7 @@ public class GooglePhotosImporter
     }
   }
 
-  private InputStreamWithBytes<InputStream, Long> getInputStreamForUrl(
+  private InputStreamWithBytes getInputStreamForUrl(
       UUID jobId, String fetchableUrl, boolean inTempStore) throws IOException {
     if (inTempStore) {
       final InputStreamWrapper streamWrapper = jobStore.getStream(jobId, fetchableUrl);


### PR DESCRIPTION
Pair is not supported by Guava and we were using an older gdata pair, switch to using supported apache pair instead