### PR TITLE
Fix skipping not found videos for Koofr

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporter.java
@@ -39,6 +39,8 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 public class KoofrVideosImporter
     implements Importer<TokensAndUrlAuthData, VideosContainerResource> {
 
+  private static final String SKIPPED_FILE_RESULT_FORMAT = "skipped-%s";
+
   private final KoofrClientFactory koofrClientFactory;
   private final ImageStreamProvider imageStreamProvider;
   private final Monitor monitor;
@@ -141,7 +143,7 @@ public class KoofrVideosImporter
     } catch (FileNotFoundException e) {
       monitor.info(
               () -> String.format("Video resource was missing for id: %s", video.getDataId()), e);
-      return null;
+      return String.format(SKIPPED_FILE_RESULT_FORMAT, video.getDataId());
     }
   }
 }


### PR DESCRIPTION
When video is imported to Koofr and it was not found in CDN, such video should be skipped.
Currently null is returned instead path to video, which breaks creation of successfull ItemImportResult, which requires non-null data.

Short-term solution: return dynamic skipped filepath based on video id.

Potential long term solution: introduce skipped result