### PR TITLE
fix typo introduced in #1109

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleAlbum.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleAlbum.java
@@ -38,7 +38,7 @@ public class GoogleAlbum {
 
   public String getTitle() { return title; }
 
-  public boolean getIsWritable() { return isWriteable; }
+  public boolean getIsWriteable() { return isWriteable; }
 
   public long getMediaItemsCount() { return mediaItemsCount; }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -308,7 +308,7 @@ public class GooglePhotosImporter
           () ->
               format(
                   "Can't find album during createPhotos call, album info: isWriteable %b, mediaItemsCount %d",
-                  album.getIsWritable(), album.getMediaItemsCount()),
+                  album.getIsWriteable(), album.getMediaItemsCount()),
           e);
     } catch (Exception ex) {
       monitor.info(() -> format("Can't find album during getAlbum call"), ex);


### PR DESCRIPTION
The [API reference](https://developers.google.com/photos/library/reference/rest/v1/albums#Album) defines `isWriteable` property, not `isWritable`.