### PR TITLE
Implement getCounts in CalendarContainerResource

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResource.java
@@ -20,12 +20,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
+
+import com.google.common.collect.ImmutableMap;
 import org.datatransferproject.types.common.models.ContainerResource;
 
 /** A Wrapper for all the possible objects that can be returned by a calendar exporter. */
 @JsonTypeName("CalendarContainerResource")
 public class CalendarContainerResource extends ContainerResource {
+  public static final String CALENDARS_COUNT_DATA_NAME = "calendarsCount";
+  public static final String EVENTS_COUNT_DATA_NAME = "eventsCount";
+
   private final Collection<CalendarModel> calendars;
   private final Collection<CalendarEventModel> events;
 
@@ -52,6 +58,14 @@ public class CalendarContainerResource extends ContainerResource {
     CalendarContainerResource that = (CalendarContainerResource) o;
     return Objects.equals(getCalendars(), that.getCalendars()) &&
             Objects.equals(getEvents(), that.getEvents());
+  }
+
+  @Override
+  public Map<String, Integer> getCounts() {
+    return new ImmutableMap.Builder<String, Integer>()
+            .put(CALENDARS_COUNT_DATA_NAME, calendars.size())
+            .put(EVENTS_COUNT_DATA_NAME, events.size())
+            .build();
   }
 
   @Override

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResourceTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 
 public class CalendarContainerResourceTest {
   @Test
@@ -50,6 +51,9 @@ public class CalendarContainerResourceTest {
     CalendarContainerResource deserialized = (CalendarContainerResource) deserializedModel;
     Truth.assertThat(deserialized.getCalendars()).hasSize(1);
     Truth.assertThat(deserialized.getEvents()).hasSize(2);
+    Map<String, Integer> counts = deserializedModel.getCounts();
+    Truth.assertThat(counts.get(CalendarContainerResource.CALENDARS_COUNT_DATA_NAME)).isEqualTo(calendars.size());
+    Truth.assertThat(counts.get(CalendarContainerResource.EVENTS_COUNT_DATA_NAME)).isEqualTo(events.size());
     Truth.assertThat(deserialized).isEqualTo(data);
   }
 }


### PR DESCRIPTION
A proper implementation of getCounts() has been added to CalendarContainerResource. 
verifySerializeDeserialize test has been amended to cover this method.