### PR TITLE
Add album support to google video importer

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/GooglePhotosImportUtils.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/GooglePhotosImportUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.datatransfer.google.common;
+
+import com.google.common.base.Strings;
+
+public class GooglePhotosImportUtils {
+
+  public static String cleanAlbumTitle(String originalTitle) {
+    String title = Strings.nullToEmpty(originalTitle);
+
+    // Album titles are restricted to 500 characters
+    // https://developers.google.com/photos/library/guides/manage-albums#creating-new-album
+    if (title.length() > 500) {
+      title = title.substring(0, 497) + "...";
+    }
+    return title;
+  }
+
+  public static String cleanDescription(String originalDescription) {
+    String description = Strings.isNullOrEmpty(originalDescription) ? "" : originalDescription;
+
+    // Descriptions are restricted to 1000 characters
+    // https://developers.google.com/photos/library/guides/upload-media#creating-media-item
+    if (description.length() > 1000) {
+      description = description.substring(0, 997) + "...";
+    }
+    return description;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/GooglePhotosImportUtils.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/GooglePhotosImportUtils.java
@@ -17,6 +17,7 @@ package org.datatransferproject.datatransfer.google.common;
 
 import com.google.common.base.Strings;
 
+// TODO(#1144) consider porting this logic to a transmogrify config (and thus deleting this class).
 public class GooglePhotosImportUtils {
 
   public static String cleanAlbumTitle(String originalTitle) {

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
@@ -36,6 +36,8 @@ import com.google.photos.library.v1.proto.BatchCreateMediaItemsResponse;
 import com.google.photos.library.v1.proto.NewMediaItem;
 import com.google.photos.library.v1.proto.NewMediaItemResult;
 import com.google.photos.library.v1.upload.UploadMediaItemResponse;
+import com.google.photos.library.v1.util.NewMediaItemFactory;
+import com.google.photos.types.proto.Album;
 import com.google.photos.types.proto.MediaItem;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
@@ -44,12 +46,17 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempotentImportExecutor;
 import org.datatransferproject.transfer.ImageStreamProvider;
+import org.datatransferproject.types.common.models.videos.VideoAlbum;
 import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 import org.datatransferproject.types.transfer.errors.ErrorDetail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,10 +70,14 @@ public class GoogleVideosImporterTest {
   private static final String VIDEO_URI = "https://www.example.com/video.mp4";
   private static final String MP4_MEDIA_TYPE = "video/mp4";
   private static final String VIDEO_ID = "myId";
+  private static final String ALBUM_ID = "album1";
 
   private GoogleVideosImporter googleVideosImporter;
   private TemporaryPerJobDataStore dataStore;
   private ImageStreamProvider streamProvider;
+  private PhotosLibraryClient client;
+  private UUID jobId;
+
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -87,16 +98,21 @@ public class GoogleVideosImporterTest {
 
     streamProvider = mock(ImageStreamProvider.class);
     when(streamProvider.getConnection(any())).thenReturn(mock(HttpURLConnection.class));
+    client = mock(PhotosLibraryClient.class);
+    jobId = UUID.randomUUID();
     googleVideosImporter =
-        new GoogleVideosImporter(null, dataStore, mock(Monitor.class), streamProvider);
+        new GoogleVideosImporter(
+            null, dataStore, mock(Monitor.class), streamProvider, Map.of(jobId, client));
   }
 
   @Test
-  public void importTwoVideos() throws Exception {
-    PhotosLibraryClient photosLibraryClient = mock(PhotosLibraryClient.class);
+  public void importTwoVideosInDifferentAlbums() throws Exception {
+    String googleAlbumId = "googleId";
+    Album expected = Album.newBuilder().setId(googleAlbumId).setTitle("albumName").build();
+    when(client.createAlbum(anyString())).thenReturn(expected);
 
     // Mock uploads
-    when(photosLibraryClient.uploadMediaItem(any()))
+    when(client.uploadMediaItem(any()))
         .thenReturn(
             UploadMediaItemResponse.newBuilder().setUploadToken("token1").build(),
             UploadMediaItemResponse.newBuilder().setUploadToken("token2").build());
@@ -105,49 +121,59 @@ public class GoogleVideosImporterTest {
     final NewMediaItemResult newMediaItemResult =
         NewMediaItemResult.newBuilder()
             .setStatus(Status.newBuilder().setCode(Code.OK_VALUE).build())
-            .setMediaItem(MediaItem.newBuilder().setId("RESULT_ID_1").build())
             .setUploadToken("token1")
             .build();
     final NewMediaItemResult newMediaItemResult2 =
         NewMediaItemResult.newBuilder()
             .setStatus(Status.newBuilder().setCode(Code.OK_VALUE).build())
-            .setMediaItem(MediaItem.newBuilder().setId("RESULT_ID_2").build())
             .setUploadToken("token2")
             .build();
     BatchCreateMediaItemsResponse response =
         BatchCreateMediaItemsResponse.newBuilder()
             .addNewMediaItemResults(newMediaItemResult)
+            .build();
+    BatchCreateMediaItemsResponse response2 =
+        BatchCreateMediaItemsResponse.newBuilder()
             .addNewMediaItemResults(newMediaItemResult2)
             .build();
-    when(photosLibraryClient.batchCreateMediaItems(ArgumentMatchers.anyList()))
+    NewMediaItem mediaItem = NewMediaItemFactory.createNewMediaItem("token1", VIDEO_DESCRIPTION);
+    NewMediaItem mediaItem2 = NewMediaItemFactory.createNewMediaItem("token2", VIDEO_DESCRIPTION);
+    when(client.batchCreateMediaItems(eq(googleAlbumId), eq(List.of(mediaItem))))
         .thenReturn(response);
-    UUID jobId = UUID.randomUUID();
+    when(client.batchCreateMediaItems(eq(List.of(mediaItem2))))
+        .thenReturn(response2);
 
     InMemoryIdempotentImportExecutor executor =
         new InMemoryIdempotentImportExecutor(mock(Monitor.class));
     long length =
-        googleVideosImporter.importVideoBatch(jobId,
-            Lists.newArrayList(
-                new VideoModel(
-                    VIDEO_TITLE,
-                    VIDEO_URI,
-                    VIDEO_DESCRIPTION,
-                    MP4_MEDIA_TYPE,
-                    VIDEO_ID,
-                    null,
-                    false,
-                    null),
-                new VideoModel(
-                    VIDEO_TITLE,
-                    VIDEO_URI,
-                    VIDEO_DESCRIPTION,
-                    MP4_MEDIA_TYPE,
-                    "myId2",
-                    null,
-                    false,
-                    null)),
-            photosLibraryClient,
-            executor);
+        googleVideosImporter
+            .importItem(
+                jobId,
+                executor,
+                mock(TokensAndUrlAuthData.class),
+                new VideosContainerResource(
+                    List.of(new VideoAlbum(ALBUM_ID, "name", null)),
+                    List.of(
+                        new VideoModel(
+                            VIDEO_TITLE,
+                            VIDEO_URI,
+                            VIDEO_DESCRIPTION,
+                            MP4_MEDIA_TYPE,
+                            VIDEO_ID,
+                            ALBUM_ID,
+                            false,
+                            null),
+                        new VideoModel(
+                            VIDEO_TITLE,
+                            VIDEO_URI,
+                            VIDEO_DESCRIPTION,
+                            MP4_MEDIA_TYPE,
+                            "myId2",
+                            null,
+                            false,
+                            null))))
+            .getBytes()
+            .get();
     assertEquals("Expected the number of bytes to be the two files of 32L.", 64L, length);
     assertEquals("Expected executor to have no errors.", 0, executor.getErrors().size());
   }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/ItemImportResult.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/ItemImportResult.java
@@ -29,6 +29,10 @@ public class ItemImportResult<T> {
     return new ItemImportResult<>(data, sizeInBytes, Status.SUCCESS, null);
   }
 
+  public static <T extends Serializable> ItemImportResult<T> success(T data) {
+    return success(data, null);
+  }
+
   public static <T extends Serializable> ItemImportResult<T> error(
       Exception exception, Long sizeInBytes) {
     Preconditions.checkNotNull(exception);

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/idempotentexecutor/ItemImportResultTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/idempotentexecutor/ItemImportResultTest.java
@@ -11,7 +11,7 @@ public class ItemImportResultTest {
 
   @Test
   public void testNullBytesIsOk() {
-    ItemImportResult<String> result = ItemImportResult.success("blabla", null);
+    ItemImportResult<String> result = ItemImportResult.success("blabla");
     assertEquals(SUCCESS, result.getStatus());
     assertFalse(result.hasBytes());
   }


### PR DESCRIPTION
Currently, all videos transferred to Google Photos end up at the top level. They're not assigned to any album. The albums specified via `VideoModel` are ignored.

This change adds support for specifying albums for video transfers. It's duplicating the functionality already present in the `GooglePhotosImporter`. Transfers where the album isn't specified work normally like before.