### PR TITLE
Migrate Blackblaze importers to new executor API

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -16,6 +16,7 @@
 
 package org.datatransferproject.datatransfer.backblaze.videos;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +26,7 @@ import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransf
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.ItemImportResult;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.transfer.ImageStreamProvider;
@@ -43,10 +45,10 @@ public class BackblazeVideosImporter
   private final BackblazeDataTransferClientFactory b2ClientFactory;
 
   public BackblazeVideosImporter(
-          Monitor monitor,
-          TemporaryPerJobDataStore jobStore,
-          ImageStreamProvider imageStreamProvider,
-          BackblazeDataTransferClientFactory b2ClientFactory) {
+      Monitor monitor,
+      TemporaryPerJobDataStore jobStore,
+      ImageStreamProvider imageStreamProvider,
+      BackblazeDataTransferClientFactory b2ClientFactory) {
     this.monitor = monitor;
     this.jobStore = jobStore;
     this.imageStreamProvider = imageStreamProvider;
@@ -69,26 +71,30 @@ public class BackblazeVideosImporter
 
     if (data.getVideos() != null && data.getVideos().size() > 0) {
       for (VideoModel video : data.getVideos()) {
-        idempotentExecutor.executeAndSwallowIOExceptions(
-            video.getDataId(), video.getName(), () -> importSingleVideo(b2Client, video));
+        idempotentExecutor.importAndSwallowIOExceptions(
+            video,
+            v -> importSingleVideo(b2Client, v));
       }
     }
 
     return ImportResult.OK;
   }
 
-  private String importSingleVideo(BackblazeDataTransferClient b2Client, VideoModel video)
+  private ItemImportResult<String> importSingleVideo(BackblazeDataTransferClient b2Client,
+      VideoModel video)
       throws IOException {
     try (InputStream videoFileStream =
         imageStreamProvider.getConnection(video.getContentUrl().toString()).getInputStream()) {
-
-      return b2Client.uploadFile(
+      File file = jobStore
+          .getTempFileFromInputStream(videoFileStream, video.getDataId(), ".mp4");
+      String res = b2Client.uploadFile(
           String.format("%s/%s.mp4", VIDEO_TRANSFER_MAIN_FOLDER, video.getDataId()),
-          jobStore.getTempFileFromInputStream(videoFileStream, video.getDataId(), ".mp4"));
+          file);
+      return ItemImportResult.success(res, file.length());
     } catch (FileNotFoundException e) {
       monitor.severe(
           () -> String.format("Video resource was missing for id: %s", video.getDataId()), e);
+      return ItemImportResult.error(e, null);
     }
-    return null;
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
@@ -24,16 +24,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import org.apache.commons.io.IOUtils;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.ImportFunction;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
@@ -41,7 +43,9 @@ import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
 public class BackblazePhotosImporterTest {
@@ -63,6 +67,8 @@ public class BackblazePhotosImporterTest {
         authData = mock(TokenSecretAuthData.class);
         client = mock(BackblazeDataTransferClient.class);
     }
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void testNullData() throws Exception {
@@ -106,10 +112,7 @@ public class BackblazePhotosImporterTest {
         String response = "response";
         UUID jobId = UUID.randomUUID();
         PhotoModel photoModel = new PhotoModel(title, photoUrl, "", "", dataId, albumId, false, null);
-        ArrayList<PhotoModel> photos = new ArrayList<>();
-        photos.add(photoModel);
-        PhotosContainerResource data = mock(PhotosContainerResource.class);
-        when(data.getPhotos()).thenReturn(photos);
+        PhotosContainerResource data = new PhotosContainerResource(Collections.emptyList(), Collections.singletonList(photoModel));
 
         when(executor.getCachedValue(albumId)).thenReturn(albumName);
 
@@ -120,15 +123,19 @@ public class BackblazePhotosImporterTest {
         when(client.uploadFile(eq("Photo Transfer/albumName/dataId.jpg"), any())).thenReturn(response);
         when(clientFactory.getOrCreateB2Client(jobId, authData)).thenReturn(client);
 
+        File file = folder.newFile();
+        when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(file);
+
         BackblazePhotosImporter sut =
                 new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
         sut.importItem(jobId, executor, authData, data);
 
-        ArgumentCaptor<Callable<String>> importCapture = ArgumentCaptor.forClass(Callable.class);
+        ArgumentCaptor<ImportFunction<PhotoModel, String>> importCapture = ArgumentCaptor.forClass(
+            ImportFunction.class);
         verify(executor, times(1))
-                .executeAndSwallowIOExceptions(eq(String.format("%s-%s", albumId, dataId)), eq(title), importCapture.capture());
+                .importAndSwallowIOExceptions(eq(photoModel), importCapture.capture());
 
-        String actual = importCapture.getValue().call();
+        String actual = importCapture.getValue().apply(photoModel).getData();
         assertEquals(response, actual);
     }
 

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
@@ -27,20 +27,22 @@ import static org.mockito.Mockito.when;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import org.apache.commons.io.IOUtils;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.ImportFunction;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
 public class BackblazeVideosImporterTest {
@@ -51,6 +53,9 @@ public class BackblazeVideosImporterTest {
     IdempotentImportExecutor executor;
     TokenSecretAuthData authData;
     BackblazeDataTransferClient client;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Before
     public void setUp() {
@@ -118,6 +123,7 @@ public class BackblazeVideosImporterTest {
         when(connection.getInputStream()).thenReturn(IOUtils.toInputStream("video content", "UTF-8"));
         when(streamProvider.getConnection(videoUrl)).thenReturn(connection);
 
+        when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(folder.newFile());
         when(client.uploadFile(eq("Video Transfer/dataId.mp4"), any())).thenReturn(response);
         when(clientFactory.getOrCreateB2Client(jobId, authData)).thenReturn(client);
 
@@ -125,11 +131,12 @@ public class BackblazeVideosImporterTest {
                 new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
         sut.importItem(jobId, executor, authData, data);
 
-        ArgumentCaptor<Callable<String>> importCapture = ArgumentCaptor.forClass(Callable.class);
+        ArgumentCaptor<ImportFunction<VideoModel, String>> importCapture = ArgumentCaptor.forClass(
+            ImportFunction.class);
         verify(executor, times(1))
-                .executeAndSwallowIOExceptions(eq(dataId), eq(title), importCapture.capture());
+                .importAndSwallowIOExceptions(eq(videoObject), importCapture.capture());
 
-        String actual = importCapture.getValue().call();
+        String actual = importCapture.getValue().apply(videoObject).getData();
         assertEquals(response, actual);
     }
 }


### PR DESCRIPTION
Following https://github.com/google/data-transfer-project/pull/1079 migrating Blackblaze photo and video importers to the new API. The new API supports size reporting.