### PR TITLE
Migrate simple cases to JUnit5 annotations

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/test/java/org/datatransferproject/cloud/google/GoogleCloudIdempotentImportExecutorTest.java
+++ b/extensions/cloud/portability-cloud-google/src/test/java/org/datatransferproject/cloud/google/GoogleCloudIdempotentImportExecutorTest.java
@@ -5,8 +5,8 @@ import com.google.cloud.datastore.Transaction;
 import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -25,7 +25,7 @@ public class GoogleCloudIdempotentImportExecutorTest {
   private static Datastore datastore;
   private static GoogleCloudIdempotentImportExecutor googleExecutor;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, InterruptedException {
     // create a local datastore with 100% consistency for testing. This is ok to assume for the
     // purposes of this test because the implementation only reads from datastore after a job has

--- a/extensions/cloud/portability-cloud-local/src/test/java/org/datatransferproject/cloud/local/LocalJobStoreTest.java
+++ b/extensions/cloud/portability-cloud-local/src/test/java/org/datatransferproject/cloud/local/LocalJobStoreTest.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
 import java.util.Map;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalJobStoreTest {
 

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
@@ -42,9 +42,9 @@ import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
@@ -57,7 +57,7 @@ public class BackblazePhotosImporterTest {
     TokenSecretAuthData authData;
     BackblazeDataTransferClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         monitor = mock(Monitor.class);
         dataStore = mock(TemporaryPerJobDataStore.class);

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
@@ -39,9 +39,9 @@ import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
@@ -57,7 +57,7 @@ public class BackblazeVideosImporterTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         monitor = mock(Monitor.class);
         dataStore = mock(TemporaryPerJobDataStore.class);

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporterTest.java
@@ -47,9 +47,9 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempoten
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
@@ -64,7 +64,7 @@ public class DaybookPhotosImporterTest {
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     monitor = mock(Monitor.class);
     jobStore = mock(TemporaryPerJobDataStore.class);

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/social/DaybookPostsImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/social/DaybookPostsImporterTest.java
@@ -46,9 +46,9 @@ import org.datatransferproject.types.common.models.social.SocialActivityLocation
 import org.datatransferproject.types.common.models.social.SocialActivityModel;
 import org.datatransferproject.types.common.models.social.SocialActivityType;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
@@ -61,7 +61,7 @@ public class DaybookPostsImporterTest {
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     monitor = mock(Monitor.class);
     executor = new InMemoryIdempotentImportExecutor(monitor);

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporterTest.java
@@ -32,8 +32,8 @@ import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FacebookVideosExporterTest {
 
@@ -44,7 +44,7 @@ public class FacebookVideosExporterTest {
   private FacebookVideosExporter facebookVideosExporter;
   private UUID uuid = UUID.randomUUID();
 
-  @Before
+  @BeforeEach
   public void setUp() throws CopyExceptionWithFailureReason {
     FacebookVideosInterface videosInterface = mock(FacebookVideosInterface.class);
 

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosExporterTest.java
@@ -50,7 +50,7 @@ import org.datatransferproject.types.common.models.photos.PhotosContainerResourc
 import org.datatransferproject.types.transfer.auth.AuthData;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
 import org.datatransferproject.types.transfer.serviceconfig.TransferServiceConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.scribe.model.Token;
 
 public class FlickrPhotosExporterTest {

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/test/java/org/datatransferproject/datatransfer/flickr/photos/FlickrPhotosImporterTest.java
@@ -47,7 +47,7 @@ import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
 import org.datatransferproject.types.transfer.serviceconfig.TransferServiceConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.scribe.model.Token;
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarExporterTest.java
@@ -48,8 +48,8 @@ import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.common.models.calendar.CalendarContainerResource;
 import org.datatransferproject.types.common.models.calendar.CalendarEventModel;
 import org.datatransferproject.types.common.models.calendar.CalendarModel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
@@ -76,7 +76,7 @@ public class GoogleCalendarExporterTest {
   private Calendar.Events.List eventListRequest;
   private Events eventListResponse;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     calendarClient = mock(Calendar.class);
     calendarCalendars = mock(Calendar.Calendars.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/calendar/GoogleCalendarImporterTest.java
@@ -24,10 +24,9 @@ import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
 import org.datatransferproject.types.common.models.calendar.CalendarContainerResource;
 import org.datatransferproject.types.common.models.calendar.CalendarEventModel;
 import org.datatransferproject.types.common.models.calendar.CalendarModel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -47,7 +46,7 @@ public class GoogleCalendarImporterTest {
   private Calendar.Events.Insert eventInsertRequest;
   private IdempotentImportExecutor executor;
 
-  @Before
+  @BeforeEach
   public void setup() {
     calendarClient = mock(Calendar.class);
     calendarCalendars = mock(Calendar.Calendars.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsExportConversionTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsExportConversionTest.java
@@ -40,7 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GoogleContactsExportConversionTest {
   private static final String DEFAULT_SOURCE_TYPE = "CONTACT";

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsExporterTest.java
@@ -16,6 +16,13 @@
 
 package org.datatransferproject.datatransfer.google.contacts;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.datatransferproject.datatransfer.google.common.GoogleStaticObjects.PERSON_FIELDS;
+import static org.datatransferproject.datatransfer.google.common.GoogleStaticObjects.SELF_RESOURCE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.api.services.people.v1.PeopleService;
 import com.google.api.services.people.v1.PeopleService.People;
 import com.google.api.services.people.v1.PeopleService.People.Connections;
@@ -29,29 +36,21 @@ import com.google.api.services.people.v1.model.PersonResponse;
 import com.google.api.services.people.v1.model.Source;
 import ezvcard.VCard;
 import ezvcard.io.json.JCardReader;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.PaginationData;
 import org.datatransferproject.types.common.StringPaginationToken;
 import org.datatransferproject.types.common.models.contacts.ContactsModelWrapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.datatransferproject.datatransfer.google.common.GoogleStaticObjects.PERSON_FIELDS;
-import static org.datatransferproject.datatransfer.google.common.GoogleStaticObjects.SELF_RESOURCE;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class GoogleContactsExporterTest {
 
@@ -75,7 +74,7 @@ public class GoogleContactsExporterTest {
   private Connections.List listConnectionsRequest;
   private ListConnectionsResponse listConnectionsResponse;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     connections = mock(Connections.class);
     getBatchGet = mock(GetBatchGet.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsImportConversionTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsImportConversionTest.java
@@ -36,8 +36,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GoogleContactsImportConversionTest {
   private VCard defaultVCard;
@@ -61,7 +61,7 @@ public class GoogleContactsImportConversionTest {
     return fields.stream().map(function).collect(Collectors.toList());
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     defaultVCard = new VCard();
     defaultVCard.setStructuredName(makeStructuredName("Haskell", "Curry", CONTACT_SOURCE_TYPE));

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/contacts/GoogleContactsImporterTest.java
@@ -16,23 +16,6 @@
 
 package org.datatransferproject.datatransfer.google.contacts;
 
-import com.google.api.services.people.v1.PeopleService;
-import com.google.api.services.people.v1.PeopleService.People;
-import com.google.api.services.people.v1.PeopleService.People.CreateContact;
-import com.google.api.services.people.v1.model.Person;
-import ezvcard.VCard;
-import ezvcard.property.StructuredName;
-import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
-import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
-import org.datatransferproject.types.common.models.contacts.ContactsModelWrapper;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
-
 import static org.datatransferproject.datatransfer.google.common.GoogleStaticObjects.CONTACT_SOURCE_TYPE;
 import static org.datatransferproject.datatransfer.google.common.GoogleStaticObjects.SOURCE_PARAM_NAME_TYPE;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +23,22 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.google.api.services.people.v1.PeopleService;
+import com.google.api.services.people.v1.PeopleService.People;
+import com.google.api.services.people.v1.PeopleService.People.CreateContact;
+import com.google.api.services.people.v1.model.Person;
+import ezvcard.VCard;
+import ezvcard.property.StructuredName;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
+import org.datatransferproject.types.common.models.contacts.ContactsModelWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GoogleContactsImporterTest {
 
@@ -49,7 +48,7 @@ public class GoogleContactsImporterTest {
   private CreateContact createContact;
   private IdempotentImportExecutor executor;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     people = mock(People.class);
     peopleService = mock(PeopleService.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosExporterTest.java
@@ -58,8 +58,8 @@ import org.datatransferproject.types.common.models.IdOnlyContainerResource;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class GooglePhotosExporterTest {
@@ -80,7 +80,7 @@ public class GooglePhotosExporterTest {
   private MediaItemSearchResponse mediaItemSearchResponse;
   private AlbumListResponse albumListResponse;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InvalidTokenException, PermissionDeniedException {
     GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
     jobStore = mock(TemporaryPerJobDataStore.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/PhotoResultSerializationTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/photos/PhotoResultSerializationTest.java
@@ -4,8 +4,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
-import java.io.*;
-import org.junit.Test;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
 
 public class PhotoResultSerializationTest {
   @Test

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporterTest.java
@@ -16,6 +16,20 @@
 
 package org.datatransferproject.datatransfer.google.videos;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.mediaModels.AlbumListResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
@@ -28,23 +42,8 @@ import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.types.common.StringPaginationToken;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GoogleVideosExporterTest {
 
@@ -61,7 +60,7 @@ public class GoogleVideosExporterTest {
   private MediaItemSearchResponse mediaItemSearchResponse;
   private AlbumListResponse albumListResponse;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     GoogleCredentialFactory credentialFactory = mock(GoogleCredentialFactory.class);
     jobStore = mock(TemporaryPerJobDataStore.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
@@ -51,8 +51,8 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempoten
 import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentMatchers;
 
@@ -68,7 +68,7 @@ public class GoogleVideosImporterTest {
   private TemporaryPerJobDataStore dataStore;
   private ImageStreamProvider streamProvider;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // Create files so we can accurately check the length of file counting
     dataStore = mock(TemporaryPerJobDataStore.class);

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/VideoResultSerializationTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/VideoResultSerializationTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import java.io.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VideoResultSerializationTest {
   @Test

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/DataChunkTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/DataChunkTest.java
@@ -16,44 +16,15 @@
 
 package org.datatransferproject.transfer.microsoft.photos;
 
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ByteArrayInputStream;
-import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import com.google.api.client.auth.oauth2.Credential;
-
-import org.datatransferproject.api.launcher.Monitor;
-import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
-import org.datatransferproject.launcher.monitor.ConsoleMonitor;
-import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
-import org.datatransferproject.spi.transfer.provider.ImportResult;
-import org.datatransferproject.spi.transfer.types.ContinuationData;
-import org.datatransferproject.transfer.microsoft.common.MicrosoftCredentialFactory;
-import org.datatransferproject.transfer.microsoft.driveModels.*;
-import org.datatransferproject.types.common.StringPaginationToken;
-import org.datatransferproject.types.common.models.ContainerResource;
-import org.datatransferproject.types.common.models.IdOnlyContainerResource;
-import org.datatransferproject.types.common.models.photos.PhotoAlbum;
-import org.datatransferproject.types.common.models.photos.PhotoModel;
-import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.transfer.microsoft.DataChunk;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Matchers;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import okhttp3.OkHttpClient;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 /** */
@@ -63,7 +34,7 @@ public class DataChunkTest {
 
   InputStream inputStream;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
   }
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/MicrosoftCalendarExportTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/MicrosoftCalendarExportTest.java
@@ -25,12 +25,12 @@ import okhttp3.OkHttpClient;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
 import org.datatransferproject.transfer.microsoft.calendar.MicrosoftCalendarExporter;
 import org.datatransferproject.transfer.microsoft.transformer.TransformerServiceImpl;
-import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.datatransferproject.types.common.models.calendar.CalendarContainerResource;
-import org.junit.After;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies Calendar export using mock HTTP endpoints that replay responses from the Microsoft Graph
@@ -257,7 +257,7 @@ public class MicrosoftCalendarExportTest {
                         && "Test Appointment 2".equals(e.getTitle())));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     client = new OkHttpClient.Builder().build();
     mapper = new ObjectMapper();
@@ -266,7 +266,7 @@ public class MicrosoftCalendarExportTest {
     server = new MockWebServer();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.shutdown();
   }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/MicrosoftCalendarImportTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/MicrosoftCalendarImportTest.java
@@ -15,11 +15,19 @@
  */
 package org.datatransferproject.transfer.microsoft.integration;
 
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import okhttp3.OkHttpClient;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
@@ -30,19 +38,10 @@ import org.datatransferproject.types.common.models.calendar.CalendarContainerRes
 import org.datatransferproject.types.common.models.calendar.CalendarEventModel;
 import org.datatransferproject.types.common.models.calendar.CalendarModel;
 import org.datatransferproject.types.transfer.auth.TokenAuthData;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies Calendar export using mock HTTP endpoints that replay responses from the Microsoft Graph
@@ -291,7 +290,7 @@ public class MicrosoftCalendarImportTest {
     Assert.assertEquals("UTC", endDate.get("timeZone"));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     client = new OkHttpClient.Builder().build();
     mapper = new ObjectMapper();
@@ -300,7 +299,7 @@ public class MicrosoftCalendarImportTest {
     server = new MockWebServer();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.shutdown();
   }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaExporterTest.java
@@ -41,9 +41,8 @@ import org.datatransferproject.types.common.models.media.MediaAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Unit tests of Microsoft onedrive exporter for Media models. */
 public class MicrosoftMediaExporterTest {
@@ -63,7 +62,7 @@ public class MicrosoftMediaExporterTest {
 
   private MicrosoftDriveItemsResponse driveItemsResponse;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     MicrosoftCredentialFactory credentialFactory = mock(MicrosoftCredentialFactory.class);
     mediaInterface = mock(MicrosoftMediaInterface.class);

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/photos/MicrosoftPhotosExporterTest.java
@@ -38,9 +38,8 @@ import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,7 +62,7 @@ public class MicrosoftPhotosExporterTest {
 
   private MicrosoftDriveItemsResponse driveItemsResponse;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     MicrosoftCredentialFactory credentialFactory = mock(MicrosoftCredentialFactory.class);
     photosInterface = mock(MicrosoftPhotosInterface.class);

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/transformer/calendar/ToCalendarAttendeeModelTransformerTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/transformer/calendar/ToCalendarAttendeeModelTransformerTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import org.datatransferproject.transfer.microsoft.helper.TestTransformerContext;
 import org.datatransferproject.types.common.models.calendar.CalendarAttendeeModel;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ToCalendarAttendeeModelTransformerTest {
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/transformer/calendar/ToCalendarEventModelTransformerTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/transformer/calendar/ToCalendarEventModelTransformerTest.java
@@ -24,8 +24,8 @@ import org.datatransferproject.transfer.microsoft.helper.TestTransformerContext;
 import org.datatransferproject.types.common.models.calendar.CalendarAttendeeModel;
 import org.datatransferproject.types.common.models.calendar.CalendarEventModel;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ToCalendarEventModelTransformerTest {
   private static final String SAMPLE_CALENDAR_EVENT =
@@ -127,7 +127,7 @@ public class ToCalendarEventModelTransformerTest {
     Assert.assertEquals(30, event.getEndTime().getDateTime().getMinute());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     transformer = new ToCalendarEventModelTransformer();
     mapper = new ObjectMapper();

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/transformer/calendar/ToCalendarEventTimeTransformerTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/transformer/calendar/ToCalendarEventTimeTransformerTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import org.datatransferproject.transfer.microsoft.helper.TestTransformerContext;
 import org.datatransferproject.types.common.models.calendar.CalendarEventModel;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ToCalendarEventTimeTransformerTest {
   private ToCalendarEventTimeTransformer transformer = new ToCalendarEventTimeTransformer();

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/transformer/calendar/ToCalendarModelTransformerTest.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/transformer/calendar/ToCalendarModelTransformerTest.java
@@ -22,8 +22,8 @@ import org.datatransferproject.transfer.microsoft.helper.TestTransformerContext;
 import org.datatransferproject.transfer.microsoft.transformer.TransformerContext;
 import org.datatransferproject.types.common.models.calendar.CalendarModel;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ToCalendarModelTransformerTest {
   private static final String SAMPLE_CALENDAR =
@@ -56,7 +56,7 @@ public class ToCalendarModelTransformerTest {
     Assert.assertEquals("Calendar", calendar.getDescription());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     transformer = new ToCalendarModelTransformer();
     mapper = new ObjectMapper();

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/test/java/org/datatransferproject/transfer/rememberthemilk/model/tasks/ModelTest.java
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/test/java/org/datatransferproject/transfer/rememberthemilk/model/tasks/ModelTest.java
@@ -17,7 +17,7 @@
 package org.datatransferproject.transfer.rememberthemilk.model.tasks;
 
 import com.fasterxml.jackson.xml.XmlMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/test/java/org/datatransferproject/transfer/rememberthemilk/tasks/RememberTheMilkSignatureGeneratorTest.java
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/test/java/org/datatransferproject/transfer/rememberthemilk/tasks/RememberTheMilkSignatureGeneratorTest.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import java.net.URL;
 import java.util.Map;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RememberTheMilkSignatureGeneratorTest {
   private static final String KEY = "BANANAS1";

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/test/java/org/datatransfer/smugmug/photos/SmugMugInterfaceTest.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/test/java/org/datatransfer/smugmug/photos/SmugMugInterfaceTest.java
@@ -16,7 +16,7 @@
 
 package org.datatransferproject.transfer.smugmug.photos;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.assertEquals;
 

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/test/java/org/datatransfer/smugmug/photos/SmugMugPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/test/java/org/datatransfer/smugmug/photos/SmugMugPhotosImporterTest.java
@@ -38,14 +38,16 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportE
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.test.types.FakeIdempotentImportExecutor;
 import org.datatransferproject.transfer.smugmug.SmugMugTransmogrificationConfig;
-import org.datatransferproject.transfer.smugmug.photos.model.*;
+import org.datatransferproject.transfer.smugmug.photos.model.SmugMugAlbum;
+import org.datatransferproject.transfer.smugmug.photos.model.SmugMugAlbumResponse;
+import org.datatransferproject.transfer.smugmug.photos.model.SmugMugImageUploadResponse;
 import org.datatransferproject.transfer.smugmug.photos.model.SmugMugImageUploadResponse.ImageInfo;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class SmugMugPhotosImporterTest {

--- a/extensions/data-transfer/portability-data-transfer-solid/src/test/java/org/datatransferproject/transfer/solid/contacts/RoundTripToRdfTest.java
+++ b/extensions/data-transfer/portability-data-transfer-solid/src/test/java/org/datatransferproject/transfer/solid/contacts/RoundTripToRdfTest.java
@@ -25,7 +25,7 @@ import java.io.StringWriter;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RoundTripToRdfTest {
 

--- a/portability-api/src/test/java/org/datatransferproject/api/action/datatype/DataTypesActionTest.java
+++ b/portability-api/src/test/java/org/datatransferproject/api/action/datatype/DataTypesActionTest.java
@@ -1,18 +1,17 @@
 package org.datatransferproject.api.action.datatype;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry;
 import org.datatransferproject.types.client.datatype.DataTypes;
 import org.datatransferproject.types.client.datatype.GetDataTypes;
 import org.junit.Assert;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
 
 public class DataTypesActionTest {
 

--- a/portability-api/src/test/java/org/datatransferproject/api/auth/PortabilityAuthServiceExtensionRegistryTest.java
+++ b/portability-api/src/test/java/org/datatransferproject/api/auth/PortabilityAuthServiceExtensionRegistryTest.java
@@ -16,23 +16,22 @@
 
 package org.datatransferproject.api.auth;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
 import org.junit.Assert;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class PortabilityAuthServiceExtensionRegistryTest {
 

--- a/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/connection/ConnectionProviderTest.java
+++ b/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/connection/ConnectionProviderTest.java
@@ -13,15 +13,15 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
 import org.datatransferproject.types.common.DownloadableItem;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ConnectionProviderTest {
 
   private TemporaryPerJobDataStore jobStore;
   private ConnectionProvider connectionProvider;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     jobStore = mock(TemporaryPerJobDataStore.class);
     connectionProvider = new ConnectionProvider(jobStore);

--- a/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
+++ b/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
@@ -31,7 +31,7 @@ import org.datatransferproject.test.types.ObjectMapperFactory;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests serialization and deserialization of a {@link PortabilityJob}.

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/i18n/MultilingualDictionaryTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/i18n/MultilingualDictionaryTest.java
@@ -18,7 +18,7 @@ package org.datatransferproject.spi.transfer.i18n;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MultilingualDictionaryTest {
   @Test

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/types/ContinuationDataTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/types/ContinuationDataTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.datatransferproject.types.common.IntPaginationToken;
 import org.datatransferproject.types.common.models.IdOnlyContainerResource;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** */
 public class ContinuationDataTest {

--- a/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/CreateTransferJobTest.java
+++ b/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/CreateTransferJobTest.java
@@ -18,7 +18,7 @@ package org.datatransferproject.types.client.transfer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /* Test for CreateTransferJob */
 public class CreateTransferJobTest {

--- a/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/TransferJobTest.java
+++ b/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/TransferJobTest.java
@@ -18,7 +18,7 @@ package org.datatransferproject.types.client.transfer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.datatransferproject.types.common.PortabilityCommon;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/DateRangeContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/DateRangeContainerResourceTest.java
@@ -18,7 +18,7 @@ package org.datatransferproject.types.common.models;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.truth.Truth;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DateRangeContainerResourceTest {
   @Test

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/calendar/CalendarContainerResourceTest.java
@@ -6,12 +6,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.common.models.calendar.CalendarEventModel.CalendarEventTime;
-import org.junit.Test;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Test;
 
 public class CalendarContainerResourceTest {
   @Test

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/mail/MailContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/mail/MailContainerResourceTest.java
@@ -5,10 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
 import java.util.List;
 import org.datatransferproject.types.common.models.ContainerResource;
-import org.datatransferproject.types.common.models.mail.MailContainerModel;
-import org.datatransferproject.types.common.models.mail.MailContainerResource;
-import org.datatransferproject.types.common.models.mail.MailMessageModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MailContainerResourceTest {
   @Test

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
@@ -11,8 +11,7 @@ import org.datatransferproject.types.common.models.TransmogrificationConfig;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // TODO(#1060) this code was ported over without unit tests; below is a mostly 1:1-port
 // backfill but the new video handling logic in MediaContainerResource should have test coverage

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotoAlbumTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotoAlbumTest.java
@@ -2,7 +2,7 @@ package org.datatransferproject.types.common.models.photos;
 
 import com.google.common.truth.Truth;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PhotoAlbumTest {
 

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotosContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/photos/PhotosContainerResourceTest.java
@@ -6,7 +6,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.truth.Truth;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.common.models.TransmogrificationConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.stream.Collectors;
 import java.util.List;

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/social/SocialActivityContainerResourceTest.java
@@ -26,7 +26,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.datatransferproject.types.common.models.ContainerResource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SocialActivityContainerResourceTest {
 

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/tasks/TaskContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/tasks/TaskContainerResourceTest.java
@@ -7,10 +7,7 @@ import com.google.common.truth.Truth;
 
 import java.util.List;
 import org.datatransferproject.types.common.models.ContainerResource;
-import org.datatransferproject.types.common.models.tasks.TaskContainerResource;
-import org.datatransferproject.types.common.models.tasks.TaskListModel;
-import org.datatransferproject.types.common.models.tasks.TaskModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TaskContainerResourceTest {
 

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
@@ -19,10 +19,9 @@ package org.datatransferproject.types.common.models.videos;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.truth.Truth;
-import org.datatransferproject.types.common.models.ContainerResource;
-import org.junit.Test;
-
 import java.util.List;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.junit.jupiter.api.Test;
 
 public class VideosContainerResourceTest {
   @Test

--- a/portability-types-transfer/src/test/java/org/datatransferproject/types/transfer/auth/AuthDataSerializationTest.java
+++ b/portability-types-transfer/src/test/java/org/datatransferproject/types/transfer/auth/AuthDataSerializationTest.java
@@ -6,14 +6,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AuthDataSerializationTest {
 
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     objectMapper = new ObjectMapper();
     objectMapper.registerSubtypes(


### PR DESCRIPTION
It's a step 2 of JUnit 4–>5 migration. The previous one: https://github.com/google/data-transfer-project/pull/1125.

This PR includes only trivial usages of JUnit annotations. I did not cover `@Rule`, `@RunWith`, `@Test(expected=...)`, etc. I'll follow up with more complex migrations in the following PRs.