### PR TITLE
Bump version to 0.3.67

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectGroup=org.datatransferproject
-projectVersion=0.3.66-SNAPSHOT
+projectVersion=0.3.67-SNAPSHOT
 annotationApiVersion=1.2
 autoValueVersion=1.6.2
 commonsLangVersion=3.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectGroup=org.datatransferproject
-projectVersion=0.3.65-SNAPSHOT
+projectVersion=0.3.66-SNAPSHOT
 annotationApiVersion=1.2
 autoValueVersion=1.6.2
 commonsLangVersion=3.4


### PR DESCRIPTION
Following releases [`0.3.65`](https://github.com/google/data-transfer-project/releases/tag/v0.3.65) and [`0.3.66`](https://github.com/google/data-transfer-project/releases/tag/v0.3.66).