### PR TITLE
Fix and improve docs

### DIFF
--- a/Documentation/Publishing.md
+++ b/Documentation/Publishing.md
@@ -4,9 +4,16 @@ Artifacts are signed and published to Maven Central. You can see the latest vers
 
 The publication process is mostly automated through Gradle plugins as documented below.
 
+## 0. Versioning
+
+We don't have strict rules on versioning just yet, but we are trying to stick 
+to [Semantic Versioning](https://semver.org/). Until the moment we have
+a clear guidance on versioning, please discuss future releases in the 
+#maintainers chat.
+
 ## 1. Setting properties
  First you must set the necessary properties in [gradle.properties](../gradle.properties). These are:
- - `projectVersion` - this is the new version you wish to publish. We use [Semantic Versioning](https://semver.org/).
+ - `projectVersion` - this is the new version you wish to publish.
  - `ossrhUsername` & `ossrhPassword` - These are your Sonatype Jira credentials. Your account must have been granted publishing permissions. These are managed from a [JIRA ticket](https://issues.sonatype.org/browse/OSSRH-44189).
  - `signing.keyId` - The GPG key being used for signing the artifacts. (More information about setting up GPG keys can be found [here](https://central.sonatype.org/publish/requirements/gpg/))
  - `signing.password` - The password for that GPG private key.
@@ -26,12 +33,13 @@ We exclude the client-rest archives as these are not a Java package.
 
 ## 4. Release
 You can then release the deployment to the Central Repository following the steps on the Sonatype website  [here](https://central.sonatype.org/publish/release/). We are on the legacy host so make sure to use https://oss.sonatype.org/. Only attempt to Close the staging repository once the upload has finished.
+
  
 ## 5. Create github release and tag
 
 1. Go to [/releases](https://github.com/google/data-transfer-project/releases);
 2. Click 'Draft a new release';
-3. fill in the title and create a tag (the tag must have a `v` prefix, the title mustn't);
+3. Fill in the title and create a tag (the tag must have a `v` prefix, the title mustn't);
 4. Click 'Generate release notes';
 5. Publish release.
 

--- a/Documentation/Publishing.md
+++ b/Documentation/Publishing.md
@@ -26,3 +26,14 @@ We exclude the client-rest archives as these are not a Java package.
 
 ## 4. Release
 You can then release the deployment to the Central Repository following the steps on the Sonatype website  [here](https://central.sonatype.org/publish/release/). We are on the legacy host so make sure to use https://oss.sonatype.org/. Only attempt to Close the staging repository once the upload has finished.
+ 
+## 5. Create github release and tag
+
+1. Go to [/releases](https://github.com/google/data-transfer-project/releases);
+2. Click 'Draft a new release';
+3. fill in the title and create a tag (the tag must have a `v` prefix, the title mustn't);
+4. Click 'Generate release notes';
+5. Publish release.
+
+## 6. Update the project version
+Go to `properties.gradle` and update the version, create a PR.

--- a/Documentation/RunningLocally.md
+++ b/Documentation/RunningLocally.md
@@ -40,13 +40,14 @@ To download our latest demo image, run:
 
 Or, to build it yourself, run:
 
- `./gradlew :distributions:demo-server:dockerize`
+1. `cd client-rest; npm install` (see [First Run/Setup](Developer.md#first-runsetup) for more details)
+2. `./gradlew :distributions:demo-server:dockerize`
 
 This will generate the dockerfile and build an image, copying over local settings (configured in `.gradle/properties.gradle`) and using the local "cloud hosting" extension.
 
 ## Run the Docker image
 
-`docker run --rm -p 3000:443 -p 5005:5005 -p 8080:8080 --env-file distributions/demo-server/env.secrets --name dtp-demo datatransferproject/demo`
+`docker run --rm -p 3000:443 -p 5005:5005 -p 8080:8080 --env-file env.secrets --name dtp-demo datatransferproject/demo`
 
 will run the demo server image from above on `localhost:8080`.
 


### PR DESCRIPTION
1. More detailed release instructions.
2. Fixed path to `env.secrets`.
3. More detailed dockerize instructions.
4. Expanded note on versioning and dedicated a section number 0 to it.