### PR TITLE
Add junit5 jupiter engine dependency & fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,9 +85,16 @@ configure(sourceProjects()) {
 
         testCompile project(":portability-test-utilities")
         testCompile "com.google.truth:truth:${truthVersion}"
-        testCompile "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
         testCompile "org.junit.vintage:junit-vintage-engine:${junitJupiterVersion}"
         testCompile "org.mockito:mockito-core:${mockitoVersion}"
+        testImplementation("org.junit.jupiter:junit-jupiter:${junitJupiterVersion}")
+    }
+
+    test {
+        useJUnitPlatform()
+        testLogging {
+            events "passed", "skipped", "failed"
+        }
     }
 
     task sourcesJar(type: Jar) {
@@ -155,7 +162,7 @@ def configurePublication(Project project) {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
                 repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2") {
-                        authentication(userName: project.hasProperty('ossrhUsername') ? ossrhUsername : '', password: project.hasProperty('ossrhPassword') ? ossrhPassword : '')
+                    authentication(userName: project.hasProperty('ossrhUsername') ? ossrhUsername : '', password: project.hasProperty('ossrhPassword') ? ossrhPassword : '')
                 }
 
                 snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
@@ -42,9 +42,10 @@ import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
+import org.junit.Before;
 import org.junit.Rule;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
@@ -57,7 +58,7 @@ public class BackblazePhotosImporterTest {
     TokenSecretAuthData authData;
     BackblazeDataTransferClient client;
 
-    @BeforeEach
+    @Before
     public void setUp() {
         monitor = mock(Monitor.class);
         dataStore = mock(TemporaryPerJobDataStore.class);

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
@@ -39,9 +39,9 @@ import org.datatransferproject.transfer.ImageStreamProvider;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
+import org.junit.Before;
 import org.junit.Rule;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
@@ -57,7 +57,7 @@ public class BackblazeVideosImporterTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    @BeforeEach
+    @Before
     public void setUp() {
         monitor = mock(Monitor.class);
         dataStore = mock(TemporaryPerJobDataStore.class);

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporterTest.java
@@ -47,9 +47,9 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempoten
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.junit.Before;
 import org.junit.Rule;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 
@@ -62,9 +62,10 @@ public class DaybookPhotosImporterTest {
   private PhotosContainerResource data;
   private OkHttpClient client;
 
-  @Rule public TemporaryFolder folder = new TemporaryFolder();
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
 
-  @BeforeEach
+  @Before
   public void setUp() {
     monitor = mock(Monitor.class);
     jobStore = mock(TemporaryPerJobDataStore.class);

--- a/portability-api/src/test/java/org/datatransferproject/api/auth/PortabilityAuthServiceExtensionRegistryTest.java
+++ b/portability-api/src/test/java/org/datatransferproject/api/auth/PortabilityAuthServiceExtensionRegistryTest.java
@@ -30,7 +30,8 @@ import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
 import org.junit.Assert;
 import org.junit.Rule;
-import org.junit.jupiter.api.Test;
+
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class PortabilityAuthServiceExtensionRegistryTest {


### PR DESCRIPTION
* Added Jupiter engine dependency
* Added Unit test logging indicating test run state.
* Fixes the issue where some Junit5 tests might not be picked up & tested.
* Modified Junit5 @Test to Junit4 annotations on files that require other migration to be done before upgrading, which might fail if updated now. (eg) @Rule is not supported in Junit5 @Test classes