### PR TITLE
Skip photos if album was deleted during transfer

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/common/KoofrClient.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/common/KoofrClient.java
@@ -103,9 +103,7 @@ public class KoofrClient {
       if (code == 404) {
         return false;
       }
-      ResponseBody body = response.body();
-      String bodyAsString = body != null ? body.string(): null;
-      throw new KoofrClientIOException(code, response.message(), bodyAsString);
+      throw new KoofrClientIOException(response);
     }
   }
 
@@ -135,13 +133,7 @@ public class KoofrClient {
       int code = response.code();
       // 409 response code means that the folder already exists
       if ((code < 200 || code > 299) && code != 409) {
-        throw new IOException(
-            "Got error code: "
-                + code
-                + " message: "
-                + response.message()
-                + " body: "
-                + response.body().string());
+       throw new KoofrClientIOException(response);
       }
     }
   }
@@ -173,9 +165,7 @@ public class KoofrClient {
     try (Response response = getResponse(requestBuilder)) {
       int code = response.code();
       if ((code < 200 || code > 299) && code != 409) {
-        ResponseBody responseBody = response.body();
-        String responseBodyAsString = responseBody != null ? responseBody.string(): null;
-        throw new KoofrClientIOException(code, response.message(), responseBodyAsString);
+        throw new KoofrClientIOException(response);
       }
     }
   }
@@ -217,7 +207,7 @@ public class KoofrClient {
 
     // We need to reset the input stream because the request could already read some data
     try (Response response =
-        getResponse(fileUploadClient, requestBuilder, () -> inputStream.reset())) {
+        getResponse(fileUploadClient, requestBuilder, inputStream::reset)) {
       int code = response.code();
       ResponseBody body = response.body();
       if (code == 413) {
@@ -225,8 +215,7 @@ public class KoofrClient {
             "Koofr quota exceeded", new Exception("Koofr file upload response code " + code));
       }
       if (code < 200 || code > 299) {
-        String bodyAsString = body != null ? body.string(): null;
-        throw new KoofrClientIOException(code, response.message(), bodyAsString);
+        throw new KoofrClientIOException(response);
       }
 
       Map<String, Object> responseData = objectMapper.readValue(body.bytes(), Map.class);
@@ -260,8 +249,7 @@ public class KoofrClient {
       }
       ResponseBody body = response.body();
       if (code < 200 || code > 299) {
-        String bodyAsString = body != null ? body.string(): null;
-        throw new KoofrClientIOException(code, response.message(), bodyAsString);
+        throw new KoofrClientIOException(response);
       }
 
       try (final Reader bodyReader =
@@ -297,8 +285,7 @@ public class KoofrClient {
       int code = response.code();
       ResponseBody body = response.body();
       if (code < 200 || code > 299) {
-        String bodyAsString = body != null ? body.string(): null;
-        throw new KoofrClientIOException(code, response.message(), bodyAsString);
+        throw new KoofrClientIOException(response);
       }
 
       Map<String, Object> responseData = objectMapper.readValue(body.bytes(), Map.class);

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/common/KoofrClient.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/common/KoofrClient.java
@@ -42,6 +42,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
+import org.datatransferproject.transfer.koofr.exceptions.KoofrClientIOException;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 /** A minimal Koofr REST API client. */
@@ -102,13 +103,9 @@ public class KoofrClient {
       if (code == 404) {
         return false;
       }
-      throw new IOException(
-          "Got error code: "
-              + code
-              + " message: "
-              + response.message()
-              + " body: "
-              + response.body().string());
+      ResponseBody body = response.body();
+      String bodyAsString = body != null ? body.string(): null;
+      throw new KoofrClientIOException(code, response.message(), bodyAsString);
     }
   }
 
@@ -176,13 +173,9 @@ public class KoofrClient {
     try (Response response = getResponse(requestBuilder)) {
       int code = response.code();
       if ((code < 200 || code > 299) && code != 409) {
-        throw new IOException(
-            "Got error code: "
-                + code
-                + " message: "
-                + response.message()
-                + " body: "
-                + response.body().string());
+        ResponseBody responseBody = response.body();
+        String responseBodyAsString = responseBody != null ? responseBody.string(): null;
+        throw new KoofrClientIOException(code, response.message(), responseBodyAsString);
       }
     }
   }
@@ -232,13 +225,8 @@ public class KoofrClient {
             "Koofr quota exceeded", new Exception("Koofr file upload response code " + code));
       }
       if (code < 200 || code > 299) {
-        throw new IOException(
-            "Got error code: "
-                + code
-                + " message: "
-                + response.message()
-                + " body: "
-                + body.string());
+        String bodyAsString = body != null ? body.string(): null;
+        throw new KoofrClientIOException(code, response.message(), bodyAsString);
       }
 
       Map<String, Object> responseData = objectMapper.readValue(body.bytes(), Map.class);
@@ -272,13 +260,8 @@ public class KoofrClient {
       }
       ResponseBody body = response.body();
       if (code < 200 || code > 299) {
-        throw new IOException(
-            "Got error code: "
-                + code
-                + " message: "
-                + response.message()
-                + " body: "
-                + body.string());
+        String bodyAsString = body != null ? body.string(): null;
+        throw new KoofrClientIOException(code, response.message(), bodyAsString);
       }
 
       try (final Reader bodyReader =
@@ -314,13 +297,8 @@ public class KoofrClient {
       int code = response.code();
       ResponseBody body = response.body();
       if (code < 200 || code > 299) {
-        throw new IOException(
-            "Got error code: "
-                + code
-                + " message: "
-                + response.message()
-                + " body: "
-                + body.string());
+        String bodyAsString = body != null ? body.string(): null;
+        throw new KoofrClientIOException(code, response.message(), bodyAsString);
       }
 
       Map<String, Object> responseData = objectMapper.readValue(body.bytes(), Map.class);

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/exceptions/KoofrClientIOException.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/exceptions/KoofrClientIOException.java
@@ -1,0 +1,20 @@
+package org.datatransferproject.transfer.koofr.exceptions;
+
+import java.io.IOException;
+
+public class KoofrClientIOException extends IOException {
+
+    private final int code;
+
+    public KoofrClientIOException(int code,
+                                  String message,
+                                  String body) {
+        super(String.format("Got error code: %s message: %s body: %s", code, message, body));
+
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/exceptions/KoofrClientIOException.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/exceptions/KoofrClientIOException.java
@@ -1,20 +1,33 @@
 package org.datatransferproject.transfer.koofr.exceptions;
 
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
 import java.io.IOException;
 
 public class KoofrClientIOException extends IOException {
 
-    private final int code;
+  private final int httpResponseCode;
 
-    public KoofrClientIOException(int code,
-                                  String message,
-                                  String body) {
-        super(String.format("Got error code: %s message: %s body: %s", code, message, body));
+  public KoofrClientIOException(Response response) {
+    super(
+        String.format(
+            "Got error code: %s message: %s body: %s",
+            response.code(), response.message(), getResponseBody(response)));
 
-        this.code = code;
+    this.httpResponseCode = response.code();
+  }
+
+  public int getCode() {
+    return httpResponseCode;
+  }
+
+  private static String getResponseBody(Response response) {
+    try {
+      ResponseBody body = response.body();
+      return body != null ? body.string() : null;
+    } catch (Exception e) {
+      return "Failed to get response body";
     }
-
-    public int getCode() {
-        return code;
-    }
+  }
 }

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/common/KoofrClientTest.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/common/KoofrClientTest.java
@@ -177,22 +177,18 @@ public class KoofrClientTest {
   }
 
   @Test
-  public void testFileExistsError() throws Exception {
+  public void testFileExistsError() {
     server.enqueue(new MockResponse().setResponseCode(500).setBody("Internal error"));
 
-    Exception caughtExc = null;
+    KoofrClientIOException caughtExc =
+        Assertions.assertThrows(
+            KoofrClientIOException.class, () -> client.fileExists("/path/to/file"));
 
-    try {
-      client.fileExists("/path/to/file");
-    } catch (Exception exc) {
-      caughtExc = exc;
-    }
-
-    Assert.assertNotNull(caughtExc);
-    Assert.assertEquals(
+    Assertions.assertNotNull(caughtExc);
+    Assertions.assertEquals(
         "Got error code: 500 message: Server Error body: Internal error", caughtExc.getMessage());
 
-    Assert.assertEquals(1, server.getRequestCount());
+    Assertions.assertEquals(1, server.getRequestCount());
   }
 
   @Test
@@ -280,22 +276,18 @@ public class KoofrClientTest {
   }
 
   @Test
-  public void testEnsureFolderError() throws Exception {
+  public void testEnsureFolderError() {
     server.enqueue(new MockResponse().setResponseCode(500).setBody("Internal error"));
 
-    Exception caughtExc = null;
+    KoofrClientIOException caughtExc =
+        Assert.assertThrows(
+            KoofrClientIOException.class, () -> client.ensureFolder("/path/to/folder", "name"));
 
-    try {
-      client.ensureFolder("/path/to/folder", "name");
-    } catch (Exception exc) {
-      caughtExc = exc;
-    }
-
-    Assert.assertNotNull(caughtExc);
-    Assert.assertEquals(
+    Assertions.assertNotNull(caughtExc);
+    Assertions.assertEquals(
         "Got error code: 500 message: Server Error body: Internal error", caughtExc.getMessage());
 
-    Assert.assertEquals(1, server.getRequestCount());
+    Assertions.assertEquals(1, server.getRequestCount());
   }
 
   @Test
@@ -368,22 +360,19 @@ public class KoofrClientTest {
   }
 
   @Test
-  public void testAddDescriptionError() throws Exception {
+  public void testAddDescriptionError() {
     server.enqueue(new MockResponse().setResponseCode(500).setBody("Internal error"));
 
-    Exception caughtExc = null;
+    Exception caughtExc =
+        Assert.assertThrows(
+            KoofrClientIOException.class,
+            () -> client.addDescription("/path/to/folder", "Test description"));
 
-    try {
-      client.addDescription("/path/to/folder", "Test description");
-    } catch (Exception exc) {
-      caughtExc = exc;
-    }
-
-    Assert.assertNotNull(caughtExc);
-    Assert.assertEquals(
+    Assertions.assertNotNull(caughtExc);
+    Assertions.assertEquals(
         "Got error code: 500 message: Server Error body: Internal error", caughtExc.getMessage());
 
-    Assert.assertEquals(1, server.getRequestCount());
+    Assertions.assertEquals(1, server.getRequestCount());
   }
 
   @Test
@@ -395,7 +384,7 @@ public class KoofrClientTest {
             .setBody(
                 "{\"name\":\"image.jpg\",\"type\":\"file\",\"modified\":1591868314156,\"size\":5,\"contentType\":\"image/jpeg\",\"hash\":\"d05374dc381d9b52806446a71c8e79b1\",\"tags\":{}}"));
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4});
+    final InputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
     String fullPath =
         client.uploadFile("/path/to/folder", "image.jpg", inputStream, "image/jpeg", null, null);
     Assert.assertEquals("/path/to/folder/image.jpg", fullPath);
@@ -423,7 +412,7 @@ public class KoofrClientTest {
             .setBody(
                 "{\"name\":\"image.jpg\",\"type\":\"file\",\"modified\":1591868314156,\"size\":5,\"contentType\":\"image/jpeg\",\"hash\":\"d05374dc381d9b52806446a71c8e79b1\",\"tags\":{}}"));
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4});
+    final InputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
     final Date modified = new Date(1596450052000L);
     String fullPath =
         client.uploadFile(
@@ -453,7 +442,7 @@ public class KoofrClientTest {
             .setBody(
                 "{\"name\":\"image.jpg\",\"type\":\"file\",\"modified\":1591868314156,\"size\":5,\"contentType\":\"image/jpeg\",\"hash\":\"d05374dc381d9b52806446a71c8e79b1\",\"tags\":{}}"));
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4});
+    final InputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
     String fullPath =
         client.uploadFile(
             "/path/to/folder", "image.jpg", inputStream, "image/jpeg", null, "Test description");
@@ -482,7 +471,7 @@ public class KoofrClientTest {
             .setBody(
                 "{\"name\":\"image (1).jpg\",\"type\":\"file\",\"modified\":1591868314156,\"size\":5,\"contentType\":\"image/jpeg\",\"hash\":\"d05374dc381d9b52806446a71c8e79b1\",\"tags\":{}}"));
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4});
+    final InputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
     String fullPath =
         client.uploadFile("/path/to/folder", "image.jpg", inputStream, "image/jpeg", null, null);
     Assert.assertEquals("/path/to/folder/image (1).jpg", fullPath);
@@ -510,7 +499,7 @@ public class KoofrClientTest {
             .setBody(
                 "{\"error\":{\"code\":\"QuotaExceeded\",\"message\":\"Quota exceeded\"},\"requestId\":\"bad2465e-300e-4079-57ad-46b256e74d21\"}"));
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4});
+    final InputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
 
     DestinationMemoryFullException caughtExc = null;
 
@@ -555,7 +544,7 @@ public class KoofrClientTest {
             .setBody(
                 "{\"name\":\"image.jpg\",\"type\":\"file\",\"modified\":1591868314156,\"size\":5,\"contentType\":\"image/jpeg\",\"hash\":\"d05374dc381d9b52806446a71c8e79b1\",\"tags\":{}}"));
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4});
+    final InputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
     String fullPath =
         client.uploadFile("/path/to/folder", "image.jpg", inputStream, "image/jpeg", null, null);
     Assert.assertEquals("/path/to/folder/image.jpg", fullPath);
@@ -586,18 +575,17 @@ public class KoofrClientTest {
   }
 
   @Test
-  public void testUploadFileError() throws Exception {
+  public void testUploadFileError() {
     server.enqueue(new MockResponse().setResponseCode(500).setBody("Internal error"));
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4});
+    final InputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
 
-    Exception caughtExc = null;
-
-    try {
-      client.uploadFile("/path/to/folder", "image.jpg", inputStream, "image/jpeg", null, null);
-    } catch (Exception exc) {
-      caughtExc = exc;
-    }
+    Exception caughtExc =
+        Assert.assertThrows(
+            KoofrClientIOException.class,
+            () ->
+                client.uploadFile(
+                    "/path/to/folder", "image.jpg", inputStream, "image/jpeg", null, null));
 
     Assert.assertNotNull(caughtExc);
     Assert.assertEquals(
@@ -609,19 +597,26 @@ public class KoofrClientTest {
   @Test
   public void testUploadFileNotFound() {
     server.enqueue(
-            new MockResponse()
-                    .setResponseCode(404)
-                    .setHeader("Content-Type", "application/json")
-                    .setBody(
-                            "{\"error\":{\"code\":\"NotFound\",\"message\":\"File not found\"},\"requestId\":\"bad2465e-300e-4079-57ad-46b256e74d21\"}"));
+        new MockResponse()
+            .setResponseCode(404)
+            .setHeader("Content-Type", "application/json")
+            .setBody(
+                "{\"error\":{\"code\":\"NotFound\",\"message\":\"File not found\"},\"requestId\":\"bad2465e-300e-4079-57ad-46b256e74d21\"}"));
 
-    final InputStream inputStream = new ByteArrayInputStream(new byte[]{0, 1, 2, 3, 4});
+    final InputStream inputStream = new ByteArrayInputStream(new byte[] {0, 1, 2, 3, 4});
 
-    KoofrClientIOException caughtException = Assertions.assertThrows(KoofrClientIOException.class, () -> client.uploadFile("/path/to/folder", "image.jpg", inputStream, "image/jpeg", null, null));
+    KoofrClientIOException caughtException =
+        Assertions.assertThrows(
+            KoofrClientIOException.class,
+            () ->
+                client.uploadFile(
+                    "/path/to/folder", "image.jpg", inputStream, "image/jpeg", null, null));
 
     Assertions.assertNotNull(caughtException);
     Assertions.assertEquals(404, caughtException.getCode());
-    Assertions.assertEquals("Got error code: 404 message: Client Error body: {\"error\":{\"code\":\"NotFound\",\"message\":\"File not found\"},\"requestId\":\"bad2465e-300e-4079-57ad-46b256e74d21\"}", caughtException.getMessage());
+    Assertions.assertEquals(
+        "Got error code: 404 message: Client Error body: {\"error\":{\"code\":\"NotFound\",\"message\":\"File not found\"},\"requestId\":\"bad2465e-300e-4079-57ad-46b256e74d21\"}",
+        caughtException.getMessage());
 
     Assertions.assertEquals(1, server.getRequestCount());
   }


### PR DESCRIPTION
Summary:
Upload File endpoint will return 404 when album was deleted in the middle of transfer, such photos should be skipped.

Introducted KoofrClientIOException in order to get code in importer and have centralized error message formatting