### PR TITLE
Use Maven Central Repository instead of deprecated JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ import org.eclipse.jgit.lib.RepositoryBuilder
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r'
@@ -67,7 +67,7 @@ def sourceProjects() {
 
 configure(sourceProjects()) {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     apply plugin: 'java'

--- a/distributions/api-default/build.gradle
+++ b/distributions/api-default/build.gradle
@@ -22,7 +22,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/distributions/demo-google-deployment/api/build.gradle
+++ b/distributions/demo-google-deployment/api/build.gradle
@@ -48,7 +48,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/distributions/demo-google-deployment/transfer/build.gradle
+++ b/distributions/demo-google-deployment/transfer/build.gradle
@@ -50,7 +50,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -46,7 +46,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 def transportType = project.hasProperty('transportType') ? transportType : "jettyrest"

--- a/distributions/transfer-default/build.gradle
+++ b/distributions/transfer-default/build.gradle
@@ -22,7 +22,7 @@ plugins {
 
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
[JCenter has been deprecated](https://blog.gradle.org/jcenter-shutdown) for some time.

>Based on the current timeline, builds that use JCenter will be able to resolve dependencies until February 1, 2022 without changes. After that date, there are no guarantees that you will be able to build your software if you continue to use JCenter.