### PR TITLE
Fix Java debugging of a running docker container

### DIFF
--- a/distributions/demo-server/src/config/demo/supervisord.conf
+++ b/distributions/demo-server/src/config/demo/supervisord.conf
@@ -16,7 +16,7 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 
 [program:dtp-java]
-command=java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -jar /app/demo-server-all.jar
+command=java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005 -jar /app/demo-server-all.jar
 autostart=true
 autorestart=true
 priority=10


### PR DESCRIPTION
I broke it when migrating to Java 11 in https://github.com/google/data-transfer-project/pull/1114.