### PR TITLE
Update docker plugin and remove JCenter dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r'
+        classpath 'com.bmuschko:gradle-docker-plugin:5.3.0'
     }
 }
 

--- a/distributions/demo-google-deployment/api/build.gradle
+++ b/distributions/demo-google-deployment/api/build.gradle
@@ -42,7 +42,7 @@ import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '6.1.0'
-    id 'com.bmuschko.docker-remote-api' version '3.2.6'
+    id 'com.bmuschko.docker-remote-api'
     id 'java'
     id 'application'
 }
@@ -120,7 +120,7 @@ shadowJar {
 task createApiServerDockerfile(type: Dockerfile) {
     description = 'Builds the API Server Dockerfile'
     group = 'docker'
-    destFile project.file("${buildDir}/api/Dockerfile")
+    setDestFile(project.file("${buildDir}/api/Dockerfile"))
     from "gcr.io/google-appengine/openjdk:11"
     exposePort 8080 // Port the API server is accessed from
     copyFile("build/libs/api-${project.version}-all.jar", "/app/api.jar")
@@ -140,7 +140,7 @@ task dockerize(type: DockerBuildImage) {
     inputDir = project.file(".")
     ext.gcpProject = project.hasProperty('gcpProject') ? gcpProject : 'missing-project-please-specify-one'
     ext.imageVersion = project.hasProperty('imageVersion') ? imageVersion : 'latest'
-    tag = "gcr.io/" + ext.gcpProject + "/portability-api:" + ext.imageVersion
+    tags.add("gcr.io/" + ext.gcpProject + "/portability-api:" + ext.imageVersion)
 }
 
 // Note: This service acct creds file should be used for local developmemt only. In production, we
@@ -155,7 +155,7 @@ task createApiServerDockerfileLocal(type: Dockerfile) {
     description = 'Builds the API Server Dockerfile for local development'
     group = 'docker'
     dependsOn copyApiServerDepsLocal
-    destFile project.file("${buildDir}/api/Dockerfile")
+    setDestFile(project.file("${buildDir}/api/Dockerfile"))
     from "gcr.io/google-appengine/openjdk:11"
     exposePort 8080 // Port the API server is accessed from
     copyFile("build/libs/api-${project.version}-all.jar", "/app/api.jar")
@@ -185,5 +185,5 @@ task dockerizeLocal(type: DockerBuildImage) {
     dependsOn copyResources, shadowJar, createApiServerDockerfileLocal
     dockerFile = project.file("${buildDir}/api/Dockerfile")
     inputDir = project.file(".")
-    tag = 'dataportability/api:latest'
+    tags.add('dataportability/api:latest')
 }

--- a/distributions/demo-google-deployment/transfer/build.gradle
+++ b/distributions/demo-google-deployment/transfer/build.gradle
@@ -44,7 +44,7 @@ import com.bmuschko.gradle.docker.tasks.image.Dockerfile
  */
 plugins {
     id 'com.github.johnrengelman.shadow' version '6.1.0'
-    id 'com.bmuschko.docker-remote-api' version '3.2.6'
+    id 'com.bmuschko.docker-remote-api'
     id 'java'
     id 'application'
 }
@@ -110,7 +110,7 @@ shadowJar {
 task createTransferServerDockerfile(type: Dockerfile) {
     description = 'Builds the Transfer Server Dockerfile'
     group = 'docker'
-    destFile project.file("${buildDir}/transfer/Dockerfile")
+    setDestFile(project.file("${buildDir}/transfer/Dockerfile"))
     from "gcr.io/google-appengine/openjdk:11"
     exposePort 8080 // Port the transfer server is accessed from
     copyFile("build/libs/transfer-all.jar", "/app/transfer.jar")
@@ -130,7 +130,7 @@ task dockerize(type: DockerBuildImage) {
     inputDir = project.file(".")
     ext.gcpProject = project.hasProperty('gcpProject') ? gcpProject : 'missing-project-please-specify-one'
     ext.imageVersion = project.hasProperty('imageVersion') ? imageVersion : 'latest'
-    tag = "gcr.io/" + ext.gcpProject + "/portability-transfer:" + ext.imageVersion
+    tags.add("gcr.io/" + ext.gcpProject + "/portability-transfer:" + ext.imageVersion)
 }
 
 // Note: This service acct creds file should be used for local testing only. In production, we use
@@ -146,7 +146,7 @@ task createTransferServerDockerfileLocal(type: Dockerfile) {
     description = 'Builds the Transfer Server Dockerfile for local development'
     group = 'docker'
     dependsOn copyTransferServerDepsLocal
-    destFile project.file("${buildDir}/transfer/Dockerfile")
+    setDestFile(project.file("${buildDir}/transfer/Dockerfile"))
     from "gcr.io/google-appengine/openjdk:11"
     exposePort 8082 // Port the transfer server is accessed from
     copyFile("build/libs/transfer-all.jar", "/app/transfer.jar")
@@ -177,5 +177,5 @@ task dockerizeLocal(type: DockerBuildImage) {
     dockerFile = project.file("${buildDir}/transfer/Dockerfile")
     inputDir = project.file(".")
     ext.gcpProject = project.hasProperty('gcpProject') ? gcpProject : 'missing-project-please-specify-one'
-    tag = "gcr.io/" + ext.gcpProject + "/portability-transfer:latest"
+    tags.add("gcr.io/" + ext.gcpProject + "/portability-transfer:latest")
 }

--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -42,12 +42,11 @@ plugins {
     id 'java'
     id 'application'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
-    id 'com.bmuschko.docker-remote-api' version '3.2.6'
+    id 'com.bmuschko.docker-remote-api'
 }
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 def transportType = project.hasProperty('transportType') ? transportType : "jettyrest"
@@ -132,7 +131,7 @@ shadowJar.dependsOn(createApiFile)
 task createDockerfile(type: Dockerfile) {
     description = 'Builds the Demo Dockerfile, which includes both the frontend served by nginx, and a combined API + transfer worker backend'
     group = 'docker'
-    destFile project.file("${buildDir}/demo/Dockerfile")
+    setDestFile(project.file("${buildDir}/demo/Dockerfile"))
     from "${javaDockerContainer}"
     // Port to open up for the debugger
     exposePort 5005
@@ -186,7 +185,7 @@ task dockerize(type: DockerBuildImage) {
     dependsOn shadowJar, createDockerfile, copyWebApp
     dockerFile = project.file("${buildDir}/demo/Dockerfile")
     inputDir = project.file(".")
-    tag = 'datatransferproject/demo:latest'
+    tags.add('datatransferproject/demo:latest')
 }
 
 task installToolsAndDockerize {


### PR DESCRIPTION
closes #1115 

I had to update the plugin version—the previous one didn't work without jcenter. The new version is backward-incompatible with the previous one, so I updated some of the calls.

You might be wondering why I decided to add this plugin to `buildscript` instead of using beautiful `plugin { id .. }` syntax. The latter one didn't work for some reason and I just went with the option that did work. 

--- 

I tested by following [Running Locally](https://github.com/google/data-transfer-project/blob/master/Documentation/RunningLocally.md) instructions for **demo-server only (I did not check other images)**:
1. Build an image: `./gradlew :distributions:demo-server:dockerize`.
2. Run: `docker run --rm -p 3000:443 -p 5005:5005 -p 8080:8080 --env-file env.secrets --name dtp-demo datatransferproject/demo`