### PR TITLE
Fix equals bug in photos resource

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoAlbum.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotoAlbum.java
@@ -20,10 +20,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
+import com.google.common.base.Strings;
 import java.util.Objects;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class PhotoAlbum {
   private final String id;
@@ -73,41 +75,44 @@ public class PhotoAlbum {
 
   @Override
   public int hashCode() {
-
     return Objects.hash(id);
   }
 
-  // Generates PhotoAlbum objects that represent fragments of this one.
-  // Used in cases where an album from the originating service is larger than the allowable size
-  // in the destination service.
-  // If an album "MyAlbum" is split into 3, the results will be "MyAlbum (1/3)", etc.
-  public List<PhotoAlbum> split(int numberOfNewAlbums){
-    List<PhotoAlbum> newAlbums = new ArrayList<>();
-    for(int i = 1; i <= numberOfNewAlbums; i++){
-      newAlbums.add(
-        new PhotoAlbum(
-          String.format("%s-pt%d", id, i),
-          String.format("%s (%d/%d)", id, i, numberOfNewAlbums),
-          description
-        )
-      );
-    }
-    return newAlbums;
+  /**
+   * Generates PhotoAlbum objects that represent fragments of this one. Used in cases where an album
+   * from the originating service is larger than the allowable size in the destination service. If
+   * an album "MyAlbum" is split into 3, the results will be "MyAlbum (1/3)", etc. Please note the
+   * resulting albums lose the original name, getting 'id (X/Y)' instead of the name.
+   */
+  public List<PhotoAlbum> split(int numberOfNewAlbums) {
+    return IntStream.range(1, numberOfNewAlbums + 1)
+        .mapToObj(
+            i ->
+                new PhotoAlbum(
+                    String.format("%s-pt%d", id, i),
+                    String.format("%s (%d/%d)", id, i, numberOfNewAlbums),
+                    description))
+        .collect(Collectors.toList());
   }
 
-  // This allows us to make album names palatable, removing unpalatable characters and
-  // enforcing length rules
+  /**
+   * This allows us to make album names palatable, removing unpalatable characters and enforcing
+   * length rules.
+   */
   public void cleanName(String forbiddenCharacters, char replacementCharacter, int maxLength) {
     // An album name is allowed to be null, handled on the importer level if there is a problem with
     // this value, so we support it here
     if (name == null) {
       return;
     }
-    name = name.chars()
-        .mapToObj(c -> (char) c)
-        .map(c -> forbiddenCharacters.contains(Character.toString(c)) ? replacementCharacter : c)
-        .map(Object::toString)
-        .collect(Collectors.joining("")).trim();
+    name =
+        name.chars()
+            .mapToObj(c -> (char) c)
+            .map(
+                c -> forbiddenCharacters.contains(Character.toString(c)) ? replacementCharacter : c)
+            .map(Object::toString)
+            .collect(Collectors.joining(""))
+            .trim();
     if (maxLength <= 0 || maxLength >= name.length()) {
       return;
     }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotosContainerResource.java
@@ -19,10 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Multimap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -30,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.common.models.TransmogrificationConfig;
 
@@ -46,8 +45,8 @@ public class PhotosContainerResource extends ContainerResource {
 
   @JsonCreator
   public PhotosContainerResource(
-          @JsonProperty("albums") Collection<PhotoAlbum> albums,
-          @JsonProperty("photos") Collection<PhotoModel> photos) {
+      @JsonProperty("albums") Collection<PhotoAlbum> albums,
+      @JsonProperty("photos") Collection<PhotoModel> photos) {
     this.albums = albums == null ? ImmutableList.of() : albums;
     this.photos = photos == null ? ImmutableList.of() : photos;
   }
@@ -63,9 +62,9 @@ public class PhotosContainerResource extends ContainerResource {
   @Override
   public Map<String, Integer> getCounts() {
     return new ImmutableMap.Builder<String, Integer>()
-            .put(PHOTOS_COUNT_DATA_NAME, photos.size())
-            .put(ALBUMS_COUNT_DATA_NAME, albums.size())
-            .build();
+        .put(PHOTOS_COUNT_DATA_NAME, photos.size())
+        .put(ALBUMS_COUNT_DATA_NAME, albums.size())
+        .build();
   }
 
   @Override
@@ -73,8 +72,8 @@ public class PhotosContainerResource extends ContainerResource {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     PhotosContainerResource that = (PhotosContainerResource) o;
-    return Objects.equals(getAlbums(), that.getAlbums()) &&
-            Objects.equals(getPhotos(), that.getPhotos());
+    return Objects.equals(getAlbums(), that.getAlbums())
+        && Objects.equals(getPhotos(), that.getPhotos());
   }
 
   @Override
@@ -92,44 +91,45 @@ public class PhotosContainerResource extends ContainerResource {
   private void transmogrifyAlbums(TransmogrificationConfig config) {
     ensureRootAlbum(config.getAlbumAllowRootPhotos());
     ensureAlbumSize(config.getAlbumMaxSize());
-    ensureCleanAlbumNames(config.getAlbumNameForbiddenCharacters(),
-            config.getAlbumNameReplacementCharacter(),
-            config.getAlbumNameMaxLength());
+    ensureCleanAlbumNames(
+        config.getAlbumNameForbiddenCharacters(),
+        config.getAlbumNameReplacementCharacter(),
+        config.getAlbumNameMaxLength());
   }
 
   // Splits albumns that are too large into albums that are smaller than {maxSize}.
   // A value of maxSize=-1 signals that there is no maximum
-  void ensureAlbumSize(int maxSize){
-    if (maxSize == -1){
+  void ensureAlbumSize(int maxSize) {
+    if (maxSize == -1) {
       // No max size; no need to go through that code.
       return;
     }
     // Group photos by albumId
-    Multimap<String, PhotoModel> albumGroups = ArrayListMultimap.create();
-    for (PhotoModel photo: photos){
-      albumGroups.put(photo.getAlbumId(), photo);
-    }
+    Map<String, List<PhotoModel>> albumGroups =
+        photos.stream().collect(Collectors.groupingBy(PhotoModel::getAlbumId));
     // Go through groups, splitting up anything that's too big
-    for(Entry<String,Collection<PhotoModel>> entry : albumGroups.asMap().entrySet()){
-      if (entry.getValue().size() > maxSize) {
-        for(PhotoAlbum album : albums){
-          if (album.getId() != entry.getKey()){
+    for (Entry<String, List<PhotoModel>> entry : albumGroups.entrySet()) {
+      List<PhotoModel> photosOfCurrentAlbum = entry.getValue();
+      if (photosOfCurrentAlbum.size() > maxSize) {
+        for (PhotoAlbum album : albums) {
+          if (!album.getId().equals(entry.getKey())) {
             continue;
           }
           // Create new partial album objects and reassign photos to those albums
-          List<PhotoAlbum> newAlbums = album.split(-Math.floorDiv(- entry.getValue().size(), maxSize));
-          Iterator<PhotoModel> remainingPhotos = entry.getValue().iterator();
-          for (PhotoAlbum newAlbum: newAlbums){
-            for (int i = 0; i < maxSize; i++){
+          List<PhotoAlbum> newAlbums =
+              album.split(-Math.floorDiv(-photosOfCurrentAlbum.size(), maxSize));
+          Iterator<PhotoModel> remainingPhotos = photosOfCurrentAlbum.iterator();
+          for (PhotoAlbum newAlbum : newAlbums) {
+            for (int i = 0; i < maxSize; i++) {
               remainingPhotos.next().reassignToAlbum(newAlbum.getId());
-              if (!remainingPhotos.hasNext()){
+              if (!remainingPhotos.hasNext()) {
                 break;
               }
             }
           }
 
           // Replace original album in state
-          List<PhotoAlbum> albums_ = new ArrayList<PhotoAlbum>(albums);
+          List<PhotoAlbum> albums_ = new ArrayList<>(albums);
           albums_.remove(album);
           albums_.addAll(newAlbums);
           this.albums = albums_;
@@ -140,24 +140,22 @@ public class PhotosContainerResource extends ContainerResource {
 
   // Ensures that the model obeys the restrictions of the destination service, grouping all
   // un-nested photos into their own root album if allowRootPhotos is true, noop otherwise
-  void ensureRootAlbum(boolean allowRootPhotos){
+  void ensureRootAlbum(boolean allowRootPhotos) {
     if (allowRootPhotos) {
       return;
     }
-    PhotoAlbum rootAlbum = new PhotoAlbum(
-            ROOT_ALBUM,
-            ROOT_ALBUM,
-            "A copy of your transferred photos that were not in any album"
-    );
+    PhotoAlbum rootAlbum =
+        new PhotoAlbum(
+            ROOT_ALBUM, ROOT_ALBUM, "A copy of your transferred photos that were not in any album");
     boolean usedRootAlbum = false;
 
-    for (PhotoModel photo: photos){
+    for (PhotoModel photo : photos) {
       if (photo.getAlbumId() == null) {
         photo.reassignToAlbum(rootAlbum.getId());
         usedRootAlbum = true;
       }
     }
-    if (usedRootAlbum){
+    if (usedRootAlbum) {
       List<PhotoAlbum> albums_ = new ArrayList<PhotoAlbum>(albums);
       albums_.add(rootAlbum);
       this.albums = albums_;
@@ -165,8 +163,9 @@ public class PhotosContainerResource extends ContainerResource {
   }
 
   // Replaces forbidden characters and makes sure that the name is not too long
-  void ensureCleanAlbumNames(String forbiddenTitleCharacters, char replacementCharacter, int maxTitleLength) {
-    for (PhotoAlbum album: albums) {
+  void ensureCleanAlbumNames(
+      String forbiddenTitleCharacters, char replacementCharacter, int maxTitleLength) {
+    for (PhotoAlbum album : albums) {
       album.cleanName(forbiddenTitleCharacters, replacementCharacter, maxTitleLength);
     }
   }
@@ -175,14 +174,15 @@ public class PhotosContainerResource extends ContainerResource {
   // limiting max title length or removing forbidden characters, etc.
   private void transmogrifyPhotos(TransmogrificationConfig config) {
     ensureCleanPhotoTitles(
-            config.getPhotoTitleForbiddenCharacters(),
-            config.getPhotoTitleReplacementCharacter(),
-            config.getPhotoTitleMaxLength());
+        config.getPhotoTitleForbiddenCharacters(),
+        config.getPhotoTitleReplacementCharacter(),
+        config.getPhotoTitleMaxLength());
   }
 
   // Replaces forbidden characters and makes sure that the title is not too long
-  void ensureCleanPhotoTitles(String forbiddenTitleCharacters, char replacementCharacter, int maxTitleLength) {
-    for (PhotoModel photo: photos) {
+  void ensureCleanPhotoTitles(
+      String forbiddenTitleCharacters, char replacementCharacter, int maxTitleLength) {
+    for (PhotoModel photo : photos) {
       photo.cleanTitle(forbiddenTitleCharacters, replacementCharacter, maxTitleLength);
     }
   }
@@ -190,9 +190,9 @@ public class PhotosContainerResource extends ContainerResource {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-            .add("albums", getAlbums())
-            .add("photos", getPhotos())
-            .add("counts", getCounts())
-            .toString();
+        .add("albums", getAlbums())
+        .add("photos", getPhotos())
+        .add("counts", getCounts())
+        .toString();
   }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotosContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/photos/PhotosContainerResource.java
@@ -106,7 +106,9 @@ public class PhotosContainerResource extends ContainerResource {
     }
     // Group photos by albumId
     Map<String, List<PhotoModel>> albumGroups =
-        photos.stream().collect(Collectors.groupingBy(PhotoModel::getAlbumId));
+        photos.stream()
+            .filter(photo -> photo.getAlbumId() != null)
+            .collect(Collectors.groupingBy(PhotoModel::getAlbumId));
     // Go through groups, splitting up anything that's too big
     for (Entry<String, List<PhotoModel>> entry : albumGroups.entrySet()) {
       List<PhotoModel> photosOfCurrentAlbum = entry.getValue();

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotoAlbumTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotoAlbumTest.java
@@ -1,0 +1,42 @@
+package org.datatransferproject.types.common.models.photos;
+
+import com.google.common.truth.Truth;
+import java.util.List;
+import org.junit.Test;
+
+public class PhotoAlbumTest {
+
+  private static final String DESCRIPTION = "AlbumDescription";
+
+  @Test
+  public void splitSimple() {
+    PhotoAlbum originalAlbum = new PhotoAlbum("123", "MyAlbum", DESCRIPTION);
+    List<PhotoAlbum> actual = originalAlbum.split(3);
+    Truth.assertThat(actual)
+        .containsExactly(
+            new PhotoAlbum("123-pt1", "123 (1/3)", DESCRIPTION),
+            new PhotoAlbum("123-pt2", "123 (2/3)", DESCRIPTION),
+            new PhotoAlbum("123-pt3", "123 (3/3)", DESCRIPTION));
+  }
+
+  @Test
+  public void splitNegative() {
+    PhotoAlbum originalAlbum = new PhotoAlbum("123", "MyAlbum", DESCRIPTION);
+    List<PhotoAlbum> actual = originalAlbum.split(-1);
+    Truth.assertThat(actual).isEmpty();
+  }
+
+  @Test
+  public void splitSingle() {
+    PhotoAlbum originalAlbum = new PhotoAlbum("123", "MyAlbum", DESCRIPTION);
+    List<PhotoAlbum> actual = originalAlbum.split(1);
+    Truth.assertThat(actual).containsExactly(new PhotoAlbum("123-pt1", "123 (1/1)", DESCRIPTION));
+  }
+
+  @Test
+  public void cleanNameSimple() {
+    PhotoAlbum originalAlbum = new PhotoAlbum("123", "MyAlbum", DESCRIPTION);
+    originalAlbum.cleanName("yu", 'X', 6);
+    Truth.assertThat(originalAlbum.getName()).isEqualTo("MXAlbX");
+  }
+}


### PR DESCRIPTION
Changes:
* `!equals` instead of `!=` when comparing string album IDs;
* simpler `PhotoAlbum::split`;
* basic tests for `PhotoAlbum`;
* formatting of every file I touched.

Looks like we use this `!=` comparison to find the album for the given group of photos. It was introduced in https://github.com/google/data-transfer-project/pull/805. I *suspect* the comparison bug didn't really show itself because the album ids for photos are probably reused everywhere (therefore have the same pointer).

I'll make the container resource easier to understand in the following PRs.