### PR TITLE
Make exception mandatory on error

### DIFF
--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/ItemImportResult.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/ItemImportResult.java
@@ -31,6 +31,7 @@ public class ItemImportResult<T> {
 
   public static <T extends Serializable> ItemImportResult<T> error(
       Exception exception, Long sizeInBytes) {
+    Preconditions.checkNotNull(exception);
     return new ItemImportResult<>(null, sizeInBytes, Status.ERROR, exception);
   }
 

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/idempotentexecutor/ItemImportResultTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/idempotentexecutor/ItemImportResultTest.java
@@ -1,0 +1,37 @@
+package org.datatransferproject.spi.transfer.idempotentexecutor;
+
+import static org.datatransferproject.spi.transfer.idempotentexecutor.ItemImportResult.Status.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+public class ItemImportResultTest {
+
+  @Test
+  public void testNullBytesIsOk() {
+    ItemImportResult<String> result = ItemImportResult.success("blabla", null);
+    assertEquals(SUCCESS, result.getStatus());
+    assertFalse(result.hasBytes());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testNullBytesThrowOnGet() {
+    ItemImportResult.success("blabla", null).getBytes();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSuccessWithNoData() {
+    ItemImportResult.success(null, 0L);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFailWithIncorrectBytes() {
+    ItemImportResult.success("blabla", -1L);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testErrorWithNoException() {
+    ItemImportResult.error(null, 10L);
+  }
+}


### PR DESCRIPTION
1. Every error must have an exception. If a client does not have one it has to create one.
2. Added some unit tests.

Test plan: `ItemImportResultTest`. 