### PR TITLE
Fix dockerize

### DIFF
--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -47,6 +47,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    jcenter()
 }
 
 def transportType = project.hasProperty('transportType') ? transportType : "jettyrest"


### PR DESCRIPTION
It's a partial reversal of https://github.com/google/data-transfer-project/pull/1075. `dockerize` does not work without `jcenter`—it can't find `docker-java-shaded`.

## How to reproduce

Try running `./gradlew :distributions:demo-server:dockerize` without the changes. It fails with
```
* What went wrong:
Execution failed for task ':distributions:demo-server:dockerize'.
> Could not resolve all files for configuration ':distributions:demo-server:dockerJava'.
   > Could not find com.aries:docker-java-shaded:3.0.14.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/aries/docker-java-shaded/3.0.14/docker-java-shaded-3.0.14.pom
       - https://repo.maven.apache.org/maven2/com/aries/docker-java-shaded/3.0.14/docker-java-shaded-3.0.14.jar
     Required by:
         project :distributions:demo-server
```

Running the same command with the proposed changes fixes the execution.   