### PR TITLE
issue-963 Add uploadedTime property to VideoModel

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
@@ -111,7 +111,7 @@ public class BackblazeVideosImporterTest {
         UUID jobId = UUID.randomUUID();
 
         VideoModel videoObject =
-                new VideoModel(title, videoUrl, description, encodingFormat, dataId, albumId, false);
+                new VideoModel(title, videoUrl, description, encodingFormat, dataId, albumId, false, null);
         ArrayList<VideoModel> videos = new ArrayList<>();
         videos.add(videoObject);
         VideosContainerResource data = mock(VideosContainerResource.class);

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporter.java
@@ -100,7 +100,8 @@ public class FacebookVideosExporter
                 "video/mp4",
                 fbid,
                 null,
-                false));
+                false,
+                video.getCreatedTime()));
       }
 
       String token = videoConnection.getAfterCursor();

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosExporterTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.restfb.Connection;
 import com.restfb.types.Video;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
@@ -40,6 +41,7 @@ public class FacebookVideosExporterTest {
   private static final String VIDEO_ID = "937644721";
   private static final String VIDEO_SOURCE = "https://www.example.com/video.mp4";
   private static final String VIDEO_NAME = "Example video";
+  private static final Date VIDEO_TIME = new Date(1234567890123L);
 
   private FacebookVideosExporter facebookVideosExporter;
   private UUID uuid = UUID.randomUUID();
@@ -53,6 +55,7 @@ public class FacebookVideosExporterTest {
     video.setId(VIDEO_ID);
     video.setSource(VIDEO_SOURCE);
     video.setDescription(VIDEO_NAME);
+    video.setCreatedTime(VIDEO_TIME);
 
     ArrayList<Video> videos = new ArrayList<>();
     videos.add(video);
@@ -69,6 +72,9 @@ public class FacebookVideosExporterTest {
 
   @Test
   public void testExportVideo() throws CopyExceptionWithFailureReason {
+    VideoModel expectedVideo = new VideoModel(VIDEO_ID + ".mp4", VIDEO_SOURCE, VIDEO_NAME,
+        "video/mp4", VIDEO_ID, null, false, VIDEO_TIME);
+
     ExportResult<VideosContainerResource> result =
         facebookVideosExporter.export(
             uuid,
@@ -78,9 +84,6 @@ public class FacebookVideosExporterTest {
     assertEquals(ExportResult.ResultType.END, result.getType());
     VideosContainerResource exportedData = result.getExportedData();
     assertEquals(1, exportedData.getVideos().size());
-    assertEquals(
-        new VideoModel(
-            VIDEO_ID + ".mp4", VIDEO_SOURCE, VIDEO_NAME, "video/mp4", VIDEO_ID, null, false),
-        exportedData.getVideos().toArray()[0]);
+    assertEquals(expectedVideo, exportedData.getVideos().toArray()[0]);
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/test/java/org/datatransferproject/transfer/facebook/videos/FacebookVideosImporterTest.java
@@ -42,7 +42,7 @@ public class FacebookVideosImporterTest {
     importer.importSingleVideo(
         client,
         new VideoModel(
-            "title", VIDEO_URL, VIDEO_DESCRIPTION, "video/mp4", "videoId", null, false));
+            "title", VIDEO_URL, VIDEO_DESCRIPTION, "video/mp4", "videoId", null, false, null));
 
     Parameter[] params = {
         Parameter.with("file_url", VIDEO_URL), Parameter.with("description", VIDEO_DESCRIPTION)

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosExporter.java
@@ -124,7 +124,8 @@ public class GoogleVideosExporter
             mediaItem.getMimeType(),
             mediaItem.getId(),
             null,
-            false);
+            false,
+            null);
   }
 
   private synchronized GoogleVideosInterface getOrCreateVideosInterface(

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporterTest.java
@@ -135,7 +135,8 @@ public class GoogleVideosImporterTest {
                     MP4_MEDIA_TYPE,
                     VIDEO_ID,
                     null,
-                    false),
+                    false,
+                    null),
                 new VideoModel(
                     VIDEO_TITLE,
                     VIDEO_URI,
@@ -143,7 +144,8 @@ public class GoogleVideosImporterTest {
                     MP4_MEDIA_TYPE,
                     "myId2",
                     null,
-                    false)),
+                    false,
+                    null)),
             photosLibraryClient,
             executor);
     assertEquals("Expected the number of bytes to be the two files of 32L.", 64L, length);
@@ -193,7 +195,8 @@ public class GoogleVideosImporterTest {
                     MP4_MEDIA_TYPE,
                     VIDEO_ID,
                     null,
-                    false),
+                    false,
+                    null),
                 new VideoModel(
                     VIDEO_TITLE,
                     VIDEO_URI,
@@ -201,7 +204,8 @@ public class GoogleVideosImporterTest {
                     MP4_MEDIA_TYPE,
                     "myId2",
                     null,
-                    false)),
+                    false,
+                    null)),
             photosLibraryClient,
             executor);
 
@@ -234,7 +238,8 @@ public class GoogleVideosImporterTest {
                     MP4_MEDIA_TYPE,
                     VIDEO_ID,
                     null,
-                    false)),
+                    false,
+                    null)),
             photosLibraryClient,
             executor);
     assertEquals("Expected the number of bytes to be 0L.", 0L, length);
@@ -258,7 +263,7 @@ public class GoogleVideosImporterTest {
             + "7890";
     final VideoModel videoModel =
         new VideoModel(
-            VIDEO_TITLE, VIDEO_URI, videoDescriptionOver1k, MP4_MEDIA_TYPE, VIDEO_ID, null, false);
+            VIDEO_TITLE, VIDEO_URI, videoDescriptionOver1k, MP4_MEDIA_TYPE, VIDEO_ID, null, false, null);
 
     String uploadToken = "token";
     NewMediaItem newMediaItemResult = googleVideosImporter.buildMediaItem(videoModel, uploadToken);
@@ -305,7 +310,8 @@ public class GoogleVideosImporterTest {
                     MP4_MEDIA_TYPE,
                     VIDEO_ID,
                     null,
-                    true)),
+                    true,
+                    null)),
             photosLibraryClient,
             executor);
     assertThat(length).isEqualTo(32);
@@ -330,7 +336,8 @@ public class GoogleVideosImporterTest {
                 MP4_MEDIA_TYPE,
                 VIDEO_ID,
                 null,
-                true)),
+                true,
+                null)),
         mock(PhotosLibraryClient.class),
         executor);
     // should only remove the video from temp store upon success

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/common/KoofrMediaExport.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/common/KoofrMediaExport.java
@@ -117,7 +117,8 @@ public class KoofrMediaExport {
               video.getEncodingFormat(),
               video.getDataId(),
               video.getAlbumId(),
-              video.isInTempStore()));
+              video.isInTempStore(),
+              video.getUploadedTime()));
     }
 
     return exportVideos;
@@ -193,13 +194,14 @@ public class KoofrMediaExport {
     String name = getFileName(file);
     String description = getFileDescription(file);
     String contentType = file.getContentType();
+    Date uploadedTime = new Date(file.getModified());
     String fullPath = rootPath + path;
 
     albumsWithVideos.add(albumId);
 
     VideoObjectContainer container = new VideoObjectContainer();
     container.videoModel =
-        new VideoModel(name, "", description, contentType, videoId, albumId, false);
+        new VideoModel(name, "", description, contentType, videoId, albumId, false, uploadedTime);
     container.fullPath = fullPath;
 
     videos.add(container);

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporter.java
@@ -35,7 +35,9 @@ import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
-/** Imports albums and videos to Koofr. */
+/**
+ * Imports videos and their albums to Koofr.
+ */
 public class KoofrVideosImporter
     implements Importer<TokensAndUrlAuthData, VideosContainerResource> {
 

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosExporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosExporterTest.java
@@ -6,6 +6,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -76,7 +79,8 @@ public class KoofrVideosExporterTest {
                 "video/mp4",
                 "/Album 2 :heart:/Video 1.mp4",
                 "/Album 2 :heart:",
-                false),
+                false,
+                Date.from(Instant.parse("2020-09-04T12:40:57.741Z"))),
             new VideoModel(
                 "Video 2.mp4",
                 "https://app-1.koofr.net/content/files/get/Video+2.mp4?base=TESTBASE",
@@ -84,7 +88,8 @@ public class KoofrVideosExporterTest {
                 "video/mp4",
                 "/Videos/Video 2.mp4",
                 "/Videos",
-                false));
+                false,
+                Date.from(Instant.parse("2020-09-04T12:41:06.949Z"))));
     assertEquals(expectedVideos, exportedData.getVideos());
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/test/java/org/datatransferproject/transfer/koofr/videos/KoofrVideosImporterTest.java
@@ -104,7 +104,8 @@ public class KoofrVideosImporterTest {
                 "video/mp4",
                 "video1",
                 "id1",
-                false),
+                false,
+                null),
             new VideoModel(
                 "video2.mp4",
                 server.url("/2.mp4").toString(),
@@ -112,7 +113,8 @@ public class KoofrVideosImporterTest {
                 "video/mp4",
                 "video2",
                 "id1",
-                false),
+                false,
+                null),
             new VideoModel(
                 "video3.mp4",
                 server.url("/3.mp4").toString(),
@@ -120,7 +122,8 @@ public class KoofrVideosImporterTest {
                 "video/mp4",
                 "video3",
                 "id2",
-                false));
+                false,
+                null));
 
     VideosContainerResource resource = spy(new VideosContainerResource(albums, videos));
 
@@ -176,7 +179,8 @@ public class KoofrVideosImporterTest {
                 "video/mp4",
                 "video1",
                 null,
-                false),
+                false,
+                null),
             new VideoModel(
                 "video2.mp4",
                 server.url("/2.mp4").toString(),
@@ -184,7 +188,8 @@ public class KoofrVideosImporterTest {
                 "video/mp4",
                 "video2",
                 null,
-                false));
+                false,
+                null));
 
     VideosContainerResource resource = spy(new VideosContainerResource(albums, videos));
 
@@ -224,15 +229,16 @@ public class KoofrVideosImporterTest {
     Collection<VideoAlbum> albums = ImmutableList.of();
 
     Collection<VideoModel> videos =
-        ImmutableList.of(
-            new VideoModel(
-                "not_found_video_1.mp4",
-                server.url("/not_found.mp4").toString(),
-                "Video not founded in CDN",
-                "video/mp4",
-                "not_found_video_1",
-                null,
-                false));
+            ImmutableList.of(
+                    new VideoModel(
+                            "not_found_video_1.mp4",
+                            server.url("/not_found.mp4").toString(),
+                            "Video not founded in CDN",
+                            "video/mp4",
+                            "not_found_video_1",
+                            null,
+                            false,
+                            null));
 
     VideosContainerResource resource = spy(new VideosContainerResource(albums, videos));
 

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/media/MicrosoftMediaExporter.java
@@ -179,7 +179,7 @@ public class MicrosoftMediaExporter
 
     VideoModel video =
         new VideoModel(driveItem.name, driveItem.downloadUrl, driveItem.description,
-            driveItem.file.mimeType, driveItem.id, albumId.orElse(null), false /*inTempStore*/);
+            driveItem.file.mimeType, driveItem.id, albumId.orElse(null), false /*inTempStore*/, null);
     monitor.debug(
         () -> String.format("%s: Microsoft OneDrive exporting video: %s", jobId, video));
     return video;

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/MediaExporterDecoratorTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/MediaExporterDecoratorTest.java
@@ -48,9 +48,9 @@ public class MediaExporterDecoratorTest {
         new PhotoModel("p3", "", null, null, "d3", "a2", false, null, null));
 
     videos = List.of(
-        new VideoModel("v1", "", null, null, "d4", null, false),
-        new VideoModel("v2", "", null, null, "d5", "a3", false),
-        new VideoModel("v3", "", null, null, "d6", null, false));
+        new VideoModel("v1", "", null, null, "d4", null, false, null),
+        new VideoModel("v2", "", null, null, "d5", "a3", false, null),
+        new VideoModel("v3", "", null, null, "d6", null, false, null));
   }
 
   @Test

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/MediaImporterDecoratorTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/MediaImporterDecoratorTest.java
@@ -41,9 +41,9 @@ public class MediaImporterDecoratorTest {
         new PhotoModel("p3", "", null, null, "d3", "a2", false, null, null));
 
     videos = List.of(
-        new VideoModel("v1", "", null, null, "d4", null, false),
-        new VideoModel("v2", "", null, null, "d5", "a3", false),
-        new VideoModel("v3", "", null, null, "d6", null, false));
+        new VideoModel("v1", "", null, null, "d4", null, false, null),
+        new VideoModel("v2", "", null, null, "d5", "a3", false, null),
+        new VideoModel("v3", "", null, null, "d6", null, false, null));
   }
 
   @Test

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideoModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/videos/VideoModel.java
@@ -21,26 +21,28 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import java.util.Date;
+import java.util.stream.Collectors;
 import org.datatransferproject.types.common.DownloadableFile;
 import org.datatransferproject.types.common.models.MediaObject;
-
-import java.util.stream.Collectors;
 
 public class VideoModel extends MediaObject implements DownloadableFile {
 
   private String dataId;
   private String albumId;
   private boolean inTempStore;
+  private Date uploadedTime;
 
   @JsonCreator
   public VideoModel(
-          @JsonProperty("name") String name,
-          @JsonProperty("contentUrl") String contentUrl,
-          @JsonProperty("description") String description,
-          @JsonProperty("encodingFormat") String encodingFormat,
-          @JsonProperty("dataId") String dataId,
-          @JsonProperty("albumId") String albumId,
-          @JsonProperty("inTempStore") boolean inTempStore) {
+      @JsonProperty("name") String name,
+      @JsonProperty("contentUrl") String contentUrl,
+      @JsonProperty("description") String description,
+      @JsonProperty("encodingFormat") String encodingFormat,
+      @JsonProperty("dataId") String dataId,
+      @JsonProperty("albumId") String albumId,
+      @JsonProperty("inTempStore") boolean inTempStore,
+      @JsonProperty("uploadedTime") Date uploadedTime) {
     super(dataId);
     setName(name);
     setContentUrl(contentUrl);
@@ -49,6 +51,7 @@ public class VideoModel extends MediaObject implements DownloadableFile {
     this.dataId = dataId;
     this.albumId = albumId;
     this.inTempStore = inTempStore;
+    this.uploadedTime = uploadedTime;
   }
 
   // TODO(zacsh) remove this in favor of getFolderId
@@ -90,36 +93,46 @@ public class VideoModel extends MediaObject implements DownloadableFile {
     return super.getName();
   }
 
+  public Date getUploadedTime() {
+    return uploadedTime;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-            .add("name", getName())
-            .add("contentUrl", getContentUrl())
-            .add("description", getDescription())
-            .add("encodingFormat", getEncodingFormat())
-            .add("dataId", dataId)
-            .add("albumId", albumId)
-            .add("inTempStore", inTempStore)
-            .toString();
+        .add("name", getName())
+        .add("contentUrl", getContentUrl())
+        .add("description", getDescription())
+        .add("encodingFormat", getEncodingFormat())
+        .add("dataId", dataId)
+        .add("albumId", albumId)
+        .add("inTempStore", inTempStore)
+        .add("uploadedTime", uploadedTime)
+        .toString();
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     VideoModel that = (VideoModel) o;
     return Objects.equal(getName(), that.getName()) &&
-            Objects.equal(getContentUrl(), that.getContentUrl()) &&
-            Objects.equal(getDescription(), that.getDescription()) &&
-            Objects.equal(getEncodingFormat(), that.getEncodingFormat()) &&
-            Objects.equal(getDataId(), that.getDataId()) &&
-            Objects.equal(getAlbumId(), that.getAlbumId());
+        Objects.equal(getContentUrl(), that.getContentUrl()) &&
+        Objects.equal(getDescription(), that.getDescription()) &&
+        Objects.equal(getEncodingFormat(), that.getEncodingFormat()) &&
+        Objects.equal(getDataId(), that.getDataId()) &&
+        Objects.equal(getAlbumId(), that.getAlbumId()) &&
+        Objects.equal(getUploadedTime(), that.getUploadedTime());
   }
 
   // Assign this video to a different album. Used in cases where an album is too large and
   // needs to be divided into smaller albums, the videos will each get reassigned to new
   // albumnIds.
-  public void reassignToAlbum(String newAlbum){
+  public void reassignToAlbum(String newAlbum) {
     this.albumId = newAlbum;
   }
 

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
@@ -388,8 +388,10 @@ public class MediaContainerResourceTest {
     List<VideoAlbum> videoAlbums =
         ImmutableList.of(new VideoAlbum("id1", "albumb1", "This:a fake album!"));
     List<VideoModel> videos = ImmutableList.of(
-        new VideoModel("Vid1", "http://fake.com/1.mp4", "A vid", "mediatype", "p1", "id1", false),
-        new VideoModel("Vid3", "http://fake.com/2.mp4", "A vid", "mediatype", "p3", "id1", false));
+        new VideoModel(
+            "Vid1", "http://fake.com/1.mp4", "A vid", "mediatype", "p1", "id1", false, null),
+        new VideoModel(
+            "Vid3", "http://fake.com/2.mp4", "A vid", "mediatype", "p3", "id1", false, null));
     MediaContainerResource data = new MediaContainerResource(mediaAlbums, null, videos);
 
     VideosContainerResource expected = new VideosContainerResource(videoAlbums, videos);
@@ -404,8 +406,10 @@ public class MediaContainerResourceTest {
     List<VideoAlbum> videoAlbums =
         ImmutableList.of(new VideoAlbum("id1", "albumb1", "This:a fake album!"));
     List<VideoModel> videos = ImmutableList.of(
-        new VideoModel("Vid1", "http://fake.com/1.mp4", "A vid", "mediatype", "p1", "id1", false),
-        new VideoModel("Vid3", "http://fake.com/2.mp4", "A vid", "mediatype", "p3", "id1", false));
+        new VideoModel(
+            "Vid1", "http://fake.com/1.mp4", "A vid", "mediatype", "p1", "id1", false, null),
+        new VideoModel(
+            "Vid3", "http://fake.com/2.mp4", "A vid", "mediatype", "p3", "id1", false, null));
     VideosContainerResource data = new VideosContainerResource(videoAlbums, videos);
 
     MediaContainerResource expected = new MediaContainerResource(mediaAlbums, null, videos);

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/videos/VideosContainerResourceTest.java
@@ -35,9 +35,9 @@ public class VideosContainerResourceTest {
     List<VideoModel> videos =
             ImmutableList.of(
                     new VideoModel("Vid1", "http://example.com/1.mp4", "A video", "video/mp4", "v1", "id1",
-                            false),
+                            false, null),
                     new VideoModel(
-                            "Vid2", "https://example.com/2.mpeg", "A 2. video", "video/mpeg", "v2", "id1", false));
+                            "Vid2", "https://example.com/2.mpeg", "A 2. video", "video/mpeg", "v2", "id1", false, null));
     
     ContainerResource data = new VideosContainerResource(albums, videos);
 


### PR DESCRIPTION
Adding `uploadedTime` property to the `VideoModel` to bring it inline with the `PhotoModel` in order to make it easier to set the creation time for transferred videos. 