### PR TITLE
Add support for Retry Strategy Identifier

### DIFF
--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/ExponentialBackoffStrategy.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/ExponentialBackoffStrategy.java
@@ -30,16 +30,19 @@ public class ExponentialBackoffStrategy implements RetryStrategy {
   private long initialIntervalMillis;
   @JsonProperty("multiplier")
   private double multiplier;
-
+  @JsonProperty("identifier")
+  private String identifier;
   public ExponentialBackoffStrategy(@JsonProperty("maxAttempts") int maxAttempts,
-      @JsonProperty("initialIntervalMillis") long initialIntervalMillis,
-      @JsonProperty("multiplier") double multiplier) {
+                                    @JsonProperty("initialIntervalMillis") long initialIntervalMillis,
+                                    @JsonProperty("multiplier") double multiplier,
+                                    @JsonProperty("identifier") String identifier) {
     Preconditions.checkArgument(maxAttempts > 0, "Max attempts should be > 0");
     Preconditions.checkArgument(initialIntervalMillis > 0L, "Initial interval should be > 0");
     Preconditions.checkArgument(multiplier >= 1, "Multiplier should be >= 1");
     this.maxAttempts = maxAttempts;
     this.initialIntervalMillis = initialIntervalMillis;
     this.multiplier = multiplier;
+    this.identifier = identifier;
   }
 
   @Override
@@ -62,9 +65,10 @@ public class ExponentialBackoffStrategy implements RetryStrategy {
   @Override
   public String toString() {
     return "ExponentialBackoffStrategy{" +
-        "maxAttempts=" + maxAttempts +
-        ", initialIntervalMillis=" + initialIntervalMillis +
-        ", multiplier=" + multiplier +
-        '}';
+            "maxAttempts=" + maxAttempts +
+            ", initialIntervalMillis=" + initialIntervalMillis +
+            ", multiplier=" + multiplier +
+            ", identifier=" + identifier +
+            '}';
   }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/ExponentialBackoffStrategy.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/ExponentialBackoffStrategy.java
@@ -33,9 +33,9 @@ public class ExponentialBackoffStrategy implements RetryStrategy {
   @JsonProperty("identifier")
   private String identifier;
   public ExponentialBackoffStrategy(@JsonProperty("maxAttempts") int maxAttempts,
-                                    @JsonProperty("initialIntervalMillis") long initialIntervalMillis,
-                                    @JsonProperty("multiplier") double multiplier,
-                                    @JsonProperty("identifier") String identifier) {
+      @JsonProperty("initialIntervalMillis") long initialIntervalMillis,
+      @JsonProperty("multiplier") double multiplier,
+      @JsonProperty("identifier") String identifier) {
     Preconditions.checkArgument(maxAttempts > 0, "Max attempts should be > 0");
     Preconditions.checkArgument(initialIntervalMillis > 0L, "Initial interval should be > 0");
     Preconditions.checkArgument(multiplier >= 1, "Multiplier should be >= 1");
@@ -44,7 +44,6 @@ public class ExponentialBackoffStrategy implements RetryStrategy {
     this.multiplier = multiplier;
     this.identifier = identifier;
   }
-
   @Override
   public boolean canTryAgain(int tries) {
     return tries <= maxAttempts;
@@ -65,10 +64,10 @@ public class ExponentialBackoffStrategy implements RetryStrategy {
   @Override
   public String toString() {
     return "ExponentialBackoffStrategy{" +
-            "maxAttempts=" + maxAttempts +
-            ", initialIntervalMillis=" + initialIntervalMillis +
-            ", multiplier=" + multiplier +
-            ", identifier=" + identifier +
-            '}';
+        "maxAttempts=" + maxAttempts +
+        ", initialIntervalMillis=" + initialIntervalMillis +
+        ", multiplier=" + multiplier +
+        ", identifier=" + identifier +
+        '}';
   }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/UniformRetryStrategy.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/UniformRetryStrategy.java
@@ -32,8 +32,8 @@ public class UniformRetryStrategy implements RetryStrategy {
   private String identifier;
 
   public UniformRetryStrategy(@JsonProperty("maxAttempts") int maxAttempts,
-                              @JsonProperty("intervalMillis") long intervalMillis,
-                              @JsonProperty("identifier") String identifier) {
+      @JsonProperty("intervalMillis") long intervalMillis,
+      @JsonProperty("identifier") String identifier) {
     Preconditions.checkArgument(maxAttempts > 0, "Max attempts should be > 0");
     Preconditions.checkArgument(intervalMillis > 0L, "Interval should be > 0");
     // TODO: enforce stronger requirements (e.g., interval > 500ms)
@@ -61,9 +61,9 @@ public class UniformRetryStrategy implements RetryStrategy {
   @Override
   public String toString() {
     return "UniformRetryStrategy{" +
-            "maxAttempts=" + maxAttempts +
-            ", intervalMillis=" + intervalMillis +
-            ", identifier=" + identifier +
-            '}';
+        "maxAttempts=" + maxAttempts +
+        ", intervalMillis=" + intervalMillis +
+        ", identifier=" + identifier +
+        '}';
   }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/UniformRetryStrategy.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/UniformRetryStrategy.java
@@ -28,14 +28,18 @@ public class UniformRetryStrategy implements RetryStrategy {
   private int maxAttempts;
   @JsonProperty("intervalMillis")
   private long intervalMillis;
+  @JsonProperty("identifier")
+  private String identifier;
 
   public UniformRetryStrategy(@JsonProperty("maxAttempts") int maxAttempts,
-      @JsonProperty("intervalMillis") long intervalMillis) {
+                              @JsonProperty("intervalMillis") long intervalMillis,
+                              @JsonProperty("identifier") String identifier) {
     Preconditions.checkArgument(maxAttempts > 0, "Max attempts should be > 0");
     Preconditions.checkArgument(intervalMillis > 0L, "Interval should be > 0");
     // TODO: enforce stronger requirements (e.g., interval > 500ms)
     this.maxAttempts = maxAttempts;
     this.intervalMillis = intervalMillis;
+    this.identifier = identifier;
   }
 
   @Override
@@ -57,8 +61,9 @@ public class UniformRetryStrategy implements RetryStrategy {
   @Override
   public String toString() {
     return "UniformRetryStrategy{" +
-        "maxAttempts=" + maxAttempts +
-        ", intervalMillis=" + intervalMillis +
-        '}';
+            "maxAttempts=" + maxAttempts +
+            ", intervalMillis=" + intervalMillis +
+            ", identifier=" + identifier +
+            '}';
   }
 }


### PR DESCRIPTION
We are adding a parameter called 'identifier' at Facebook to distinguish the Retry Strategy actually used, using our logs. This is a backward compatible change, if the 'identifier' field is not passed, it is defaulted to 'null'.