### PR TITLE
Migrate Google importers to the new executor API

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -302,12 +302,12 @@ public class GooglePhotosImporter
     if (status.getCode() == Code.OK_VALUE) {
       PhotoResult photoResult = new PhotoResult(mediaItem.getMediaItem().getId(), bytes);
       executor.importAndSwallowIOExceptions(
-          item, inp -> ItemImportResult.success(photoResult, bytes));
+          item, itemToImport -> ItemImportResult.success(photoResult, bytes));
       return bytes;
     } else {
       executor.importAndSwallowIOExceptions(
           item,
-          inp ->
+          itemToImport ->
               ItemImportResult.error(
                   new IOException(
                       String.format(

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -50,13 +50,14 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputS
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.spi.transfer.i18n.BaseMultilingualDictionary;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
-import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorHelper;
+import org.datatransferproject.spi.transfer.idempotentexecutor.ItemImportResult;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
 import org.datatransferproject.transfer.ImageStreamProvider;
+import org.datatransferproject.types.common.ImportableItem;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
@@ -168,7 +169,7 @@ public class GooglePhotosImporter
     if (photos != null && photos.size() > 0) {
       Map<String, List<PhotoModel>> photosByAlbum =
           photos.stream()
-              .filter(photo -> !executor.isKeyCached(IdempotentImportExecutorHelper.getPhotoIdempotentId(photo)))
+              .filter(photo -> !executor.isKeyCached(photo.getIdempotentId()))
               .collect(Collectors.groupingBy(PhotoModel::getAlbumId));
 
       for (Entry<String, List<PhotoModel>> albumEntry : photosByAlbum.entrySet()) {
@@ -214,6 +215,7 @@ public class GooglePhotosImporter
     //  Resumable uploads would allow the upload of larger media that don't fit in memory.  To do
     //  this however, seems to require knowledge of the total file size.
     for (PhotoModel photo : photos) {
+      Long size = null;
       try {
         Pair<InputStream, Long> inputStreamBytesPair =
             getInputStreamForUrl(jobId, photo.getFetchableUrl(), photo.isInTempStore());
@@ -222,7 +224,8 @@ public class GooglePhotosImporter
           String uploadToken = getOrCreatePhotosInterface(jobId, authData).uploadPhotoContent(s);
           mediaItems.add(new NewMediaItem(cleanDescription(photo.getDescription()), uploadToken));
           uploadTokenToDataId.put(uploadToken, photo);
-          uploadTokenToLength.put(uploadToken, inputStreamBytesPair.getRight());
+          size = inputStreamBytesPair.getRight();
+          uploadTokenToLength.put(uploadToken, size);
         }
 
         try {
@@ -238,13 +241,10 @@ public class GooglePhotosImporter
                       jobId, photo.getFetchableUrl()),
               e);
         }
-      } catch (IOException e) {
-        executor.executeAndSwallowIOExceptions(
-            IdempotentImportExecutorHelper.getPhotoIdempotentId(photo),
-            photo.getTitle(),
-            () -> {
-              throw e;
-            });
+      } catch (IOException exception) {
+        Long finalSize = size;
+        executor.importAndSwallowIOExceptions(
+            photo, p -> ItemImportResult.error(exception, finalSize));
       }
     }
 
@@ -265,22 +265,19 @@ public class GooglePhotosImporter
         PhotoModel photo = uploadTokenToDataId.get(mediaItem.getUploadToken());
         totalBytes +=
             processMediaResult(
-                mediaItem,
-                IdempotentImportExecutorHelper.getPhotoIdempotentId(photo),
-                executor,
-                photo.getTitle(),
-                uploadTokenToLength.get(mediaItem.getUploadToken()));
+                mediaItem, photo, executor, uploadTokenToLength.get(mediaItem.getUploadToken()));
         uploadTokenToDataId.remove(mediaItem.getUploadToken());
       }
 
       if (!uploadTokenToDataId.isEmpty()) {
-        for (PhotoModel photo : uploadTokenToDataId.values()) {
-          executor.executeAndSwallowIOExceptions(
-              IdempotentImportExecutorHelper.getPhotoIdempotentId(photo),
-              photo.getTitle(),
-              () -> {
-                throw new IOException("Photo was missing from results list.");
-              });
+        for (Entry<String, PhotoModel> entry : uploadTokenToDataId.entrySet()) {
+          PhotoModel photo = entry.getValue();
+          executor.importAndSwallowIOExceptions(
+              photo,
+              p ->
+                  ItemImportResult.error(
+                      new IOException("Photo was missing from results list."),
+                      uploadTokenToLength.get(entry.getKey())));
         }
       }
     } catch (IOException e) {
@@ -297,32 +294,32 @@ public class GooglePhotosImporter
 
   private long processMediaResult(
       NewMediaItemResult mediaItem,
-      String idempotentId,
+      ImportableItem item,
       IdempotentImportExecutor executor,
-      String title,
       long bytes)
       throws Exception {
     Status status = mediaItem.getStatus();
     if (status.getCode() == Code.OK_VALUE) {
-      executor.executeAndSwallowIOExceptions(
-          idempotentId, title, () -> new PhotoResult(mediaItem.getMediaItem().getId(), bytes));
+      PhotoResult photoResult = new PhotoResult(mediaItem.getMediaItem().getId(), bytes);
+      executor.importAndSwallowIOExceptions(
+          item, inp -> ItemImportResult.success(photoResult, bytes));
       return bytes;
     } else {
-      executor.executeAndSwallowIOExceptions(
-          idempotentId,
-          title,
-          () -> {
-            throw new IOException(
-                String.format(
-                    "Media item could not be created. Code: %d Message: %s",
-                    status.getCode(), status.getMessage()));
-          });
+      executor.importAndSwallowIOExceptions(
+          item,
+          inp ->
+              ItemImportResult.error(
+                  new IOException(
+                      String.format(
+                          "Media item could not be created. Code: %d Message: %s",
+                          status.getCode(), status.getMessage())),
+                  bytes));
       return 0;
     }
   }
 
   private Pair<InputStream, Long> getInputStreamForUrl(
-     UUID jobId, String fetchableUrl, boolean inTempStore) throws IOException {
+      UUID jobId, String fetchableUrl, boolean inTempStore) throws IOException {
     if (inTempStore) {
       final InputStreamWrapper streamWrapper = jobStore.getStream(jobId, fetchableUrl);
       return Pair.of(streamWrapper.getStream(), streamWrapper.getBytes());


### PR DESCRIPTION
Following #1079 migrating Google photo and video importers to the new API. The new API supports size reporting.