### PR TITLE
Add automatic media job type compatibility and introduce the DataVertical enum

### DIFF
--- a/extensions/auth/portability-auth-daybook/src/main/java/org/datatransferproject/auth/daybook/DaybookOAuthConfig.java
+++ b/extensions/auth/portability-auth-daybook/src/main/java/org/datatransferproject/auth/daybook/DaybookOAuthConfig.java
@@ -1,10 +1,13 @@
 package org.datatransferproject.auth.daybook;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import org.datatransferproject.auth.OAuth2Config;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that provides Daybook-specific information for OAuth2
@@ -27,12 +30,12 @@ public class DaybookOAuthConfig implements OAuth2Config {
   }
 
   @Override
-  public Map<String, Set<String>> getExportScopes() {
-    return ImmutableMap.of("PHOTOS", ImmutableSet.of("db.read"));
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.of(PHOTOS, ImmutableSet.of("db.read"));
   }
 
   @Override
-  public Map<String, Set<String>> getImportScopes() {
-    return ImmutableMap.of("PHOTOS", ImmutableSet.of("db.write"));
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.of(PHOTOS, ImmutableSet.of("db.write"));
   }
 }

--- a/extensions/auth/portability-auth-deezer/src/main/java/org/datatransferproject/auth/deezer/DeezerOAuthConfig.java
+++ b/extensions/auth/portability-auth-deezer/src/main/java/org/datatransferproject/auth/deezer/DeezerOAuthConfig.java
@@ -16,9 +16,8 @@
 
 package org.datatransferproject.auth.deezer;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.datatransferproject.types.common.models.DataVertical.PLAYLISTS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -27,7 +26,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.datatransferproject.auth.OAuth2Config;
-import org.datatransferproject.auth.OAuth2TokenResponse;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 /**
@@ -56,16 +55,16 @@ public class DeezerOAuthConfig implements OAuth2Config {
 
   // For descriptions of scopes see: https://developers.deezer.com/api/permissions
   @Override
-  public Map<String, Set<String>> getExportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("PLAYLISTS", ImmutableSet.of("offline_access,manage_library"))
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(PLAYLISTS, ImmutableSet.of("offline_access,manage_library"))
         .build();
   }
 
   @Override
-  public Map<String, Set<String>> getImportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("PLAYLISTS", ImmutableSet.of("offline_access,manage_library"))
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(PLAYLISTS, ImmutableSet.of("offline_access,manage_library"))
         .build();
   }
 

--- a/extensions/auth/portability-auth-facebook/src/main/java/org/datatransferproject/auth/facebook/FacebookOAuthConfig.java
+++ b/extensions/auth/portability-auth-facebook/src/main/java/org/datatransferproject/auth/facebook/FacebookOAuthConfig.java
@@ -16,12 +16,16 @@
 
 package org.datatransferproject.auth.facebook;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.datatransferproject.auth.OAuth2Config;
 
 import java.util.Map;
 import java.util.Set;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that supplies Facebook-specific OAuth2 info
@@ -51,18 +55,18 @@ public class FacebookOAuthConfig implements OAuth2Config {
     }
 
     @Override
-    public Map<String, Set<String>> getExportScopes() {
-        return ImmutableMap.<String, Set<String>>builder()
-            .put("PHOTOS", ImmutableSet.of("user_photos"))
-            .put("VIDEOS", ImmutableSet.of("user_videos"))
+    public Map<DataVertical, Set<String>> getExportScopes() {
+        return ImmutableMap.<DataVertical, Set<String>>builder()
+            .put(PHOTOS, ImmutableSet.of("user_photos"))
+            .put(VIDEOS, ImmutableSet.of("user_videos"))
             .build();
     }
 
     @Override
-    public Map<String, Set<String>> getImportScopes() {
-        return ImmutableMap.<String, Set<String>>builder()
-            .put("PHOTOS", ImmutableSet.of("user_photos"))
-            .put("VIDEOS", ImmutableSet.of("user_videos"))
+    public Map<DataVertical, Set<String>> getImportScopes() {
+        return ImmutableMap.<DataVertical, Set<String>>builder()
+            .put(PHOTOS, ImmutableSet.of("user_photos"))
+            .put(VIDEOS, ImmutableSet.of("user_videos"))
             .build();
     }
 }

--- a/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrOAuthConfig.java
+++ b/extensions/auth/portability-auth-flickr/src/main/java/org/datatransferproject/auth/flickr/FlickrOAuthConfig.java
@@ -16,6 +16,8 @@
 
 package org.datatransferproject.auth.flickr;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.datatransferproject.auth.OAuth1Config;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that supplies Flickr-specific OAuth1 info
@@ -53,19 +56,19 @@ public class FlickrOAuthConfig implements OAuth1Config {
   }
 
   @Override
-  public List<String> getExportTypes() {
-    return ImmutableList.of("PHOTOS");
+  public List<DataVertical> getExportTypes() {
+    return ImmutableList.of(PHOTOS);
   }
 
   @Override
-  public List<String> getImportTypes() {
-    return ImmutableList.of("PHOTOS");
+  public List<DataVertical> getImportTypes() {
+    return ImmutableList.of(PHOTOS);
   }
 
   public Map<String, String> getAdditionalUrlParameters(
-      String dataType, AuthMode mode, OAuth1Step step) {
+      DataVertical dataType, AuthMode mode, OAuth1Step step) {
 
-    if (dataType.equals("PHOTOS") && step == OAuth1Step.AUTHORIZATION) {
+    if (dataType.equals(PHOTOS) && step == OAuth1Step.AUTHORIZATION) {
       return (mode == AuthMode.EXPORT)
           ? ImmutableMap.of(PERMS, "read")
           : ImmutableMap.of(PERMS, "write");

--- a/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/BloggerOAuthConfig.java
+++ b/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/BloggerOAuthConfig.java
@@ -16,10 +16,13 @@
 
 package org.datatransferproject.auth.google;
 
+import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that supplies Google Blogger-specific OAuth2 info, this is needed so because multiple
@@ -36,17 +39,17 @@ public class BloggerOAuthConfig extends GoogleOAuthConfig {
 
   // See https://developers.google.com/identity/protocols/googlescopes
   @Override
-  public Map<String, Set<String>> getExportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("SOCIAL-POSTS", ImmutableSet.of("https://www.googleapis.com/auth/blogger.readonly"))
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(SOCIAL_POSTS, ImmutableSet.of("https://www.googleapis.com/auth/blogger.readonly"))
         .build();
   }
 
   // See https://developers.google.com/identity/protocols/googlescopes
   @Override
-  public Map<String, Set<String>> getImportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("SOCIAL-POSTS", ImmutableSet.of(
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(SOCIAL_POSTS, ImmutableSet.of(
             "https://www.googleapis.com/auth/blogger",
             // Any photos associated with the blog are stored in Drive.
             // This permission only grants access to files created by this app

--- a/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleOAuthConfig.java
+++ b/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleOAuthConfig.java
@@ -16,11 +16,21 @@
 
 package org.datatransferproject.auth.google;
 
+import static org.datatransferproject.types.common.models.DataVertical.BLOBS;
+import static org.datatransferproject.types.common.models.DataVertical.CALENDAR;
+import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
+import static org.datatransferproject.types.common.models.DataVertical.MAIL;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
+import static org.datatransferproject.types.common.models.DataVertical.TASKS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import org.datatransferproject.auth.OAuth2Config;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that supplies Google-specific OAuth2 info
@@ -48,31 +58,31 @@ public class GoogleOAuthConfig implements OAuth2Config {
 
   // See https://developers.google.com/identity/protocols/googlescopes
   @Override
-  public Map<String, Set<String>> getExportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("BLOBS", ImmutableSet.of("https://www.googleapis.com/auth/drive.readonly"))
-        .put("CALENDAR", ImmutableSet.of("https://www.googleapis.com/auth/calendar.readonly"))
-        .put("CONTACTS", ImmutableSet.of("https://www.googleapis.com/auth/contacts.readonly"))
-        .put("MAIL", ImmutableSet.of("https://www.googleapis.com/auth/gmail.readonly"))
-        .put("PHOTOS", ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.readonly"))
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(BLOBS, ImmutableSet.of("https://www.googleapis.com/auth/drive.readonly"))
+        .put(CALENDAR, ImmutableSet.of("https://www.googleapis.com/auth/calendar.readonly"))
+        .put(CONTACTS, ImmutableSet.of("https://www.googleapis.com/auth/contacts.readonly"))
+        .put(MAIL, ImmutableSet.of("https://www.googleapis.com/auth/gmail.readonly"))
+        .put(PHOTOS, ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.readonly"))
         // For G+
-        .put("SOCIAL-POSTS", ImmutableSet.of("https://www.googleapis.com/auth/plus.login"))
-        .put("TASKS", ImmutableSet.of("https://www.googleapis.com/auth/tasks.readonly"))
-        .put("VIDEOS", ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.readonly"))
+        .put(SOCIAL_POSTS, ImmutableSet.of("https://www.googleapis.com/auth/plus.login"))
+        .put(TASKS, ImmutableSet.of("https://www.googleapis.com/auth/tasks.readonly"))
+        .put(VIDEOS, ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.readonly"))
         .build();
   }
 
   // See https://developers.google.com/identity/protocols/googlescopes
   @Override
-  public Map<String, Set<String>> getImportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("BLOBS", ImmutableSet.of("https://www.googleapis.com/auth/drive"))
-        .put("CALENDAR", ImmutableSet.of("https://www.googleapis.com/auth/calendar"))
-        .put("CONTACTS", ImmutableSet.of("https://www.googleapis.com/auth/contacts"))
-        .put("MAIL", ImmutableSet.of("https://www.googleapis.com/auth/gmail.modify"))
-        .put("PHOTOS", ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.appendonly"))
-        .put("TASKS", ImmutableSet.of("https://www.googleapis.com/auth/tasks"))
-        .put("VIDEOS", ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary"))
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(BLOBS, ImmutableSet.of("https://www.googleapis.com/auth/drive"))
+        .put(CALENDAR, ImmutableSet.of("https://www.googleapis.com/auth/calendar"))
+        .put(CONTACTS, ImmutableSet.of("https://www.googleapis.com/auth/contacts"))
+        .put(MAIL, ImmutableSet.of("https://www.googleapis.com/auth/gmail.modify"))
+        .put(PHOTOS, ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.appendonly"))
+        .put(TASKS, ImmutableSet.of("https://www.googleapis.com/auth/tasks"))
+        .put(VIDEOS, ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary"))
         .build();
   }
 

--- a/extensions/auth/portability-auth-harness-microsoft/src/main/java/org/datatransferproject/auth/microsoft/harness/AuthTestDriver.java
+++ b/extensions/auth/portability-auth-harness-microsoft/src/main/java/org/datatransferproject/auth/microsoft/harness/AuthTestDriver.java
@@ -14,6 +14,7 @@ import org.datatransferproject.auth.microsoft.MicrosoftAuthServiceExtension;
 import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 import org.datatransferproject.spi.api.types.AuthFlowConfiguration;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.transfer.auth.TokenAuthData;
 
 /** */
@@ -51,7 +52,7 @@ public class AuthTestDriver {
     OkHttpClient client = TestHelper.createTestBuilder(callbackHost).build();
 
     AuthDataGenerator authDataGenerator = new MicrosoftAuthServiceExtension()
-        .getAuthDataGenerator("CONTACTS", AuthMode.EXPORT);
+        .getAuthDataGenerator(DataVertical.CONTACTS, AuthMode.EXPORT);
 
     AuthFlowConfiguration configuration = authDataGenerator
         .generateConfiguration(callbackBase, "1");

--- a/extensions/auth/portability-auth-imgur/src/main/java/org.datatransferproject.auth.imgur/ImgurOAuthConfig.java
+++ b/extensions/auth/portability-auth-imgur/src/main/java/org.datatransferproject.auth.imgur/ImgurOAuthConfig.java
@@ -16,11 +16,14 @@
 
 package org.datatransferproject.auth.imgur;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import org.datatransferproject.auth.OAuth2Config;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that provides Imgur-specific information for OAuth2
@@ -45,12 +48,12 @@ public class ImgurOAuthConfig implements OAuth2Config {
 
   // Imgur doesn't require scopes
   @Override
-  public Map<String, Set<String>> getExportScopes() {
-    return ImmutableMap.of("PHOTOS", ImmutableSet.of(""));
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.of(PHOTOS, ImmutableSet.of(""));
   }
 
   @Override
-  public Map<String, Set<String>> getImportScopes() {
-    return ImmutableMap.of("PHOTOS", ImmutableSet.of(""));
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.of(PHOTOS, ImmutableSet.of(""));
   }
 }

--- a/extensions/auth/portability-auth-instagram/src/main/java/org/datatransferproject/auth/instagram/InstagramOAuthConfig.java
+++ b/extensions/auth/portability-auth-instagram/src/main/java/org/datatransferproject/auth/instagram/InstagramOAuthConfig.java
@@ -16,11 +16,14 @@
 
 package org.datatransferproject.auth.instagram;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import org.datatransferproject.auth.OAuth2Config;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that provides Instagram-specific information for OAuth2
@@ -46,13 +49,13 @@ public class InstagramOAuthConfig implements OAuth2Config {
 
   // See https://www.instagram.com/developer/authorization/
   @Override
-  public Map<String, Set<String>> getExportScopes() {
-    return ImmutableMap.of("PHOTOS", ImmutableSet.of("basic"));
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.of(PHOTOS, ImmutableSet.of("basic"));
   }
 
   // Instagram does not provide an API for import; https://help.instagram.com/442418472487929
   @Override
-  public Map<String, Set<String>> getImportScopes() {
+  public Map<DataVertical, Set<String>> getImportScopes() {
     return ImmutableMap.of();
   }
 }

--- a/extensions/auth/portability-auth-koofr/src/main/java/org/datatransferproject/auth/koofr/KoofrOAuthConfig.java
+++ b/extensions/auth/portability-auth-koofr/src/main/java/org/datatransferproject/auth/koofr/KoofrOAuthConfig.java
@@ -16,11 +16,15 @@
 
 package org.datatransferproject.auth.koofr;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import org.datatransferproject.auth.OAuth2Config;
+import org.datatransferproject.types.common.models.DataVertical;
 
 public class KoofrOAuthConfig implements OAuth2Config {
 
@@ -40,19 +44,19 @@ public class KoofrOAuthConfig implements OAuth2Config {
   }
 
   @Override
-  public Map<String, Set<String>> getExportScopes() {
+  public Map<DataVertical, Set<String>> getExportScopes() {
     // NOTE: KoofrTransferExtension does not implement export at the moment
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("PHOTOS", ImmutableSet.of("files.read"))
-        .put("VIDEOS", ImmutableSet.of("files.read"))
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(PHOTOS, ImmutableSet.of("files.read"))
+        .put(VIDEOS, ImmutableSet.of("files.read"))
         .build();
   }
 
   @Override
-  public Map<String, Set<String>> getImportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("PHOTOS", ImmutableSet.of("files.import"))
-        .put("VIDEOS", ImmutableSet.of("files.import"))
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(PHOTOS, ImmutableSet.of("files.import"))
+        .put(VIDEOS, ImmutableSet.of("files.import"))
         .build();
   }
 }

--- a/extensions/auth/portability-auth-microsoft/src/main/java/org/datatransferproject/auth/microsoft/MicrosoftOAuthConfig.java
+++ b/extensions/auth/portability-auth-microsoft/src/main/java/org/datatransferproject/auth/microsoft/MicrosoftOAuthConfig.java
@@ -16,11 +16,17 @@
 
 package org.datatransferproject.auth.microsoft;
 
+import static org.datatransferproject.types.common.models.DataVertical.CALENDAR;
+import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
+import static org.datatransferproject.types.common.models.DataVertical.MAIL;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import org.datatransferproject.auth.OAuth2Config;
+import org.datatransferproject.types.common.models.DataVertical;
 
 public class MicrosoftOAuthConfig implements OAuth2Config {
 
@@ -40,22 +46,22 @@ public class MicrosoftOAuthConfig implements OAuth2Config {
   }
 
   @Override
-  public Map<String, Set<String>> getExportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("MAIL", ImmutableSet.of("user.read", "Mail.Read"))
-        .put("CONTACTS", ImmutableSet.of("user.read", "Contacts.Read"))
-        .put("CALENDAR", ImmutableSet.of("user.read", "Calendars.Read"))
-        .put("PHOTOS", ImmutableSet.of("user.read", "Files.Read"))
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(MAIL, ImmutableSet.of("user.read", "Mail.Read"))
+        .put(CONTACTS, ImmutableSet.of("user.read", "Contacts.Read"))
+        .put(CALENDAR, ImmutableSet.of("user.read", "Calendars.Read"))
+        .put(PHOTOS, ImmutableSet.of("user.read", "Files.Read"))
         .build();
   }
 
   @Override
-  public Map<String, Set<String>> getImportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("MAIL", ImmutableSet.of("user.read", "Mail.ReadWrite"))
-        .put("CONTACTS", ImmutableSet.of("user.read", "Contacts.ReadWrite"))
-        .put("CALENDAR", ImmutableSet.of("user.read", "Calendars.ReadWrite"))
-        .put("PHOTOS", ImmutableSet.of("user.read", "Files.ReadWrite"))
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(MAIL, ImmutableSet.of("user.read", "Mail.ReadWrite"))
+        .put(CONTACTS, ImmutableSet.of("user.read", "Contacts.ReadWrite"))
+        .put(CALENDAR, ImmutableSet.of("user.read", "Calendars.ReadWrite"))
+        .put(PHOTOS, ImmutableSet.of("user.read", "Files.ReadWrite"))
         .build();
   }
 }

--- a/extensions/auth/portability-auth-offline-demo/src/main/java/org/datatransferproject/auth/offline/OfflineDemoAuthServiceExtension.java
+++ b/extensions/auth/portability-auth-offline-demo/src/main/java/org/datatransferproject/auth/offline/OfflineDemoAuthServiceExtension.java
@@ -15,13 +15,16 @@
  */
 package org.datatransferproject.auth.offline;
 
+import static org.datatransferproject.types.common.models.DataVertical.OFFLINE_DATA;
+
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.spi.api.auth.AuthDataGenerator;
-import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry;
+import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
 
 import java.util.Collections;
 import java.util.List;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Provides an extension that demonstrates how import of offline data can be implemented.
@@ -32,7 +35,7 @@ import java.util.List;
 public class OfflineDemoAuthServiceExtension implements AuthServiceExtension {
   private static final String SERVICE_ID = "OFFLINE-DEMO";
 
-  private static final List<String> SUPPORTED_SERVICES = Collections.singletonList("OFFLINE-DATA");
+  private static final List<DataVertical> SUPPORTED_SERVICES = Collections.singletonList(OFFLINE_DATA);
 
   @Override
   public String getServiceId() {
@@ -41,17 +44,17 @@ public class OfflineDemoAuthServiceExtension implements AuthServiceExtension {
 
   @Override
   public AuthDataGenerator getAuthDataGenerator(
-      String type, AuthServiceProviderRegistry.AuthMode mode) {
+      DataVertical type, AuthMode mode) {
     return new OfflineDemoAuthDataGenerator();
   }
 
   @Override
-  public List<String> getImportTypes() {
+  public List<DataVertical> getImportTypes() {
     return SUPPORTED_SERVICES;
   }
 
   @Override
-  public List<String> getExportTypes() {
+  public List<DataVertical> getExportTypes() {
     return SUPPORTED_SERVICES;
   }
 

--- a/extensions/auth/portability-auth-rememberthemilk/src/main/java/org/datatransferproject/auth/rememberthemilk/RememberTheMilkAuthServiceExtension.java
+++ b/extensions/auth/portability-auth-rememberthemilk/src/main/java/org/datatransferproject/auth/rememberthemilk/RememberTheMilkAuthServiceExtension.java
@@ -24,19 +24,21 @@ import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 
 import java.io.IOException;
 import java.util.List;
 
 import static java.lang.String.format;
+import static org.datatransferproject.types.common.models.DataVertical.TASKS;
 
 public class RememberTheMilkAuthServiceExtension implements AuthServiceExtension {
   private static final String RTM_KEY = "RTM_KEY";
   private static final String RTM_SECRET = "RTM_SECRET";
   private static final String SERVICE_ID = "REMEMBER_THE_MILK";
 
-  private final List<String> supportedServices = ImmutableList.of("TASKS");
+  private final List<DataVertical> supportedServices = ImmutableList.of(TASKS);
   private RememberTheMilkAuthDataGenerator importAuthDataGenerator;
   private RememberTheMilkAuthDataGenerator exportAuthDataGenerator;
   private boolean initialized = false;
@@ -47,7 +49,7 @@ public class RememberTheMilkAuthServiceExtension implements AuthServiceExtension
   }
 
   @Override
-  public AuthDataGenerator getAuthDataGenerator(String transferDataType, AuthMode mode) {
+  public AuthDataGenerator getAuthDataGenerator(DataVertical transferDataType, AuthMode mode) {
     Preconditions.checkArgument(
         initialized,
         "RememberTheMilkAuthServiceExtension is not initialized! Unable to retrieve AuthDataGenerator");
@@ -58,12 +60,12 @@ public class RememberTheMilkAuthServiceExtension implements AuthServiceExtension
   }
 
   @Override
-  public List<String> getImportTypes() {
+  public List<DataVertical> getImportTypes() {
     return supportedServices;
   }
 
   @Override
-  public List<String> getExportTypes() {
+  public List<DataVertical> getExportTypes() {
     return supportedServices;
   }
 

--- a/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugOAuthConfig.java
+++ b/extensions/auth/portability-auth-smugmug/src/main/java/org/datatransferproject/auth/smugmug/SmugMugOAuthConfig.java
@@ -16,6 +16,8 @@
 
 package org.datatransferproject.auth.smugmug;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.datatransferproject.auth.OAuth1Config;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that supplies SmugMug-specific OAuth1 info
@@ -54,19 +57,19 @@ public class SmugMugOAuthConfig implements OAuth1Config {
   }
 
   @Override
-  public List<String> getExportTypes() {
-    return ImmutableList.of("PHOTOS");
+  public List<DataVertical> getExportTypes() {
+    return ImmutableList.of(PHOTOS);
   }
 
   @Override
-  public List<String> getImportTypes() {
-    return ImmutableList.of("PHOTOS");
+  public List<DataVertical> getImportTypes() {
+    return ImmutableList.of(PHOTOS);
   }
 
   public Map<String, String> getAdditionalUrlParameters(
-      String dataType, AuthMode mode, OAuth1Step step) {
+      DataVertical dataType, AuthMode mode, OAuth1Step step) {
 
-    if (dataType.equals("PHOTOS") && step == OAuth1Step.AUTHORIZATION) {
+    if (dataType.equals(PHOTOS) && step == OAuth1Step.AUTHORIZATION) {
       return (mode == AuthMode.EXPORT)
           ? ImmutableMap.of(ACCESS, "Full", PERMISSIONS, "Read")
           : ImmutableMap.of(ACCESS, "Full", PERMISSIONS, "Add");

--- a/extensions/auth/portability-auth-spotify/src/main/java/org/datatransferproject/auth/spotify/SpotifyOAuthConfig.java
+++ b/extensions/auth/portability-auth-spotify/src/main/java/org/datatransferproject/auth/spotify/SpotifyOAuthConfig.java
@@ -16,11 +16,14 @@
 
 package org.datatransferproject.auth.spotify;
 
+import static org.datatransferproject.types.common.models.DataVertical.PLAYLISTS;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Map;
 import java.util.Set;
 import org.datatransferproject.auth.OAuth2Config;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that supplies Spotify-specific OAuth2 info
@@ -45,16 +48,16 @@ public class SpotifyOAuthConfig implements OAuth2Config {
   }
 
   @Override
-  public Map<String, Set<String>> getExportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("PLAYLISTS", ImmutableSet.of("playlist-read-private"))
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(PLAYLISTS, ImmutableSet.of("playlist-read-private"))
         .build();
   }
 
   @Override
-  public Map<String, Set<String>> getImportScopes() {
-    return ImmutableMap.<String, Set<String>>builder()
-        .put("PLAYLISTS", ImmutableSet.of("playlist-modify-private"))
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(PLAYLISTS, ImmutableSet.of("playlist-modify-private"))
         .build();
   }
 

--- a/extensions/auth/portability-auth-twitter/src/main/java/org/datatransferproject/auth/twitter/TwitterOAuthConfig.java
+++ b/extensions/auth/portability-auth-twitter/src/main/java/org/datatransferproject/auth/twitter/TwitterOAuthConfig.java
@@ -16,6 +16,8 @@
 
 package org.datatransferproject.auth.twitter;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.datatransferproject.auth.OAuth1Config;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class that supplies Twitter-specific OAuth1 info
@@ -54,19 +57,19 @@ public class TwitterOAuthConfig implements OAuth1Config {
   }
 
   @Override
-  public List<String> getExportTypes() {
-    return ImmutableList.of("PHOTOS");
+  public List<DataVertical> getExportTypes() {
+    return ImmutableList.of(PHOTOS);
   }
 
   @Override
-  public List<String> getImportTypes() {
-    return ImmutableList.of("PHOTOS");
+  public List<DataVertical> getImportTypes() {
+    return ImmutableList.of(PHOTOS);
   }
 
   public Map<String, String> getAdditionalUrlParameters(
-      String dataType, AuthMode mode, OAuth1Step step) {
+      DataVertical dataType, AuthMode mode, OAuth1Step step) {
 
-    if (dataType.equals("PHOTOS") && step == OAuth1Step.REQUEST_TOKEN) {
+    if (dataType.equals(PHOTOS) && step == OAuth1Step.REQUEST_TOKEN) {
       return (mode == AuthMode.EXPORT)
           ? ImmutableMap.of(X_AUTH_ACCESS_TYPE, "read")
           : ImmutableMap.of(X_AUTH_ACCESS_TYPE, "write");

--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleDtpInternalMetricRecorder.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleDtpInternalMetricRecorder.java
@@ -36,6 +36,7 @@ import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
 
 import java.io.IOException;
 import java.time.Duration;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * A {@link DtpInternalMetricRecorder} that writes metrics to Stackdriver.
@@ -211,9 +212,9 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void startedJob(String dataType, String exportService, String importService) {
+  public void startedJob(DataVertical dataType, String exportService, String importService) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_EXPORT_SERVICE, TagValue.create(exportService), TAG_METADATA)
         .put(KEY_IMPORT_SERVICE, TagValue.create(importService), TAG_METADATA)
         .build();
@@ -224,12 +225,12 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void exportPageAttemptFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_EXPORT_SERVICE, TagValue.create(service), TAG_METADATA)
         .put(KEY_SUCCESS, TagValue.create(Boolean.toString(success)), TAG_METADATA)
         .build();
@@ -243,12 +244,12 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void exportPageFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_EXPORT_SERVICE, TagValue.create(service), TAG_METADATA)
         .put(KEY_SUCCESS, TagValue.create(Boolean.toString(success)), TAG_METADATA)
         .build();
@@ -262,12 +263,12 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void importPageAttemptFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_IMPORT_SERVICE, TagValue.create(service), TAG_METADATA)
         .put(KEY_SUCCESS, TagValue.create(Boolean.toString(success)), TAG_METADATA)
         .build();
@@ -281,12 +282,12 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void importPageFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_IMPORT_SERVICE, TagValue.create(service), TAG_METADATA)
         .put(KEY_SUCCESS, TagValue.create(Boolean.toString(success)), TAG_METADATA)
         .build();
@@ -300,13 +301,13 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void finishedJob(
-      String dataType,
+      DataVertical dataType,
       String exportService,
       String importService,
       boolean success,
       Duration duration) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_EXPORT_SERVICE, TagValue.create(exportService), TAG_METADATA)
         .put(KEY_IMPORT_SERVICE, TagValue.create(importService), TAG_METADATA)
         .put(KEY_SUCCESS, TagValue.create(Boolean.toString(success)), TAG_METADATA)
@@ -320,19 +321,19 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void cancelledJob(String dataType, String exportService, String importService, Duration duration) {
+  public void cancelledJob(DataVertical dataType, String exportService, String importService, Duration duration) {
     // Need Google folks to implement the necessary changes here.
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag) {
     recordGenericMetric(dataType, service, tag, 1);
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, boolean bool) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, boolean bool) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_GENERIC_SERVICE, TagValue.create(service), TAG_METADATA)
         .put(KEY_GENERIC_TAG, TagValue.create(tag), TAG_METADATA)
         .put(KEY_GENERIC_BOOL, TagValue.create(Boolean.toString(bool)), TAG_METADATA)
@@ -345,9 +346,9 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, Duration duration) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, Duration duration) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_GENERIC_SERVICE, TagValue.create(service), TAG_METADATA)
         .put(KEY_GENERIC_TAG, TagValue.create(tag), TAG_METADATA)
         .build();
@@ -359,9 +360,9 @@ class GoogleDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, int value) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, int value) {
     TagContext tctx = tagger.emptyBuilder()
-        .put(KEY_DATA_TYPE, TagValue.create(dataType), TAG_METADATA)
+        .put(KEY_DATA_TYPE, TagValue.create(dataType.getDataType()), TAG_METADATA)
         .put(KEY_GENERIC_SERVICE, TagValue.create(service), TAG_METADATA)
         .put(KEY_GENERIC_TAG, TagValue.create(tag), TAG_METADATA)
         .build();

--- a/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureDtpInternalMetricRecorder.java
+++ b/extensions/cloud/portability-cloud-microsoft/src/main/java/org/datatransferproject/cloud/microsoft/cosmos/AzureDtpInternalMetricRecorder.java
@@ -21,6 +21,7 @@ import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
 import org.datatransferproject.api.launcher.Monitor;
 
 import java.time.Duration;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * A placeholder {@link DtpInternalMetricRecorder} that simply logs metrics
@@ -35,7 +36,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void startedJob(String dataType, String exportService, String importService) {
+  public void startedJob(DataVertical dataType, String exportService, String importService) {
     monitor.debug(
         () ->
             format(
@@ -45,7 +46,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void exportPageAttemptFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
@@ -59,7 +60,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void exportPageFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
@@ -72,7 +73,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void importPageAttemptFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
@@ -86,7 +87,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void importPageFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
@@ -99,7 +100,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
 
   @Override
   public void finishedJob(
-      String dataType,
+      DataVertical dataType,
       String exportService,
       String importService,
       boolean success,
@@ -112,7 +113,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void cancelledJob(String dataType, String exportService, String importService, Duration duration) {
+  public void cancelledJob(DataVertical dataType, String exportService, String importService, Duration duration) {
     monitor.debug(
          () ->
              format("Metric: cancelledJob, data type: %s, from: %s, to: %s, duration: %s",
@@ -121,14 +122,14 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag) {
     monitor.debug(
         () ->
             format("Metric: Generic, data type: %s, service: %s, tag: %s", dataType, service, tag));
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, boolean bool) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, boolean bool) {
     monitor.debug(
         () ->
             format(
@@ -137,7 +138,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, Duration duration) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, Duration duration) {
     monitor.debug(
         () ->
             format(
@@ -146,7 +147,7 @@ class AzureDtpInternalMetricRecorder implements DtpInternalMetricRecorder {
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, int value) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, int value) {
     monitor.debug(
         () ->
             format(

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/BackblazeTransferExtension.java
@@ -16,6 +16,9 @@
 
 package org.datatransferproject.datatransfer.backblaze;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -26,6 +29,7 @@ import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransf
 import org.datatransferproject.datatransfer.backblaze.photos.BackblazePhotosImporter;
 import org.datatransferproject.datatransfer.backblaze.videos.BackblazeVideosImporter;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -33,9 +37,9 @@ import org.datatransferproject.transfer.ImageStreamProvider;
 
 public class BackblazeTransferExtension implements TransferExtension {
   public static final String SERVICE_ID = "Backblaze";
-  private static final List<String> SUPPORTED_TYPES = ImmutableList.of("PHOTOS", "VIDEOS");
+  private static final List<DataVertical> SUPPORTED_TYPES = ImmutableList.of(PHOTOS, VIDEOS);
 
-  private ImmutableMap<String, Importer> importerMap;
+  private ImmutableMap<DataVertical, Importer> importerMap;
   private boolean initialized = false;
 
   @Override
@@ -44,13 +48,13 @@ public class BackblazeTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     //TODO: Implement exporters as per https://github.com/google/data-transfer-project/issues/960
     throw new IllegalArgumentException();
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "Trying to call getImporter before initalizing BackblazeTransferExtension");
     Preconditions.checkArgument(
@@ -70,17 +74,17 @@ public class BackblazeTransferExtension implements TransferExtension {
 
     TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
 
-    ImmutableMap.Builder<String, Importer> importerBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Importer> importerBuilder = ImmutableMap.builder();
     BackblazeDataTransferClientFactory backblazeDataTransferClientFactory =
             new BackblazeDataTransferClientFactory(monitor);
     ImageStreamProvider isProvider = new ImageStreamProvider();
 
     importerBuilder.put(
-            "PHOTOS",
+            PHOTOS,
             new BackblazePhotosImporter(
                     monitor, jobStore, isProvider, backblazeDataTransferClientFactory));
     importerBuilder.put(
-            "VIDEOS",
+            VIDEOS,
             new BackblazeVideosImporter(
                     monitor, jobStore, isProvider, backblazeDataTransferClientFactory));
     importerMap = importerBuilder.build();

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/main/java/org/datatransferproject/transfer/daybook/DaybookTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/main/java/org/datatransferproject/transfer/daybook/DaybookTransferExtension.java
@@ -16,6 +16,9 @@
 
 package org.datatransferproject.transfer.daybook;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -25,6 +28,7 @@ import okhttp3.OkHttpClient;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -37,11 +41,11 @@ public class DaybookTransferExtension implements TransferExtension {
   private static final String SERVICE_ID = "Daybook";
   private static final String BASE_URL =
       "https://us-central1-diary-a77f6.cloudfunctions.net/post-daybook-dtp";
-  private static final ImmutableList<String> SUPPORTED_DATA_TYPES =
-      ImmutableList.of("PHOTOS", "SOCIAL-POSTS");
+  private static final ImmutableList<DataVertical> SUPPORTED_DATA_TYPES =
+      ImmutableList.of(PHOTOS, SOCIAL_POSTS);
 
   private boolean initialized = false;
-  private ImmutableMap<String, Importer<?, ?>> importerMap;
+  private ImmutableMap<DataVertical, Importer<?, ?>> importerMap;
 
   @Override
   public void initialize(ExtensionContext context) {
@@ -56,12 +60,12 @@ public class DaybookTransferExtension implements TransferExtension {
     OkHttpClient client = context.getService(OkHttpClient.class);
     TemporaryPerJobDataStore jobStore = context.getService(TemporaryPerJobDataStore.class);
 
-    ImmutableMap.Builder<String, Importer<?, ?>> importerBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Importer<?, ?>> importerBuilder = ImmutableMap.builder();
     String exportService = JobMetadata.getExportService();
     importerBuilder.put(
-        "PHOTOS", new DaybookPhotosImporter(monitor, client, jobStore, BASE_URL, exportService));
+        PHOTOS, new DaybookPhotosImporter(monitor, client, jobStore, BASE_URL, exportService));
     importerBuilder.put(
-        "SOCIAL-POSTS", new DaybookPostsImporter(monitor, client, mapper, BASE_URL, exportService));
+        SOCIAL_POSTS, new DaybookPostsImporter(monitor, client, mapper, BASE_URL, exportService));
     importerMap = importerBuilder.build();
     initialized = true;
   }
@@ -72,7 +76,7 @@ public class DaybookTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "DaybookTransferExtension is not initialized. Unable to get Importer");
     Preconditions.checkArgument(
@@ -82,7 +86,7 @@ public class DaybookTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     throw new IllegalArgumentException();
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-deezer/src/main/java/org/datatransferproject/transfer/deezer/DeezerTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-deezer/src/main/java/org/datatransferproject/transfer/deezer/DeezerTransferExtension.java
@@ -15,11 +15,14 @@
  */
 package org.datatransferproject.transfer.deezer;
 
+import static org.datatransferproject.types.common.models.DataVertical.PLAYLISTS;
+
 import com.google.api.client.http.HttpTransport;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -31,7 +34,7 @@ import org.datatransferproject.types.transfer.serviceconfig.TransferServiceConfi
 
 
 public class DeezerTransferExtension implements TransferExtension {
-  private static final ImmutableList<String> SUPPORTED_DATA_TYPES = ImmutableList.of("PLAYLISTS");
+  private static final ImmutableList<DataVertical> SUPPORTED_DATA_TYPES = ImmutableList.of(PLAYLISTS);
 
   private Exporter<TokensAndUrlAuthData, PlaylistContainerResource> exporter;
   private Importer<TokensAndUrlAuthData, PlaylistContainerResource> importer;
@@ -44,7 +47,7 @@ public class DeezerTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "DeezerTransferExtension not initialized. Unable to get Exporter");
     Preconditions.checkArgument(SUPPORTED_DATA_TYPES.contains(transferDataType));
@@ -52,7 +55,7 @@ public class DeezerTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "DeezerTransferExtension not initialized. Unable to get Importer");
     Preconditions.checkArgument(SUPPORTED_DATA_TYPES.contains(transferDataType));

--- a/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/FacebookTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-facebook/src/main/java/org/datatransferproject/transfer/facebook/FacebookTransferExtension.java
@@ -16,6 +16,9 @@
 
 package org.datatransferproject.transfer.facebook;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -24,6 +27,7 @@ import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -36,10 +40,10 @@ public class FacebookTransferExtension implements TransferExtension {
   private static final String SERVICE_ID = "Facebook";
   private boolean initialized = false;
 
-  private static final ImmutableList<String> SUPPORTED_SERVICES =
-      ImmutableList.of("PHOTOS", "VIDEOS");
-  private ImmutableMap<String, Importer> importerMap;
-  private ImmutableMap<String, Exporter> exporterMap;
+  private static final ImmutableList<DataVertical> SUPPORTED_SERVICES =
+      ImmutableList.of(PHOTOS, VIDEOS);
+  private ImmutableMap<DataVertical, Importer> importerMap;
+  private ImmutableMap<DataVertical, Exporter> exporterMap;
 
   @Override
   public String getServiceId() {
@@ -47,14 +51,14 @@ public class FacebookTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized);
     Preconditions.checkArgument(SUPPORTED_SERVICES.contains(transferDataType));
     return exporterMap.get(transferDataType);
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized);
     Preconditions.checkArgument(SUPPORTED_SERVICES.contains(transferDataType));
     return importerMap.get(transferDataType);
@@ -79,16 +83,16 @@ public class FacebookTransferExtension implements TransferExtension {
       return;
     }
 
-    ImmutableMap.Builder<String, Importer> importerBuilder = ImmutableMap.builder();
-    importerBuilder.put("VIDEOS", new FacebookVideosImporter(appCredentials));
+    ImmutableMap.Builder<DataVertical, Importer> importerBuilder = ImmutableMap.builder();
+    importerBuilder.put(VIDEOS, new FacebookVideosImporter(appCredentials));
     importerMap = importerBuilder.build();
 
-    ImmutableMap.Builder<String, Exporter> exporterBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Exporter> exporterBuilder = ImmutableMap.builder();
     exporterBuilder.put(
-        "PHOTOS",
+        PHOTOS,
         new FacebookPhotosExporter(
             appCredentials, monitor, context.getService(TemporaryPerJobDataStore.class)));
-    exporterBuilder.put("VIDEOS", new FacebookVideosExporter(appCredentials, monitor));
+    exporterBuilder.put(VIDEOS, new FacebookVideosExporter(appCredentials, monitor));
     exporterMap = exporterBuilder.build();
 
     initialized = true;

--- a/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/FlickrTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-flickr/src/main/java/org/datatransferproject/datatransfer/flickr/FlickrTransferExtension.java
@@ -17,6 +17,7 @@
 package org.datatransferproject.datatransfer.flickr;
 
 import static java.lang.String.format;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -27,6 +28,7 @@ import org.datatransferproject.datatransfer.flickr.photos.FlickrPhotosExporter;
 import org.datatransferproject.datatransfer.flickr.photos.FlickrPhotosImporter;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -38,7 +40,7 @@ public class FlickrTransferExtension implements TransferExtension {
   private static final String FLICKR_KEY = "FLICKR_KEY";
   private static final String FLICKR_SECRET = "FLICKR_SECRET";
 
-  private final Set<String> supportedServices = ImmutableSet.of("PHOTOS");
+  private final Set<DataVertical> supportedServices = ImmutableSet.of(PHOTOS);
 
   private Importer importer;
   private Exporter exporter;
@@ -52,14 +54,14 @@ public class FlickrTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized);
     Preconditions.checkArgument(supportedServices.contains(transferDataType));
     return exporter;
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized);
     Preconditions.checkArgument(supportedServices.contains(transferDataType));
     return importer;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/BloggerTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/BloggerTransferExtension.java
@@ -16,6 +16,8 @@
 
 package org.datatransferproject.datatransfer.google;
 
+import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
+
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.common.base.Preconditions;
@@ -27,6 +29,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.blogger.GoogleBloggerImporter;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -43,10 +46,10 @@ public class BloggerTransferExtension implements TransferExtension {
   private static final String SERVICE_ID = "GoogleBlogger";
 
   // TODO: centralized place, or enum type for these
-  private static final ImmutableList<String> SUPPORTED_SERVICES =
-      ImmutableList.of("SOCIAL-POSTS");
-  private ImmutableMap<String, Importer> importerMap;
-  private ImmutableMap<String, Exporter> exporterMap;
+  private static final ImmutableList<DataVertical> SUPPORTED_SERVICES =
+      ImmutableList.of(SOCIAL_POSTS);
+  private ImmutableMap<DataVertical, Importer> importerMap;
+  private ImmutableMap<DataVertical, Exporter> exporterMap;
   private boolean initialized = false;
 
   @Override
@@ -55,14 +58,14 @@ public class BloggerTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized);
     Preconditions.checkArgument(SUPPORTED_SERVICES.contains(transferDataType));
     return exporterMap.get(transferDataType);
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized);
     Preconditions.checkArgument(SUPPORTED_SERVICES.contains(transferDataType));
     return importerMap.get(transferDataType);
@@ -98,13 +101,13 @@ public class BloggerTransferExtension implements TransferExtension {
     GoogleCredentialFactory credentialFactory =
         new GoogleCredentialFactory(httpTransport, jsonFactory, appCredentials, monitor);
 
-    ImmutableMap.Builder<String, Importer> importerBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Importer> importerBuilder = ImmutableMap.builder();
 
-    importerBuilder.put("SOCIAL-POSTS", new GoogleBloggerImporter(credentialFactory));
+    importerBuilder.put(SOCIAL_POSTS, new GoogleBloggerImporter(credentialFactory));
 
     importerMap = importerBuilder.build();
 
-    ImmutableMap.Builder<String, Exporter> exporterBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Exporter> exporterBuilder = ImmutableMap.builder();
 
     exporterMap = exporterBuilder.build();
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
@@ -1,5 +1,14 @@
 package org.datatransferproject.datatransfer.google;
 
+import static org.datatransferproject.types.common.models.DataVertical.BLOBS;
+import static org.datatransferproject.types.common.models.DataVertical.CALENDAR;
+import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
+import static org.datatransferproject.types.common.models.DataVertical.MAIL;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
+import static org.datatransferproject.types.common.models.DataVertical.TASKS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.common.base.Preconditions;
@@ -26,6 +35,7 @@ import org.datatransferproject.datatransfer.google.videos.GoogleVideosExporter;
 import org.datatransferproject.datatransfer.google.videos.GoogleVideosImporter;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -38,11 +48,11 @@ import org.datatransferproject.types.transfer.auth.AppCredentials;
 public class GoogleTransferExtension implements TransferExtension {
   public static final String SERVICE_ID = "google";
   // TODO: centralized place, or enum type for these
-  private static final ImmutableList<String> SUPPORTED_SERVICES =
+  private static final ImmutableList<DataVertical> SUPPORTED_SERVICES =
       ImmutableList.of(
-          "BLOBS", "CALENDAR", "CONTACTS", "MAIL", "PHOTOS", "SOCIAL-POSTS", "TASKS", "VIDEOS");
-  private ImmutableMap<String, Importer> importerMap;
-  private ImmutableMap<String, Exporter> exporterMap;
+          BLOBS, CALENDAR, CONTACTS, MAIL, PHOTOS, SOCIAL_POSTS, TASKS, VIDEOS);
+  private ImmutableMap<DataVertical, Importer> importerMap;
+  private ImmutableMap<DataVertical, Exporter> exporterMap;
   private boolean initialized = false;
 
   @Override
@@ -51,14 +61,14 @@ public class GoogleTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized);
     Preconditions.checkArgument(SUPPORTED_SERVICES.contains(transferDataType));
     return exporterMap.get(transferDataType);
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(initialized);
     Preconditions.checkArgument(SUPPORTED_SERVICES.contains(transferDataType));
     return importerMap.get(transferDataType);
@@ -95,33 +105,33 @@ public class GoogleTransferExtension implements TransferExtension {
     GoogleCredentialFactory credentialFactory =
         new GoogleCredentialFactory(httpTransport, jsonFactory, appCredentials, monitor);
 
-    ImmutableMap.Builder<String, Importer> importerBuilder = ImmutableMap.builder();
-    importerBuilder.put("BLOBS", new DriveImporter(credentialFactory, jobStore, monitor));
-    importerBuilder.put("CONTACTS", new GoogleContactsImporter(credentialFactory));
-    importerBuilder.put("CALENDAR", new GoogleCalendarImporter(credentialFactory));
-    importerBuilder.put("MAIL", new GoogleMailImporter(credentialFactory, monitor));
-    importerBuilder.put("TASKS", new GoogleTasksImporter(credentialFactory));
+    ImmutableMap.Builder<DataVertical, Importer> importerBuilder = ImmutableMap.builder();
+    importerBuilder.put(BLOBS, new DriveImporter(credentialFactory, jobStore, monitor));
+    importerBuilder.put(CONTACTS, new GoogleContactsImporter(credentialFactory));
+    importerBuilder.put(CALENDAR, new GoogleCalendarImporter(credentialFactory));
+    importerBuilder.put(MAIL, new GoogleMailImporter(credentialFactory, monitor));
+    importerBuilder.put(TASKS, new GoogleTasksImporter(credentialFactory));
     importerBuilder.put(
-        "PHOTOS",
+        PHOTOS,
         new GooglePhotosImporter(
             credentialFactory,
             jobStore,
             jsonFactory,
             monitor,
             context.getSetting("googleWritesPerSecond", 1.0)));
-    importerBuilder.put("VIDEOS", new GoogleVideosImporter(appCredentials, jobStore, monitor));
+    importerBuilder.put(VIDEOS, new GoogleVideosImporter(appCredentials, jobStore, monitor));
     importerMap = importerBuilder.build();
 
-    ImmutableMap.Builder<String, Exporter> exporterBuilder = ImmutableMap.builder();
-    exporterBuilder.put("BLOBS", new DriveExporter(credentialFactory, jobStore, monitor));
-    exporterBuilder.put("CONTACTS", new GoogleContactsExporter(credentialFactory));
-    exporterBuilder.put("CALENDAR", new GoogleCalendarExporter(credentialFactory));
-    exporterBuilder.put("MAIL", new GoogleMailExporter(credentialFactory));
-    exporterBuilder.put("SOCIAL-POSTS", new GooglePlusExporter(credentialFactory));
-    exporterBuilder.put("TASKS", new GoogleTasksExporter(credentialFactory, monitor));
+    ImmutableMap.Builder<DataVertical, Exporter> exporterBuilder = ImmutableMap.builder();
+    exporterBuilder.put(BLOBS, new DriveExporter(credentialFactory, jobStore, monitor));
+    exporterBuilder.put(CONTACTS, new GoogleContactsExporter(credentialFactory));
+    exporterBuilder.put(CALENDAR, new GoogleCalendarExporter(credentialFactory));
+    exporterBuilder.put(MAIL, new GoogleMailExporter(credentialFactory));
+    exporterBuilder.put(SOCIAL_POSTS, new GooglePlusExporter(credentialFactory));
+    exporterBuilder.put(TASKS, new GoogleTasksExporter(credentialFactory, monitor));
     exporterBuilder.put(
-        "PHOTOS", new GooglePhotosExporter(credentialFactory, jobStore, jsonFactory, monitor));
-    exporterBuilder.put("VIDEOS", new GoogleVideosExporter(credentialFactory, jsonFactory));
+        PHOTOS, new GooglePhotosExporter(credentialFactory, jobStore, jsonFactory, monitor));
+    exporterBuilder.put(VIDEOS, new GoogleVideosExporter(credentialFactory, jsonFactory));
 
     exporterMap = exporterBuilder.build();
 

--- a/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/ImgurTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-imgur/src/main/java/org/datatransferproject/datatransfer/imgur/ImgurTransferExtension.java
@@ -16,6 +16,8 @@
 
 package org.datatransferproject.datatransfer.imgur;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -26,6 +28,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.imgur.photos.ImgurPhotosExporter;
 import org.datatransferproject.datatransfer.imgur.photos.ImgurPhotosImporter;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -37,7 +40,7 @@ public class ImgurTransferExtension implements TransferExtension {
 
   private boolean initialized = false;
 
-  private static final ImmutableList<String> SUPPORTED_DATA_TYPES = ImmutableList.of("PHOTOS");
+  private static final ImmutableList<DataVertical> SUPPORTED_DATA_TYPES = ImmutableList.of(PHOTOS);
 
   private ImgurPhotosExporter exporter;
   private ImgurPhotosImporter importer;
@@ -67,7 +70,7 @@ public class ImgurTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "ImgurTransferExtension is not initialized. Unable to get Exporter");
     Preconditions.checkArgument(
@@ -77,7 +80,7 @@ public class ImgurTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "ImgurTransferExtension is not initialized. Unable to get Importer");
     Preconditions.checkArgument(

--- a/extensions/data-transfer/portability-data-transfer-instagram/src/main/java/org/datatransferproject/transfer/instagram/InstagramTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-instagram/src/main/java/org/datatransferproject/transfer/instagram/InstagramTransferExtension.java
@@ -15,6 +15,8 @@
  */
 package org.datatransferproject.transfer.instagram;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpTransport;
@@ -22,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -31,7 +34,7 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 
 public class InstagramTransferExtension implements TransferExtension {
-  private static final ImmutableList<String> SUPPORTED_DATA_TYPES = ImmutableList.of("PHOTOS");
+  private static final ImmutableList<DataVertical> SUPPORTED_DATA_TYPES = ImmutableList.of(PHOTOS);
 
   private Exporter<TokensAndUrlAuthData, PhotosContainerResource> exporter;
 
@@ -43,7 +46,7 @@ public class InstagramTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "InstagramTransferExtension not initialized. Unable to get Exporter");
     Preconditions.checkArgument(SUPPORTED_DATA_TYPES.contains(transferDataType));
@@ -51,7 +54,7 @@ public class InstagramTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "InstagramTransferExtension not initialized. Unable to get Importer");
     Preconditions.checkArgument(false, "Instagram does not support import");

--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/KoofrTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/KoofrTransferExtension.java
@@ -1,6 +1,8 @@
 package org.datatransferproject.transfer.koofr;
 
 import static java.lang.String.format;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpTransport;
@@ -15,6 +17,7 @@ import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -29,15 +32,13 @@ import org.datatransferproject.types.transfer.auth.AppCredentials;
 /** Bootstraps the Koofr data transfer services. */
 public class KoofrTransferExtension implements TransferExtension {
   public static final String SERVICE_ID = "koofr";
-  private static final String PHOTOS = "PHOTOS";
-  private static final String VIDEOS = "VIDEOS";
-  private static final ImmutableList<String> SUPPORTED_IMPORT_SERVICES =
+  private static final ImmutableList<DataVertical> SUPPORTED_IMPORT_SERVICES =
       ImmutableList.of(PHOTOS, VIDEOS);
-  private static final ImmutableList<String> SUPPORTED_EXPORT_SERVICES =
+  private static final ImmutableList<DataVertical> SUPPORTED_EXPORT_SERVICES =
       ImmutableList.of(PHOTOS, VIDEOS);
   private static final String BASE_API_URL = "https://app.koofr.net";
-  private ImmutableMap<String, Importer> importerMap;
-  private ImmutableMap<String, Exporter> exporterMap;
+  private ImmutableMap<DataVertical, Importer> importerMap;
+  private ImmutableMap<DataVertical, Exporter> exporterMap;
   private boolean initialized = false;
 
   // Needed for ServiceLoader to load this class.
@@ -49,14 +50,14 @@ public class KoofrTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkState(initialized);
     Preconditions.checkArgument(SUPPORTED_EXPORT_SERVICES.contains(transferDataType));
     return exporterMap.get(transferDataType);
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkState(initialized);
     Preconditions.checkArgument(SUPPORTED_IMPORT_SERVICES.contains(transferDataType));
     return importerMap.get(transferDataType);
@@ -114,12 +115,12 @@ public class KoofrTransferExtension implements TransferExtension {
         new KoofrClientFactory(
             BASE_API_URL, client, fileUploadClient, mapper, monitor, credentialFactory);
 
-    ImmutableMap.Builder<String, Importer> importBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Importer> importBuilder = ImmutableMap.builder();
     importBuilder.put(PHOTOS, new KoofrPhotosImporter(koofrClientFactory, monitor, jobStore));
     importBuilder.put(VIDEOS, new KoofrVideosImporter(koofrClientFactory, monitor));
     importerMap = importBuilder.build();
 
-    ImmutableMap.Builder<String, Exporter> exportBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Exporter> exportBuilder = ImmutableMap.builder();
     exportBuilder.put(PHOTOS, new KoofrPhotosExporter(koofrClientFactory, monitor));
     exportBuilder.put(VIDEOS, new KoofrVideosExporter(koofrClientFactory, monitor));
     exporterMap = exportBuilder.build();

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/main/java/org/datatransferproject/transfer/microsoft/MicrosoftTransferExtension.java
@@ -1,5 +1,11 @@
 package org.datatransferproject.transfer.microsoft;
 
+import static org.datatransferproject.types.common.models.DataVertical.CALENDAR;
+import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
+import static org.datatransferproject.types.common.models.DataVertical.MEDIA;
+import static org.datatransferproject.types.common.models.DataVertical.OFFLINE_DATA;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,8 +16,8 @@ import okhttp3.OkHttpClient;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
-import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -34,22 +40,16 @@ import java.io.IOException;
 /** Bootstraps the Microsoft data transfer services. */
 public class MicrosoftTransferExtension implements TransferExtension {
   public static final String SERVICE_ID = "microsoft";
-  // TODO(#1065) centralized place, or enum type for these?
-  private static final String CONTACTS = "CONTACTS";
-  private static final String CALENDAR = "CALENDAR";
-  private static final String PHOTOS = "PHOTOS";
-  private static final String MEDIA = "MEDIA";
-  private static final String OFFLINE_DATA = "OFFLINE-DATA";
 
   // TODO(#1065) don't keep adding here - just have the converters invoked automatically when Media
   // isn't supported on one or the other side of this equation; this is just a WIP prototype to show
   // the concept of converters at play.
-  private static final ImmutableList<String> SUPPORTED_IMPORT_SERVICES =
+  private static final ImmutableList<DataVertical> SUPPORTED_IMPORT_SERVICES =
       ImmutableList.of(CALENDAR, CONTACTS, PHOTOS);
-  private static final ImmutableList<String> SUPPORTED_EXPORT_SERVICES =
+  private static final ImmutableList<DataVertical> SUPPORTED_EXPORT_SERVICES =
       ImmutableList.of(CALENDAR, CONTACTS, PHOTOS, MEDIA, OFFLINE_DATA);
-  private ImmutableMap<String, Importer> importerMap;
-  private ImmutableMap<String, Exporter> exporterMap;
+  private ImmutableMap<DataVertical, Importer> importerMap;
+  private ImmutableMap<DataVertical, Exporter> exporterMap;
 
   private static final String BASE_GRAPH_URL = "https://graph.microsoft.com";
 
@@ -68,7 +68,7 @@ public class MicrosoftTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkState(initialized);
 
     if (!offlineData && transferDataType.equals(OFFLINE_DATA)) {
@@ -83,7 +83,7 @@ public class MicrosoftTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkState(initialized);
     Preconditions.checkArgument(SUPPORTED_IMPORT_SERVICES.contains(transferDataType));
     return importerMap.get(transferDataType);
@@ -123,7 +123,7 @@ public class MicrosoftTransferExtension implements TransferExtension {
 
     Monitor monitor = context.getMonitor();
 
-    ImmutableMap.Builder<String, Importer> importBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Importer> importBuilder = ImmutableMap.builder();
     importBuilder.put(
         CONTACTS,
         new MicrosoftContactsImporter(BASE_GRAPH_URL, client, mapper, transformerService));
@@ -137,7 +137,7 @@ public class MicrosoftTransferExtension implements TransferExtension {
           credentialFactory));
     importerMap = importBuilder.build();
 
-    ImmutableMap.Builder<String, Exporter> exporterBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<DataVertical, Exporter> exporterBuilder = ImmutableMap.builder();
     exporterBuilder.put(
         CONTACTS,
         new MicrosoftContactsExporter(BASE_GRAPH_URL, client, mapper, transformerService));

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/LocalExportTestRunner.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/LocalExportTestRunner.java
@@ -1,5 +1,7 @@
 package org.datatransferproject.transfer.microsoft.integration;
 
+import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
+
 import java.util.Optional;
 import org.datatransferproject.auth.microsoft.harness.AuthTestDriver;
 import org.datatransferproject.spi.transfer.provider.ExportResult;
@@ -22,7 +24,7 @@ public class LocalExportTestRunner {
     TokenAuthData token = authTestDriver.getOAuthTokenCode();
 
     Exporter<TokenAuthData, ContactsModelWrapper> contacts =
-        (Exporter<TokenAuthData, ContactsModelWrapper>) serviceProvider.getExporter("CONTACTS");
+        (Exporter<TokenAuthData, ContactsModelWrapper>) serviceProvider.getExporter(CONTACTS);
     ExportResult<ContactsModelWrapper> wrapper = contacts.export(UUID.randomUUID(), token,
         Optional.empty());
   }

--- a/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/LocalImportTestRunner.java
+++ b/extensions/data-transfer/portability-data-transfer-microsoft/src/test/java/org/datatransferproject/transfer/microsoft/integration/LocalImportTestRunner.java
@@ -15,6 +15,8 @@
  */
 package org.datatransferproject.transfer.microsoft.integration;
 
+import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
+
 import ezvcard.VCard;
 import ezvcard.io.json.JCardWriter;
 import ezvcard.property.StructuredName;
@@ -40,7 +42,7 @@ public class LocalImportTestRunner {
     TokenAuthData token = authTestDriver.getOAuthTokenCode();
 
     Importer<TokenAuthData, ContactsModelWrapper> contacts =
-        (Importer<TokenAuthData, ContactsModelWrapper>) serviceProvider.getImporter("CONTACTS");
+        (Importer<TokenAuthData, ContactsModelWrapper>) serviceProvider.getImporter(CONTACTS);
 
     ContactsModelWrapper wrapper = new ContactsModelWrapper(createCards());
     FakeIdempotentImportExecutor executor = new FakeIdempotentImportExecutor();

--- a/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/OfflineDemoTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-offline-demo/src/main/java/org/datatransferproject/transfer/offline/OfflineDemoTransferExtension.java
@@ -1,6 +1,7 @@
 package org.datatransferproject.transfer.offline;
 
 import org.datatransferproject.api.launcher.ExtensionContext;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -19,12 +20,12 @@ public class OfflineDemoTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     return null;
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     return new OfflineDemoImporter();
   }
 

--- a/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/RememberTheMilkTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-rememberthemilk/src/main/java/org/datatransferproject/transfer/rememberthemilk/RememberTheMilkTransferExtension.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -31,9 +32,10 @@ import org.datatransferproject.types.transfer.auth.AppCredentials;
 import java.io.IOException;
 
 import static java.lang.String.format;
+import static org.datatransferproject.types.common.models.DataVertical.TASKS;
 
 public class RememberTheMilkTransferExtension implements TransferExtension {
-  private static final ImmutableList<String> SUPPORTED_DATA_TYPES = ImmutableList.of("TASKS");
+  private static final ImmutableList<DataVertical> SUPPORTED_DATA_TYPES = ImmutableList.of(TASKS);
   private static final String RTM_KEY = "RTM_KEY";
   private static final String RTM_SECRET = "RTM_SECRET";
   private RememberTheMilkTasksExporter exporter;
@@ -46,7 +48,7 @@ public class RememberTheMilkTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "RememberTheMilkTransferExtension not initialized. Unable to get Exporter");
     Preconditions.checkArgument(SUPPORTED_DATA_TYPES.contains(transferDataType));
@@ -54,7 +56,7 @@ public class RememberTheMilkTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "RememberTheMilkTransferExtension not initialized. Unable to get Importer");
     Preconditions.checkArgument(SUPPORTED_DATA_TYPES.contains(transferDataType));

--- a/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/SmugMugTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-smugmug/src/main/java/org/datatransferproject/transfer/smugmug/SmugMugTransferExtension.java
@@ -17,7 +17,6 @@
 package org.datatransferproject.transfer.smugmug;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.http.HttpTransport;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.ExtensionContext;
@@ -25,6 +24,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.api.launcher.TypeManager;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -35,10 +35,11 @@ import org.datatransferproject.types.transfer.auth.AppCredentials;
 import java.io.IOException;
 
 import static java.lang.String.format;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 
 public class SmugMugTransferExtension implements TransferExtension {
 
-  private static final ImmutableList<String> SUPPORTED_TYPES = ImmutableList.of("PHOTOS");
+  private static final ImmutableList<DataVertical> SUPPORTED_TYPES = ImmutableList.of(PHOTOS);
   private static final String SMUGMUG_KEY = "SMUGMUG_KEY";
   private static final String SMUGMUG_SECRET = "SMUGMUG_SECRET";
 
@@ -52,7 +53,7 @@ public class SmugMugTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "Trying to call getExporter before initalizing SmugMugTransferExtension");
     Preconditions.checkArgument(
@@ -62,7 +63,7 @@ public class SmugMugTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "Trying to call getImporter before initalizing SmugMugTransferExtension");
     Preconditions.checkArgument(

--- a/extensions/data-transfer/portability-data-transfer-spotify/src/main/java/org/datatransferproject/transfer/spotify/SpotifyTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-spotify/src/main/java/org/datatransferproject/transfer/spotify/SpotifyTransferExtension.java
@@ -15,6 +15,8 @@
  */
 package org.datatransferproject.transfer.spotify;
 
+import static org.datatransferproject.types.common.models.DataVertical.PLAYLISTS;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.wrapper.spotify.SpotifyApi;
@@ -22,6 +24,7 @@ import java.io.IOException;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -33,7 +36,7 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 
 public class SpotifyTransferExtension implements TransferExtension {
-  private static final ImmutableList<String> SUPPORTED_DATA_TYPES = ImmutableList.of("PLAYLISTS");
+  private static final ImmutableList<DataVertical> SUPPORTED_DATA_TYPES = ImmutableList.of(PLAYLISTS);
 
   private Exporter<TokensAndUrlAuthData, PlaylistContainerResource> exporter;
   private Importer<TokensAndUrlAuthData, PlaylistContainerResource> importer;
@@ -46,7 +49,7 @@ public class SpotifyTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "SpotifyTransferExtension not initialized. Unable to get Exporter");
     Preconditions.checkArgument(SUPPORTED_DATA_TYPES.contains(transferDataType));
@@ -54,7 +57,7 @@ public class SpotifyTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "SpotifyTransferExtension not initialized. Unable to get Importer");
     Preconditions.checkArgument(SUPPORTED_DATA_TYPES.contains(transferDataType));

--- a/extensions/data-transfer/portability-data-transfer-twitter/src/main/java/org/datatransferproject/transfer/twitter/TwitterTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-twitter/src/main/java/org/datatransferproject/transfer/twitter/TwitterTransferExtension.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -30,6 +31,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static java.lang.String.format;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 
 /**
  * Extension to allow Twitter content to be transferred.
@@ -39,7 +41,7 @@ import static java.lang.String.format;
  * <p>In the future if a social vertical gets defined support should be added for that.
  */
 public class TwitterTransferExtension implements TransferExtension {
-  private static final List<String> SUPPORTED_TYPES = ImmutableList.of("PHOTOS");
+  private static final List<DataVertical> SUPPORTED_TYPES = ImmutableList.of(PHOTOS);
   private static final String TWITTER_KEY = "TWITTER_KEY";
   private static final String TWITTER_SECRET = "TWITTER_SECRET";
 
@@ -53,7 +55,7 @@ public class TwitterTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Exporter<?, ?> getExporter(String transferDataType) {
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "Trying to call getExporter before initalizing TwitterTransferExtension");
     Preconditions.checkArgument(
@@ -63,7 +65,7 @@ public class TwitterTransferExtension implements TransferExtension {
   }
 
   @Override
-  public Importer<?, ?> getImporter(String transferDataType) {
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
     Preconditions.checkArgument(
         initialized, "Trying to call getImporter before initalizing TwitterTransferExtension");
     Preconditions.checkArgument(

--- a/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/rest/TransferServicesController.java
+++ b/extensions/transport/portability-transport-jettyrest/src/main/java/org/datatransferproject/transport/jettyrest/rest/TransferServicesController.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /** Lists services available for export and import for the given type. */
 @Consumes({MediaType.APPLICATION_JSON})
@@ -39,7 +40,7 @@ public class TransferServicesController {
 
   @GET()
   @Path("{dataType}")
-  public TransferServices transferServices(@PathParam("dataType") String dataType) {
+  public TransferServices transferServices(@PathParam("dataType") DataVertical dataType) {
     return action.handle(new GetTransferServices(dataType));
   }
 }

--- a/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1Config.java
+++ b/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1Config.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Interface for providing information necessary to run OAuth1 flow
@@ -50,13 +51,15 @@ public interface OAuth1Config {
 
   /**
    * Returns a list of export data types (e.g., PHOTOS, CALENDAR) this config is designed to support.
+   * @return
    */
-  List<String> getExportTypes();
+  List<DataVertical> getExportTypes();
 
   /**
    * Returns a list of import data types (e.g., PHOTOS, CALENDAR) this config is designed to support.
+   * @return
    */
-  List<String> getImportTypes();
+  List<DataVertical> getImportTypes();
 
   /**
    * Return a map of parameters that will be added to the OAuth request.
@@ -68,7 +71,7 @@ public interface OAuth1Config {
    * privilege for the given mode (EXPORT, IMPORT) should be used.
    */
   default Map<String, String> getAdditionalUrlParameters(
-      String dataType, AuthMode mode, OAuth1Step step) {
+      DataVertical dataType, AuthMode mode, OAuth1Step step) {
     return Collections.emptyMap();
   }
 

--- a/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1DataGenerator.java
+++ b/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1DataGenerator.java
@@ -30,6 +30,7 @@ import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 import org.datatransferproject.spi.api.types.AuthFlowConfiguration;
 import org.datatransferproject.types.common.PortabilityCommon.AuthProtocol;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.AuthData;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
@@ -41,7 +42,7 @@ public class OAuth1DataGenerator implements AuthDataGenerator {
 
   private final OAuth1Config config;
   private final Monitor monitor;
-  private final String dataType;
+  private final DataVertical dataType;
   private final AuthMode mode;
   // TODO: handle dynamic updates of client ids and secrets #597
   private final String clientId;
@@ -52,7 +53,7 @@ public class OAuth1DataGenerator implements AuthDataGenerator {
       OAuth1Config config,
       AppCredentials appCredentials,
       HttpTransport httpTransport,
-      String datatype,
+      DataVertical datatype,
       AuthMode mode,
       Monitor monitor) {
     this.config = config;

--- a/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1ServiceExtension.java
+++ b/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth1ServiceExtension.java
@@ -30,6 +30,7 @@ import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 
 /**
@@ -40,8 +41,8 @@ public class OAuth1ServiceExtension implements AuthServiceExtension {
 
   private final OAuth1Config oAuth1Config;
 
-  private volatile Map<String, OAuth1DataGenerator> exportAuthDataGenerators;
-  private volatile Map<String, OAuth1DataGenerator> importAuthDataGenerators;
+  private volatile Map<DataVertical, OAuth1DataGenerator> exportAuthDataGenerators;
+  private volatile Map<DataVertical, OAuth1DataGenerator> importAuthDataGenerators;
 
   private AppCredentials appCredentials;
   private HttpTransport httpTransport;
@@ -59,17 +60,17 @@ public class OAuth1ServiceExtension implements AuthServiceExtension {
   }
 
   @Override
-  public AuthDataGenerator getAuthDataGenerator(String transferDataType, AuthMode mode) {
+  public AuthDataGenerator getAuthDataGenerator(DataVertical transferDataType, AuthMode mode) {
     return getOrCreateAuthDataGenerator(transferDataType, mode);
   }
 
   @Override
-  public List<String> getImportTypes() {
+  public List<DataVertical> getImportTypes() {
     return oAuth1Config.getImportTypes();
   }
 
   @Override
-  public List<String> getExportTypes() {
+  public List<DataVertical> getExportTypes() {
     return oAuth1Config.getExportTypes();
   }
 
@@ -105,14 +106,14 @@ public class OAuth1ServiceExtension implements AuthServiceExtension {
   }
 
   private synchronized OAuth1DataGenerator getOrCreateAuthDataGenerator(
-      String transferType, AuthMode mode) {
+      DataVertical transferType, AuthMode mode) {
     Preconditions.checkState(initialized, "Cannot get OAuth1DataGenerator before initialization");
     Preconditions.checkArgument(
         mode == AuthMode.EXPORT
             ? getExportTypes().contains(transferType)
             : getImportTypes().contains(transferType));
 
-    Map<String, OAuth1DataGenerator> generators =
+    Map<DataVertical, OAuth1DataGenerator> generators =
         mode == AuthMode.EXPORT ? exportAuthDataGenerators : importAuthDataGenerators;
 
     if (!generators.containsKey(transferType)) {

--- a/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth2Config.java
+++ b/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth2Config.java
@@ -18,9 +18,9 @@ package org.datatransferproject.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 /**
@@ -46,14 +46,16 @@ public interface OAuth2Config {
   /**
    * Returns a map of scopes needed for export, keyed by data type (e.g., PHOTOS, CALENDAR) as
    * defined in the auth data generator or elsewhere
+   * @return
    */
-  Map<String, Set<String>> getExportScopes();
+  Map<DataVertical, Set<String>> getExportScopes();
 
   /**
    * Returns a map of scopes needed for import, keyed by data type (e.g., PHOTOS, CALENDAR) as
    * defined in the auth data generator or elsewhere
+   * @return
    */
-  Map<String, Set<String>> getImportScopes();
+  Map<DataVertical, Set<String>> getImportScopes();
 
   /**
    * Returns a map of any additional parameters necessary for this service

--- a/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth2DataGenerator.java
+++ b/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth2DataGenerator.java
@@ -35,6 +35,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 import org.datatransferproject.spi.api.types.AuthFlowConfiguration;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.AuthData;
 
@@ -52,7 +53,7 @@ public class OAuth2DataGenerator implements AuthDataGenerator {
 
   OAuth2DataGenerator(OAuth2Config config, AppCredentials appCredentials,
       HttpTransport httpTransport,
-      String dataType, AuthMode authMode) {
+      DataVertical dataType, AuthMode authMode) {
     this.config = config;
     validateConfig();
     this.clientId = appCredentials.getKey();

--- a/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth2ServiceExtension.java
+++ b/libraries/auth/src/main/java/org/datatransferproject/auth/OAuth2ServiceExtension.java
@@ -24,6 +24,7 @@ import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 
 import java.io.IOException;
@@ -42,8 +43,8 @@ public class OAuth2ServiceExtension implements AuthServiceExtension {
 
   private final OAuth2Config oAuth2Config;
 
-  private volatile Map<String, OAuth2DataGenerator> exportAuthDataGenerators;
-  private volatile Map<String, OAuth2DataGenerator> importAuthDataGenerators;
+  private volatile Map<DataVertical, OAuth2DataGenerator> exportAuthDataGenerators;
+  private volatile Map<DataVertical, OAuth2DataGenerator> importAuthDataGenerators;
 
   private AppCredentials appCredentials;
   private HttpTransport httpTransport;
@@ -60,17 +61,17 @@ public class OAuth2ServiceExtension implements AuthServiceExtension {
   }
 
   @Override
-  public AuthDataGenerator getAuthDataGenerator(String transferDataType, AuthMode mode) {
+  public AuthDataGenerator getAuthDataGenerator(DataVertical transferDataType, AuthMode mode) {
     return getOrCreateAuthDataGenerator(transferDataType, mode);
   }
 
   @Override
-  public List<String> getImportTypes() {
+  public List<DataVertical> getImportTypes() {
     return new ArrayList<>(oAuth2Config.getImportScopes().keySet());
   }
 
   @Override
-  public List<String> getExportTypes() {
+  public List<DataVertical> getExportTypes() {
     return new ArrayList<>(oAuth2Config.getExportScopes().keySet());
   }
 
@@ -106,14 +107,14 @@ public class OAuth2ServiceExtension implements AuthServiceExtension {
   }
 
   private synchronized OAuth2DataGenerator getOrCreateAuthDataGenerator(
-      String transferType, AuthMode mode) {
+      DataVertical transferType, AuthMode mode) {
     Preconditions.checkState(initialized, "Cannot get OAuth2DataGenerator before initialization");
     Preconditions.checkArgument(
         mode == AuthMode.EXPORT
             ? getExportTypes().contains(transferType)
             : getImportTypes().contains(transferType));
 
-    Map<String, OAuth2DataGenerator> generators =
+    Map<DataVertical, OAuth2DataGenerator> generators =
         mode == AuthMode.EXPORT ? exportAuthDataGenerators : importAuthDataGenerators;
 
     if (!generators.containsKey(transferType)) {

--- a/portability-api-launcher/build.gradle
+++ b/portability-api-launcher/build.gradle
@@ -9,6 +9,10 @@ plugins {
     id 'signing'
 }
 
+dependencies {
+    compile project(':portability-types-common')
+}
+
 configurePublication(project)
 
 

--- a/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/DtpInternalMetricRecorder.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/DtpInternalMetricRecorder.java
@@ -16,6 +16,7 @@
 package org.datatransferproject.api.launcher;
 
 import java.time.Duration;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Interface to log metrics about a DTP job.
@@ -30,44 +31,44 @@ public interface DtpInternalMetricRecorder {
   // Metrics related to DTP internals
 
   /** A DTP job started. **/
-  void startedJob(String dataType, String exportService, String importService);
+  void startedJob(DataVertical dataType, String exportService, String importService);
   /** A DTP job finished **/
   void finishedJob(
-      String dataType,
+      DataVertical dataType,
       String exportService,
       String importService,
       boolean success,
       Duration duration);
   /** A DTP job cancelled **/
   void cancelledJob(
-      String dataType,
+      DataVertical dataType,
       String exportService,
       String importService,
       Duration duration);
 
   /** An single attempt to export a page of data finished. **/
   void exportPageAttemptFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration);
 
   /** An attempt to export a page of data finished including all retires. **/
-  void exportPageFinished(String dataType, String service, boolean success, Duration duration);
+  void exportPageFinished(DataVertical dataType, String service, boolean success, Duration duration);
 
   /** An single attempt to import a page of data finished. **/
   void importPageAttemptFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration);
 
   /** An attempt to import a page of data finished including all retires. **/
-  void importPageFinished(String dataType, String service, boolean success, Duration duration);
+  void importPageFinished(DataVertical dataType, String service, boolean success, Duration duration);
 
   // Metrics from {@link MetricRecorder}
-  void recordGenericMetric(String dataType, String service, String tag);
-  void recordGenericMetric(String dataType, String service, String tag, boolean bool);
-  void recordGenericMetric(String dataType, String service, String tag, Duration duration);
-  void recordGenericMetric(String dataType, String service, String tag, int value);
+  void recordGenericMetric(DataVertical dataType, String service, String tag);
+  void recordGenericMetric(DataVertical dataType, String service, String tag, boolean bool);
+  void recordGenericMetric(DataVertical dataType, String service, String tag, Duration duration);
+  void recordGenericMetric(DataVertical dataType, String service, String tag, int value);
 }

--- a/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/MetricRecorder.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/api/launcher/MetricRecorder.java
@@ -16,6 +16,7 @@
 package org.datatransferproject.api.launcher;
 
 import java.time.Duration;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Interface to allow transfer extensions to record generic metrics/stats about their processing.
@@ -26,34 +27,34 @@ public interface MetricRecorder {
    * Record a generic event metric.
    *
    * @param dataType the data type being processed
-   * @param tag a tag to identify the metric, this should be a low cardinality value
+   * @param tag      a tag to identify the metric, this should be a low cardinality value
    */
-  void recordMetric(String dataType, String tag);
+  void recordMetric(DataVertical dataType, String tag);
 
   /**
    * Record a generic event metric with a boolean value.
    *
    * @param dataType the data type being processed
-   * @param tag a tag to identify the metric, this should be a low cardinality value
-   * @param bool a true/false value related to the event
+   * @param tag      a tag to identify the metric, this should be a low cardinality value
+   * @param bool     a true/false value related to the event
    */
-  void recordMetric(String dataType, String tag, boolean bool);
+  void recordMetric(DataVertical dataType, String tag, boolean bool);
 
   /**
    * Record a generic event metric with a boolean value.
    *
    * @param dataType the data type being processed
-   * @param tag a tag to identify the metric, this should be a low cardinality value
+   * @param tag      a tag to identify the metric, this should be a low cardinality value
    * @param duration a duration related to the event
    */
-  void recordMetric(String dataType, String tag, Duration duration);
+  void recordMetric(DataVertical dataType, String tag, Duration duration);
 
   /**
    * Record a generic event metric with a integer value.
    *
    * @param dataType the data type being processed
-   * @param tag a tag to identify the metric, this should be a low cardinality value
-   * @param value a numeric value related to the event
+   * @param tag      a tag to identify the metric, this should be a low cardinality value
+   * @param value    a numeric value related to the event
    */
-  void recordMetric(String dataType, String tag, int value);
+  void recordMetric(DataVertical dataType, String tag, int value);
 }

--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/metrics/LoggingDtpInternalMetricRecorder.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/metrics/LoggingDtpInternalMetricRecorder.java
@@ -22,6 +22,7 @@ import org.datatransferproject.api.launcher.ExtensionContext;
 import org.datatransferproject.api.launcher.Monitor;
 
 import java.time.Duration;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * A default {@link DtpInternalMetricRecorder} that simply logs metrics
@@ -47,7 +48,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
   }
 
   @Override
-  public void startedJob(String dataType, String exportService, String importService) {
+  public void startedJob(DataVertical dataType, String exportService, String importService) {
     monitor.debug(
         () ->
             format(
@@ -57,7 +58,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
 
   @Override
   public void exportPageAttemptFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
@@ -71,7 +72,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
 
   @Override
   public void exportPageFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
@@ -84,7 +85,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
 
   @Override
   public void importPageAttemptFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
@@ -98,7 +99,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
 
   @Override
   public void importPageFinished(
-      String dataType,
+      DataVertical dataType,
       String service,
       boolean success,
       Duration duration) {
@@ -111,7 +112,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
 
   @Override
   public void finishedJob(
-      String dataType,
+      DataVertical dataType,
       String exportService,
       String importService,
       boolean success,
@@ -125,7 +126,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
 
   @Override
   public void cancelledJob(
-      String dataType, String exportService, String importService, Duration duration) {
+      DataVertical dataType, String exportService, String importService, Duration duration) {
     monitor.debug(
         () ->
             format(
@@ -134,14 +135,14 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag) {
     monitor.debug(
         () ->
             format("Metric: Generic, data type: %s, service: %s, tag: %s", dataType, service, tag));
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, boolean bool) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, boolean bool) {
     monitor.debug(
         () ->
             format(
@@ -150,7 +151,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, Duration duration) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, Duration duration) {
     monitor.debug(
         () ->
             format(
@@ -159,7 +160,7 @@ public class LoggingDtpInternalMetricRecorder implements DtpInternalMetricRecord
   }
 
   @Override
-  public void recordGenericMetric(String dataType, String service, String tag, int value) {
+  public void recordGenericMetric(DataVertical dataType, String service, String tag, int value) {
     monitor.debug(
         () ->
             format(

--- a/portability-api-launcher/src/main/java/org/datatransferproject/launcher/metrics/ServiceAwareMetricRecorder.java
+++ b/portability-api-launcher/src/main/java/org/datatransferproject/launcher/metrics/ServiceAwareMetricRecorder.java
@@ -19,6 +19,7 @@ import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
 import org.datatransferproject.api.launcher.MetricRecorder;
 
 import java.time.Duration;
+import org.datatransferproject.types.common.models.DataVertical;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,22 +38,22 @@ public class ServiceAwareMetricRecorder implements MetricRecorder {
     this.metricRecorder = checkNotNull(metricRecorder, "metricRecorder can't be null");
   }
   @Override
-  public void recordMetric(String dataType, String tag) {
+  public void recordMetric(DataVertical dataType, String tag) {
     metricRecorder.recordGenericMetric(dataType, service, tag);
   }
 
   @Override
-  public void recordMetric(String dataType, String tag, boolean bool) {
+  public void recordMetric(DataVertical dataType, String tag, boolean bool) {
     metricRecorder.recordGenericMetric(dataType, service, tag, bool);
   }
 
   @Override
-  public void recordMetric(String dataType, String tag, Duration duration) {
+  public void recordMetric(DataVertical dataType, String tag, Duration duration) {
     metricRecorder.recordGenericMetric(dataType, service, tag, duration);
   }
 
   @Override
-  public void recordMetric(String dataType, String tag, int value) {
+  public void recordMetric(DataVertical dataType, String tag, int value) {
     metricRecorder.recordGenericMetric(dataType, service, tag, value);
   }
 }

--- a/portability-api/src/main/java/org/datatransferproject/api/action/ActionUtils.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/ActionUtils.java
@@ -21,6 +21,7 @@ import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 
 import java.util.UUID;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /** Helper functions for validating action related data. */
 public final class ActionUtils {
@@ -36,8 +37,9 @@ public final class ActionUtils {
         Charsets.UTF_8));
   }
 
-  /** Determines whether the current service is a valid service for import. */
-  public static boolean isValidTransferDataType(String transferDataType) {
-    return !Strings.isNullOrEmpty(transferDataType);
+  /** Determines whether the current service is a valid service for import.
+   * @param transferDataType*/
+  public static boolean isValidTransferDataType(DataVertical transferDataType) {
+    return transferDataType != null;
   }
 }

--- a/portability-api/src/main/java/org/datatransferproject/api/action/datatype/DataTypesAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/datatype/DataTypesAction.java
@@ -23,6 +23,7 @@ import org.datatransferproject.types.client.datatype.DataTypes;
 import org.datatransferproject.types.client.datatype.GetDataTypes;
 
 import java.util.Set;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * An {@link Action} that handles listing data types available for export and import for a given
@@ -46,7 +47,7 @@ public final class DataTypesAction implements Action<GetDataTypes, DataTypes> {
   /** Lists the set of data types that support both import and export. */
   @Override
   public DataTypes handle(GetDataTypes request) {
-    Set<String> transferDataTypes = registry.getTransferDataTypes();
+    Set<DataVertical> transferDataTypes = registry.getTransferDataTypes();
     if (transferDataTypes.isEmpty()) {
       monitor.severe(
           () ->

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/CreateTransferJobAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/CreateTransferJobAction.java
@@ -27,6 +27,7 @@ import org.datatransferproject.spi.api.types.AuthFlowConfiguration;
 import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.client.transfer.CreateTransferJob;
 import org.datatransferproject.types.client.transfer.TransferJob;
 import org.datatransferproject.types.common.ExportInformation;
@@ -66,7 +67,7 @@ public class CreateTransferJobAction implements Action<CreateTransferJob, Transf
 
   @Override
   public TransferJob handle(CreateTransferJob request) {
-    String dataType = request.getDataType();
+    DataVertical dataType = request.getDataType();
     String exportService = request.getExportService();
     String importService = request.getImportService();
     Optional<ExportInformation> exportInformation = Optional
@@ -191,7 +192,7 @@ public class CreateTransferJobAction implements Action<CreateTransferJob, Transf
    */
   private PortabilityJob createJob(
       String encodedSessionKey,
-      String dataType,
+      DataVertical dataType,
       String exportService,
       String importService,
       Optional<ExportInformation> exportInformation,

--- a/portability-api/src/main/java/org/datatransferproject/api/action/transfer/GetTransferServicesAction.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/action/transfer/GetTransferServicesAction.java
@@ -23,6 +23,7 @@ import org.datatransferproject.types.client.transfer.TransferServices;
 import org.datatransferproject.types.client.transfer.GetTransferServices;
 
 import java.util.Set;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /** Returns the import and export services available for a given data type. */
 public final class GetTransferServicesAction
@@ -43,7 +44,7 @@ public final class GetTransferServicesAction
   /** Lists the services available for export and import for a given data type. */
   @Override
   public TransferServices handle(GetTransferServices request) {
-    String transferDataType = request.getTransferDataType();
+    DataVertical transferDataType = request.getTransferDataType();
     // Validate incoming data type parameter
     if (!ActionUtils.isValidTransferDataType(transferDataType)) {
       throw new IllegalArgumentException("Invalid transferDataType: " + transferDataType);

--- a/portability-api/src/main/java/org/datatransferproject/api/auth/PortabilityAuthServiceProviderRegistry.java
+++ b/portability-api/src/main/java/org/datatransferproject/api/auth/PortabilityAuthServiceProviderRegistry.java
@@ -29,11 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.datatransferproject.types.common.models.DataVertical;
 
 public class PortabilityAuthServiceProviderRegistry implements AuthServiceProviderRegistry {
   private final ImmutableMap<String, AuthServiceExtension> authServiceProviderMap;
-  private final ImmutableSet<String> supportedImportTypes;
-  private final ImmutableSet<String> supportedExportTypes;
+  private final ImmutableSet<DataVertical> supportedImportTypes;
+  private final ImmutableSet<DataVertical> supportedExportTypes;
 
   @Inject
   public PortabilityAuthServiceProviderRegistry(
@@ -41,14 +42,14 @@ public class PortabilityAuthServiceProviderRegistry implements AuthServiceProvid
 
     ImmutableMap.Builder<String, AuthServiceExtension> serviceProviderBuilder =
         ImmutableMap.builder();
-    ImmutableSet.Builder<String> supportedImportTypesBuilder = ImmutableSet.builder();
-    ImmutableSet.Builder<String> supportedExportTypesBuilder = ImmutableSet.builder();
+    ImmutableSet.Builder<DataVertical> supportedImportTypesBuilder = ImmutableSet.builder();
+    ImmutableSet.Builder<DataVertical> supportedExportTypesBuilder = ImmutableSet.builder();
 
     serviceProviderMap.forEach(
         (service, provider) -> {
-          List<String> importTypes = provider.getImportTypes();
-          List<String> exportTypes = provider.getExportTypes();
-          for (String type : importTypes) {
+          List<DataVertical> importTypes = provider.getImportTypes();
+          List<DataVertical> exportTypes = provider.getExportTypes();
+          for (DataVertical type : importTypes) {
             Preconditions.checkArgument(
                 exportTypes.contains(type),
                 "TransferDataType [%s] is available for import but not export in [%s] AuthServiceExtension",
@@ -67,7 +68,7 @@ public class PortabilityAuthServiceProviderRegistry implements AuthServiceProvid
 
   @Override
   public AuthDataGenerator getAuthDataGenerator(
-      String serviceId, String transferDataType, AuthMode mode) {
+      String serviceId, DataVertical transferDataType, AuthMode mode) {
     AuthServiceExtension provider = authServiceProviderMap.get(serviceId);
     Preconditions.checkArgument(
         provider != null, "AuthServiceExtension not found for serviceId [%s]", serviceId);
@@ -94,7 +95,7 @@ public class PortabilityAuthServiceProviderRegistry implements AuthServiceProvid
   }
 
   @Override
-  public Set<String> getImportServices(String transferDataType) {
+  public Set<String> getImportServices(DataVertical transferDataType) {
     Preconditions.checkArgument(
         supportedImportTypes.contains(transferDataType),
         "TransferDataType [%s] is not valid for import",
@@ -103,13 +104,13 @@ public class PortabilityAuthServiceProviderRegistry implements AuthServiceProvid
         .values()
         .stream()
         .filter(
-            sp -> sp.getImportTypes().stream().anyMatch(e -> e.equalsIgnoreCase(transferDataType)))
+            sp -> sp.getImportTypes().stream().anyMatch(e -> e == transferDataType))
         .map(AuthServiceExtension::getServiceId)
         .collect(Collectors.toSet());
   }
 
   @Override
-  public Set<String> getExportServices(String transferDataType) {
+  public Set<String> getExportServices(DataVertical transferDataType) {
     Preconditions.checkArgument(
         supportedExportTypes.contains(transferDataType),
         "TransferDataType [%s] is not valid for export",
@@ -118,14 +119,14 @@ public class PortabilityAuthServiceProviderRegistry implements AuthServiceProvid
         .values()
         .stream()
         .filter(
-            sp -> sp.getExportTypes().stream().anyMatch(e -> e.equalsIgnoreCase(transferDataType)))
+            sp -> sp.getExportTypes().stream().anyMatch(e -> e == transferDataType))
         .map(AuthServiceExtension::getServiceId)
         .collect(Collectors.toSet());
   }
 
   /** Returns the set of data types that support both import and export. */
   @Override
-  public Set<String> getTransferDataTypes() {
+  public Set<DataVertical> getTransferDataTypes() {
     return Sets.intersection(supportedExportTypes, supportedImportTypes);
   }
 }

--- a/portability-api/src/test/java/org/datatransferproject/api/action/datatype/DataTypesActionTest.java
+++ b/portability-api/src/test/java/org/datatransferproject/api/action/datatype/DataTypesActionTest.java
@@ -1,5 +1,7 @@
 package org.datatransferproject.api.action.datatype;
 
+import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,6 +12,7 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry;
 import org.datatransferproject.types.client.datatype.DataTypes;
 import org.datatransferproject.types.client.datatype.GetDataTypes;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +31,7 @@ public class DataTypesActionTest {
   @Test
   public void testHandle() {
     AuthServiceProviderRegistry registry = mock(AuthServiceProviderRegistry.class);
-    Set<String> dataTypes = new HashSet<>(Arrays.asList("CONTACTS", "PHOTOS"));
+    Set<DataVertical> dataTypes = new HashSet<>(Arrays.asList(CONTACTS, PHOTOS));
     when(registry.getTransferDataTypes()).thenReturn(dataTypes);
     DataTypesAction dataTypesAction = new DataTypesAction(registry, new Monitor() {});
 

--- a/portability-api/src/test/java/org/datatransferproject/api/auth/PortabilityAuthServiceExtensionRegistryTest.java
+++ b/portability-api/src/test/java/org/datatransferproject/api/auth/PortabilityAuthServiceExtensionRegistryTest.java
@@ -16,6 +16,8 @@
 
 package org.datatransferproject.api.auth;
 
+import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +30,7 @@ import java.util.Set;
 import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.junit.Assert;
 import org.junit.Rule;
 
@@ -39,7 +42,7 @@ public class PortabilityAuthServiceExtensionRegistryTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private AuthServiceExtension getMockedAuthProvider(
-      List<String> supportedImportTypes, List<String> supportedExportTypes, String serviceId) {
+      List<DataVertical> supportedImportTypes, List<DataVertical> supportedExportTypes, String serviceId) {
     AuthServiceExtension mockAuthProvider = mock(AuthServiceExtension.class);
 
     when(mockAuthProvider.getExportTypes()).thenReturn(supportedExportTypes);
@@ -51,8 +54,8 @@ public class PortabilityAuthServiceExtensionRegistryTest {
 
   @Test
   public void requireImportAndExportTest() {
-    List<String> supportedImportTypes = ImmutableList.of("PHOTOS", "CONTACTS");
-    List<String> supportedExportTypes = ImmutableList.of("CONTACTS");
+    List<DataVertical> supportedImportTypes = ImmutableList.of(PHOTOS, CONTACTS);
+    List<DataVertical> supportedExportTypes = ImmutableList.of(CONTACTS);
 
     AuthServiceExtension mockAuthProvider = getMockedAuthProvider(
         supportedImportTypes, supportedExportTypes, "mockAuthProvider");
@@ -66,7 +69,7 @@ public class PortabilityAuthServiceExtensionRegistryTest {
 
   @Test
   public void testGetTransferDataTypes() {
-    List<String> supportedServiceTypes = ImmutableList.of("PHOTOS", "CONTACTS");
+    List<DataVertical> supportedServiceTypes = ImmutableList.of(PHOTOS, CONTACTS);
 
     AuthServiceExtension mockAuthProvider = getMockedAuthProvider(
         supportedServiceTypes, supportedServiceTypes, "mockAuthProvider");
@@ -75,18 +78,18 @@ public class PortabilityAuthServiceExtensionRegistryTest {
         new PortabilityAuthServiceProviderRegistry(
             ImmutableMap.of("mockServiceProvider", mockAuthProvider));
 
-    Set<String> actual = registry.getTransferDataTypes();
+    Set<DataVertical> actual = registry.getTransferDataTypes();
 
-    final String services[] = new String[] {"PHOTOS", "CONTACTS"};
-    Set<String> expected = new HashSet<>(Arrays.asList(services));
+    final DataVertical[] services = new DataVertical[] {PHOTOS, CONTACTS};
+    Set<DataVertical> expected = new HashSet<>(Arrays.asList(services));
 
     Assert.assertEquals(actual, expected);
   }
 
   @Test
   public void testGetExportServices1() {
-    List<String> supportedServiceTypes1 = ImmutableList.of("PHOTOS", "CONTACTS");
-    List<String> supportedServiceTypes2 = ImmutableList.of("CONTACTS");
+    List<DataVertical> supportedServiceTypes1 = ImmutableList.of(PHOTOS, CONTACTS);
+    List<DataVertical> supportedServiceTypes2 = ImmutableList.of(CONTACTS);
 
     AuthServiceExtension mockAuthProvider1 = getMockedAuthProvider(
         supportedServiceTypes1, supportedServiceTypes1, "mockAuthProvider1");
@@ -98,8 +101,8 @@ public class PortabilityAuthServiceExtensionRegistryTest {
             ImmutableMap.of("mockServiceProvider1", mockAuthProvider1,
                 "mockServiceProvider2", mockAuthProvider2));
 
-    Set<String> actual = registry.getExportServices("CONTACTS");
-    final String services[] = new String[]{"mockAuthProvider1", "mockAuthProvider2"};
+    Set<String> actual = registry.getExportServices(CONTACTS);
+    final String[] services = new String[]{"mockAuthProvider1", "mockAuthProvider2"};
     Set<String> expected = new HashSet<>(Arrays.asList(services));
 
     Assert.assertEquals(actual, expected);
@@ -107,8 +110,8 @@ public class PortabilityAuthServiceExtensionRegistryTest {
 
   @Test
   public void testGetExportServices2() {
-    List<String> supportedServiceTypes1 = ImmutableList.of("PHOTOS", "CONTACTS");
-    List<String> supportedServiceTypes2 = ImmutableList.of("CONTACTS");
+    List<DataVertical> supportedServiceTypes1 = ImmutableList.of(PHOTOS, CONTACTS);
+    List<DataVertical> supportedServiceTypes2 = ImmutableList.of(CONTACTS);
 
     AuthServiceExtension mockAuthProvider1 = getMockedAuthProvider(
         supportedServiceTypes1, supportedServiceTypes1, "mockAuthProvider1");
@@ -120,8 +123,8 @@ public class PortabilityAuthServiceExtensionRegistryTest {
             ImmutableMap.of("mockServiceProvider1", mockAuthProvider1,
                 "mockServiceProvider2", mockAuthProvider2));
 
-    Set<String> actual = registry.getExportServices("PHOTOS");
-    final String services[] = new String[] {"mockAuthProvider1"};
+    Set<String> actual = registry.getExportServices(PHOTOS);
+    final String[] services = new String[] {"mockAuthProvider1"};
     Set<String> expected = new HashSet<>(Arrays.asList(services));
 
     Assert.assertEquals(actual, expected);
@@ -129,8 +132,8 @@ public class PortabilityAuthServiceExtensionRegistryTest {
 
   @Test
   public void testGetImportServices1() {
-    List<String> supportedServiceTypes1 = ImmutableList.of("PHOTOS", "CONTACTS");
-    List<String> supportedServiceTypes2 = ImmutableList.of("CONTACTS");
+    List<DataVertical> supportedServiceTypes1 = ImmutableList.of(PHOTOS, CONTACTS);
+    List<DataVertical> supportedServiceTypes2 = ImmutableList.of(CONTACTS);
 
     AuthServiceExtension mockAuthProvider1 = getMockedAuthProvider(
         supportedServiceTypes1, supportedServiceTypes1, "mockAuthProvider1");
@@ -141,8 +144,8 @@ public class PortabilityAuthServiceExtensionRegistryTest {
             ImmutableMap.of("mockServiceProvider1", mockAuthProvider1,
                 "mockServiceProvider2", mockAuthProvider2));
 
-    Set<String> actual = registry.getImportServices("CONTACTS");
-    final String services[] = new String[]{"mockAuthProvider1", "mockAuthProvider2"};
+    Set<String> actual = registry.getImportServices(CONTACTS);
+    final String[] services = new String[]{"mockAuthProvider1", "mockAuthProvider2"};
     Set<String> expected = new HashSet<>(Arrays.asList(services));
 
     Assert.assertEquals(actual, expected);
@@ -150,8 +153,8 @@ public class PortabilityAuthServiceExtensionRegistryTest {
 
   @Test
   public void testGetImportServices2() {
-    List<String> supportedServiceTypes1 = ImmutableList.of("PHOTOS", "CONTACTS");
-    List<String> supportedServiceTypes2 = ImmutableList.of("CONTACTS");
+    List<DataVertical> supportedServiceTypes1 = ImmutableList.of(PHOTOS, CONTACTS);
+    List<DataVertical> supportedServiceTypes2 = ImmutableList.of(CONTACTS);
 
     AuthServiceExtension mockAuthProvider1 = getMockedAuthProvider(
         supportedServiceTypes1, supportedServiceTypes1, "mockAuthProvider1");
@@ -163,8 +166,8 @@ public class PortabilityAuthServiceExtensionRegistryTest {
             ImmutableMap.of("mockServiceProvider1", mockAuthProvider1,
                 "mockServiceProvider2", mockAuthProvider2));
 
-    Set<String> actual = registry.getImportServices("PHOTOS");
-    final String services[] = new String[] {"mockAuthProvider1"};
+    Set<String> actual = registry.getImportServices(PHOTOS);
+    final String[] services = new String[] {"mockAuthProvider1"};
     Set<String> expected = new HashSet<>(Arrays.asList(services));
 
     Assert.assertEquals(actual, expected);
@@ -172,12 +175,12 @@ public class PortabilityAuthServiceExtensionRegistryTest {
 
   @Test
   public void testGetAuthDataGenerator() {
-    List<String> supportedServiceTypes = ImmutableList.of("PHOTOS", "CONTACTS");
+    List<DataVertical> supportedServiceTypes = ImmutableList.of(PHOTOS, CONTACTS);
     AuthServiceExtension mockAuthProvider = getMockedAuthProvider(
         supportedServiceTypes, supportedServiceTypes, "mockAuthProvider");
 
     when(mockAuthProvider
-        .getAuthDataGenerator("CONTACTS", AuthServiceProviderRegistry.AuthMode.EXPORT))
+        .getAuthDataGenerator(CONTACTS, AuthServiceProviderRegistry.AuthMode.EXPORT))
         .thenReturn(mock(AuthDataGenerator.class));
 
     AuthServiceProviderRegistry registry =
@@ -185,7 +188,7 @@ public class PortabilityAuthServiceExtensionRegistryTest {
             ImmutableMap.of("mockServiceProvider", mockAuthProvider));
 
     AuthDataGenerator actual = registry.getAuthDataGenerator(
-        "mockServiceProvider","CONTACTS", AuthServiceProviderRegistry.AuthMode.EXPORT);
+        "mockServiceProvider", CONTACTS, AuthServiceProviderRegistry.AuthMode.EXPORT);
 
     Assert.assertNotNull(actual);
   }

--- a/portability-spi-api/src/main/java/org/datatransferproject/spi/api/auth/AuthServiceProviderRegistry.java
+++ b/portability-spi-api/src/main/java/org/datatransferproject/spi/api/auth/AuthServiceProviderRegistry.java
@@ -2,6 +2,7 @@ package org.datatransferproject.spi.api.auth;
 
 import java.util.Set;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /** Manages {@link AuthServiceExtension}s registered in the system. */
 public interface AuthServiceProviderRegistry {
@@ -15,24 +16,25 @@ public interface AuthServiceProviderRegistry {
    * @return An AuthDataGenerator from the specified AuthServiceExtension for the type and mode
    *     requested.
    */
-  AuthDataGenerator getAuthDataGenerator(String serviceId, String transferDataType, AuthMode mode);
+  AuthDataGenerator getAuthDataGenerator(String serviceId, DataVertical transferDataType, AuthMode mode);
 
   /**
    * Returns the set of service ids that can import the given {@code transferDataType}.
    *
    * @param transferDataType the transfer data type
    */
-  Set<String> getImportServices(String transferDataType);
+  Set<String> getImportServices(DataVertical transferDataType);
 
   /**
    * Returns the set of service ids that can export the given {@code transferDataType}.
    *
    * @param transferDataType the transfer data type
    */
-  Set<String> getExportServices(String transferDataType);
+  Set<String> getExportServices(DataVertical transferDataType);
 
-  /** Returns the set of data types that support both import and export. */
-  Set<String> getTransferDataTypes();
+  /** Returns the set of data types that support both import and export.
+   * @return*/
+  Set<DataVertical> getTransferDataTypes();
 
   /**
    * The AuthorizationMode to use for lookups. IMPORT specifies an authorization that allows you to

--- a/portability-spi-api/src/main/java/org/datatransferproject/spi/api/auth/extension/AuthServiceExtension.java
+++ b/portability-spi-api/src/main/java/org/datatransferproject/spi/api/auth/extension/AuthServiceExtension.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.datatransferproject.api.launcher.AbstractExtension;
 import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry.AuthMode;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Factory responsible for providing {@link AuthDataGenerator} implementations.
@@ -21,19 +22,19 @@ public interface AuthServiceExtension extends AbstractExtension{
    *
    * @param transferDataType the data type
    */
-  AuthDataGenerator getAuthDataGenerator(String transferDataType, AuthMode mode);
+  AuthDataGenerator getAuthDataGenerator(DataVertical transferDataType, AuthMode mode);
 
   /**
    * get supported import types
    *
    * @return The list of types that are supported for IMPORT AuthMode
    */
-  List<String> getImportTypes();
+  List<DataVertical> getImportTypes();
 
   /**
    * get supported export types
    *
    * @return The list of types that are supported for EXPORT AuthMode
    */
-  List<String> getExportTypes();
+  List<DataVertical> getExportTypes();
 }

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStoreWithValidator.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/storage/JobStoreWithValidator.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import org.datatransferproject.spi.cloud.types.JobAuthorization;
 import org.datatransferproject.spi.cloud.types.PortabilityJob;
 import org.datatransferproject.spi.cloud.types.PortabilityJob.State;
+import org.datatransferproject.types.common.models.DataVertical;
 
 public abstract class JobStoreWithValidator implements JobStore {
 
@@ -35,9 +36,9 @@ public abstract class JobStoreWithValidator implements JobStore {
   }
 
   private static void validateForUpdateStateToCredsAvailable(PortabilityJob job) {
-    String dataType = job.transferDataType();
+    DataVertical dataType = job.transferDataType();
     Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(dataType), "Missing valid dataTypeParam: %s", dataType);
+        dataType != null, "Missing valid dataTypeParam: %s", dataType);
 
     String exportService = job.exportService();
     Preconditions.checkArgument(

--- a/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
+++ b/portability-spi-cloud/src/main/java/org/datatransferproject/spi/cloud/types/PortabilityJob.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.TimeZone;
 import javax.annotation.Nullable;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * A job that will fulfill a transfer request.
@@ -100,11 +101,16 @@ public abstract class PortabilityJob {
             ? TransferMode.valueOf((String) properties.get(TRANSFER_MODE))
             : TransferMode.DATA_TRANSFER;
 
+    DataVertical dataType =
+        properties.containsKey(DATA_TYPE_KEY)
+            ? DataVertical.fromDataType((String) properties.get(DATA_TYPE_KEY))
+            : null;
+
     return PortabilityJob.builder()
         .setState(state)
         .setExportService((String) properties.get(EXPORT_SERVICE_KEY))
         .setImportService((String) properties.get(IMPORT_SERVICE_KEY))
-        .setTransferDataType((String) properties.get(DATA_TYPE_KEY))
+        .setTransferDataType(dataType)
         .setExportInformation((String) properties.get(EXPORT_INFORMATION_KEY))
         .setCreatedTimestamp(now) // TODO: get from DB
         .setLastUpdateTimestamp(now)
@@ -151,7 +157,7 @@ public abstract class PortabilityJob {
   public abstract String importService();
 
   @JsonProperty("transferDataType")
-  public abstract String transferDataType();
+  public abstract DataVertical transferDataType();
 
   @Nullable
   @JsonProperty("exportInformation")
@@ -187,7 +193,7 @@ public abstract class PortabilityJob {
   public Map<String, Object> toMap() {
     ImmutableMap.Builder<String, Object> builder =
         ImmutableMap.<String, Object>builder()
-            .put(DATA_TYPE_KEY, transferDataType())
+            .put(DATA_TYPE_KEY, transferDataType().getDataType())
             .put(EXPORT_SERVICE_KEY, exportService())
             .put(IMPORT_SERVICE_KEY, importService())
             .put(AUTHORIZATION_STATE, jobAuthorization().state().toString())
@@ -289,7 +295,7 @@ public abstract class PortabilityJob {
     public abstract Builder setImportService(String importService);
 
     @JsonProperty("transferDataType")
-    public abstract Builder setTransferDataType(String transferDataType);
+    public abstract Builder setTransferDataType(DataVertical transferDataType);
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("exportInformation")

--- a/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
+++ b/portability-spi-cloud/src/test/java/org/datatransferproject/spi/cloud/types/PortabilityJobTest.java
@@ -17,6 +17,8 @@
 package org.datatransferproject.spi.cloud.types;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -29,6 +31,7 @@ import org.datatransferproject.spi.cloud.types.PortabilityJob.State;
 import org.datatransferproject.spi.cloud.types.PortabilityJob.TransferMode;
 import org.datatransferproject.test.types.ObjectMapperFactory;
 import org.datatransferproject.types.common.ExportInformation;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.junit.jupiter.api.Test;
@@ -41,7 +44,7 @@ public class PortabilityJobTest {
   private static final Map<String, Object> MANDATORY_FIELDS = ImmutableMap.<String, Object>builder()
       .put("EXPORT_SERVICE", "test")
       .put("IMPORT_SERVICE", "test")
-      .put("DATA_TYPE", "test")
+      .put("DATA_TYPE", "SOCIAL-POSTS")
       .put("EXPORT_INFORMATION", "test")
       .put("AUTHORIZATION_STATE", "INITIAL")
       .build();
@@ -63,7 +66,7 @@ public class PortabilityJobTest {
             .setState(State.NEW)
             .setExportService("fooService")
             .setImportService("barService")
-            .setTransferDataType("PHOTOS")
+            .setTransferDataType(PHOTOS)
             .setCreatedTimestamp(date)
             .setLastUpdateTimestamp(date.plusSeconds(120))
             .setJobAuthorization(jobAuthorization)
@@ -95,7 +98,7 @@ public class PortabilityJobTest {
             .setState(State.NEW)
             .setExportService("fooService")
             .setImportService("barService")
-            .setTransferDataType("PHOTOS")
+            .setTransferDataType(PHOTOS)
             .setExportInformation(
                 objectMapper.writeValueAsString(
                     new ExportInformation(
@@ -132,7 +135,7 @@ public class PortabilityJobTest {
             .setState(State.NEW)
             .setExportService("fooService")
             .setImportService("barService")
-            .setTransferDataType("PHOTOS")
+            .setTransferDataType(PHOTOS)
             .setCreatedTimestamp(date)
             .setLastUpdateTimestamp(date.plusSeconds(120))
             .setJobAuthorization(jobAuthorization)
@@ -159,7 +162,7 @@ public class PortabilityJobTest {
             .setState(State.NEW)
             .setExportService("fooService")
             .setImportService("barService")
-            .setTransferDataType("PHOTOS")
+            .setTransferDataType(PHOTOS)
             .setCreatedTimestamp(date)
             .setLastUpdateTimestamp(date.plusSeconds(120))
             .setJobAuthorization(jobAuthorization)

--- a/portability-spi-transfer/build.gradle
+++ b/portability-spi-transfer/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     compile project(':portability-api-launcher')
 
     compile('org.apache.commons:commons-lang3:3.11')
-
 }
 
 configurePublication(project)

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/extension/TransferExtension.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/extension/TransferExtension.java
@@ -16,6 +16,7 @@
 package org.datatransferproject.spi.transfer.extension;
 
 import org.datatransferproject.api.launcher.AbstractExtension;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
 
@@ -25,9 +26,11 @@ public interface TransferExtension extends AbstractExtension {
   /** The key associated with this extension's service. */
   String getServiceId();
 
-  /** Returns initialized extension exporter. */
-  Exporter<?, ?> getExporter(String transferDataType);
+  /** Returns initialized extension exporter.
+   * @param transferDataType*/
+  Exporter<?, ?> getExporter(DataVertical transferDataType);
 
-  /** Returns initialized extension importer. */
-  Importer<?, ?> getImporter(String transferDataType);
+  /** Returns initialized extension importer.
+   * @param transferDataType*/
+  Importer<?, ?> getImporter(DataVertical transferDataType);
 }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/ExportResult.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/ExportResult.java
@@ -1,6 +1,7 @@
 package org.datatransferproject.spi.transfer.provider;
 
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 import java.util.Optional;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.types.common.models.DataModel;
@@ -9,6 +10,7 @@ import org.datatransferproject.types.common.models.DataModel;
  * The result of an item export operation, after retries.
  */
 public class ExportResult<T extends DataModel> {
+
   public static final ExportResult CONTINUE = new ExportResult(ResultType.CONTINUE);
   public static final ExportResult END = new ExportResult(ResultType.CONTINUE);
 
@@ -31,7 +33,7 @@ public class ExportResult<T extends DataModel> {
   /**
    * Ctor.
    *
-   * @param type the result type
+   * @param type         the result type
    * @param exportedData the exported data
    */
   public ExportResult(ResultType type, T exportedData) {
@@ -51,8 +53,8 @@ public class ExportResult<T extends DataModel> {
   /**
    * Ctor.
    *
-   * @param type the result type
-   * @param exportedData the exported data
+   * @param type             the result type
+   * @param exportedData     the exported data
    * @param continuationData continuation information
    */
   public ExportResult(ResultType type, T exportedData, ContinuationData continuationData) {
@@ -99,6 +101,26 @@ public class ExportResult<T extends DataModel> {
     Preconditions.checkArgument(!type.equals(ResultType.ERROR), mustHaveThrowable);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ExportResult)) {
+      return false;
+    }
+    ExportResult<?> that = (ExportResult<?>) o;
+    return type == that.type &&
+        Objects.equals(exportedData, that.exportedData) &&
+        Objects.equals(continuationData, that.continuationData) &&
+        Objects.equals(throwable, that.throwable);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, exportedData, continuationData, throwable);
+  }
+
   /**
    * Result types.
    */
@@ -115,6 +137,16 @@ public class ExportResult<T extends DataModel> {
     /**
      * Indicates an unrecoverable error was raised.
      */
-    ERROR
+    ERROR;
+
+    public static ResultType merge(ResultType t1, ResultType t2) {
+      if (t1 == ResultType.ERROR || t2 == ResultType.ERROR) {
+        return ResultType.ERROR;
+      }
+      if (t1 == ResultType.CONTINUE || t2 == ResultType.CONTINUE) {
+        return ResultType.CONTINUE;
+      }
+      return ResultType.END;
+    }
   }
 }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProvider.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProvider.java
@@ -1,0 +1,143 @@
+package org.datatransferproject.spi.transfer.provider;
+
+import java.util.function.Function;
+import org.datatransferproject.spi.transfer.extension.TransferExtension;
+import org.datatransferproject.spi.transfer.provider.converter.AnyToAnyExporter;
+import org.datatransferproject.spi.transfer.provider.converter.AnyToAnyImporter;
+import org.datatransferproject.spi.transfer.provider.converter.MediaExporterDecorator;
+import org.datatransferproject.spi.transfer.provider.converter.MediaImporterDecorator;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
+
+/**
+ * Provides a compatibility layer between adapter types. E.g. when asking for a Media adapter and it
+ * isn't available, it will combine Photo and Video adapters on the fly to seamlessly support the
+ * request.
+ */
+public class TransferCompatibilityProvider {
+
+  private static final String PHOTOS = "PHOTOS";
+  private static final String VIDEOS = "VIDEOS";
+  private static final String MEDIA = "MEDIA";
+
+  public Exporter getCompatibleExporter(TransferExtension extension, String jobType) {
+    Exporter<?, ?> exporter = getExporterOrNull(extension, jobType);
+    if (exporter != null) {
+      return exporter;
+    }
+
+    switch (jobType) {
+      case MEDIA:
+        exporter = getMediaExporter(extension);
+        break;
+      case PHOTOS:
+        exporter = getPhotosExporter(extension);
+        break;
+      case VIDEOS:
+        exporter = getVideosExporter(extension);
+        break;
+    }
+    if (exporter == null) {
+      return extension.getExporter(jobType); // preserve original exception
+    }
+    return exporter;
+  }
+
+  public Importer getCompatibleImporter(TransferExtension extension, String jobType) {
+    Importer<?, ?> importer = getImporterOrNull(extension, jobType);
+    if (importer != null) {
+      return importer;
+    }
+
+    switch (jobType) {
+      case MEDIA:
+        importer = getMediaImporter(extension);
+        break;
+      case PHOTOS:
+        importer = getPhotosImporter(extension);
+        break;
+      case VIDEOS:
+        importer = getVideosImporter(extension);
+        break;
+    }
+    if (importer == null) {
+      return extension.getImporter(jobType);
+    }
+    return importer;
+  }
+
+  private Importer<?, ?> getVideosImporter(TransferExtension extension) {
+    Importer media = getImporterOrNull(extension, MEDIA);
+    if (media == null) {
+      return null;
+    }
+    return new AnyToAnyImporter<>(media, MediaContainerResource::videoToMedia);
+  }
+
+  private Importer<?, ?> getPhotosImporter(TransferExtension extension) {
+    Importer media = getImporterOrNull(extension, MEDIA);
+    if (media == null) {
+      return null;
+    }
+    return new AnyToAnyImporter<>(media, MediaContainerResource::photoToMedia);
+  }
+
+  private Importer<?, ?> getMediaImporter(TransferExtension extension) {
+    Importer<?, ?> photo = getImporterOrNull(extension, PHOTOS);
+    Importer<?, ?> video = getImporterOrNull(extension, VIDEOS);
+    if (photo == null || video == null) {
+      return null;
+    }
+    return new MediaImporterDecorator(photo, video);
+  }
+
+  private Exporter<?, ?> getVideosExporter(TransferExtension extension) {
+    Exporter media = getExporterOrNull(extension, MEDIA);
+    if (media == null) {
+      return null;
+    }
+    Function<ContainerResource, ContainerResource> converter = (cr) ->
+        (cr instanceof VideosContainerResource) ?
+            MediaContainerResource.videoToMedia((VideosContainerResource) cr) : cr;
+    return new AnyToAnyExporter<>(media, MediaContainerResource::mediaToVideo, converter);
+  }
+
+  private Exporter<?, ?> getPhotosExporter(TransferExtension extension) {
+    Exporter media = getExporterOrNull(extension, MEDIA);
+    if (media == null) {
+      return null;
+    }
+    Function<ContainerResource, ContainerResource> converter = (cr) ->
+        (cr instanceof PhotosContainerResource) ?
+            MediaContainerResource.photoToMedia((PhotosContainerResource) cr) : cr;
+    return new AnyToAnyExporter<>(media, MediaContainerResource::mediaToPhoto, converter);
+  }
+
+  private Exporter<?, ?> getMediaExporter(TransferExtension extension) {
+    Exporter<?, ?> photo = getExporterOrNull(extension, PHOTOS);
+    Exporter<?, ?> video = getExporterOrNull(extension, VIDEOS);
+    if (photo == null || video == null) {
+      return null;
+    }
+    return new MediaExporterDecorator(photo, video);
+  }
+
+  private Exporter<?, ?> getExporterOrNull(TransferExtension extension, String jobType) {
+    // TODO: Don't use exceptions for control flow. Have a way to query supported adapters
+    try {
+      return extension.getExporter(jobType);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private Importer<?, ?> getImporterOrNull(TransferExtension extension, String jobType) {
+    try {
+      return extension.getImporter(jobType);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProvider.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProvider.java
@@ -1,6 +1,11 @@
 package org.datatransferproject.spi.transfer.provider;
 
+import static org.datatransferproject.types.common.models.DataVertical.MEDIA;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
 import java.util.function.Function;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.converter.AnyToAnyExporter;
 import org.datatransferproject.spi.transfer.provider.converter.AnyToAnyImporter;
@@ -18,11 +23,7 @@ import org.datatransferproject.types.common.models.videos.VideosContainerResourc
  */
 public class TransferCompatibilityProvider {
 
-  private static final String PHOTOS = "PHOTOS";
-  private static final String VIDEOS = "VIDEOS";
-  private static final String MEDIA = "MEDIA";
-
-  public Exporter getCompatibleExporter(TransferExtension extension, String jobType) {
+  public Exporter getCompatibleExporter(TransferExtension extension, DataVertical jobType) {
     Exporter<?, ?> exporter = getExporterOrNull(extension, jobType);
     if (exporter != null) {
       return exporter;
@@ -45,7 +46,7 @@ public class TransferCompatibilityProvider {
     return exporter;
   }
 
-  public Importer getCompatibleImporter(TransferExtension extension, String jobType) {
+  public Importer getCompatibleImporter(TransferExtension extension, DataVertical jobType) {
     Importer<?, ?> importer = getImporterOrNull(extension, jobType);
     if (importer != null) {
       return importer;
@@ -124,7 +125,7 @@ public class TransferCompatibilityProvider {
     return new MediaExporterDecorator(photo, video);
   }
 
-  private Exporter<?, ?> getExporterOrNull(TransferExtension extension, String jobType) {
+  private Exporter<?, ?> getExporterOrNull(TransferExtension extension, DataVertical jobType) {
     // TODO: Don't use exceptions for control flow. Have a way to query supported adapters
     try {
       return extension.getExporter(jobType);
@@ -133,7 +134,7 @@ public class TransferCompatibilityProvider {
     }
   }
 
-  private Importer<?, ?> getImporterOrNull(TransferExtension extension, String jobType) {
+  private Importer<?, ?> getImporterOrNull(TransferExtension extension, DataVertical jobType) {
     try {
       return extension.getImporter(jobType);
     } catch (Exception e) {

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/AnyToAnyExporter.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/AnyToAnyExporter.java
@@ -1,0 +1,67 @@
+package org.datatransferproject.spi.transfer.provider.converter;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import org.datatransferproject.spi.transfer.provider.ExportResult;
+import org.datatransferproject.spi.transfer.provider.Exporter;
+import org.datatransferproject.types.common.ExportInformation;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.datatransferproject.types.transfer.auth.AuthData;
+
+/**
+ * Allows flexible bridging between adapters of different types with compatible functionality.
+ *
+ * @param <From> The container type supported by the available exporter.
+ * @param <To>   The container type that's desired.
+ */
+public class AnyToAnyExporter<
+    AD extends AuthData,
+    From extends ContainerResource,
+    To extends ContainerResource> implements Exporter<AD, To> {
+
+  private final Exporter<AD, From> exporter;
+  private final Function<From, To> containerResourceConverter;
+  private final Function<ContainerResource, ContainerResource> exportInformationConverter;
+
+  /**
+   * @param exporter                   existing exporter
+   * @param containerResourceConverter function converting between the existing and desired
+   *                                   containers.
+   * @param exportInformationConverter converter that's used to adapt the export information that
+   *                                   goes into the export call. It's required because exporters
+   *                                   often support various container resources as part of export
+   *                                   information. E.g. photo exporters support
+   *                                   DateRangeContainerResource, while media adapters might only
+   *                                   support MediaContainerResource.
+   */
+  public AnyToAnyExporter(Exporter<AD, From> exporter,
+      Function<From, To> containerResourceConverter,
+      Function<ContainerResource, ContainerResource> exportInformationConverter) {
+    this.exporter = exporter;
+    this.containerResourceConverter = containerResourceConverter;
+    this.exportInformationConverter = exportInformationConverter;
+  }
+
+  /**
+   * @param exporter                   existing exporter
+   * @param containerResourceConverter function converting between the existing and desired
+   *                                   containers.
+   */
+  public AnyToAnyExporter(Exporter<AD, From> exporter,
+      Function<From, To> containerResourceConverter) {
+    this(exporter, containerResourceConverter, Function.identity());
+  }
+
+  @Override
+  public ExportResult<To> export(UUID jobId, AD authData, Optional<ExportInformation> exportInfo)
+      throws Exception {
+    Optional<ExportInformation> infoWithConvertedResource =
+        exportInfo.map(
+            (ei) ->
+                ei.copyWithResource(exportInformationConverter.apply(ei.getContainerResource())));
+    ExportResult<From> originalResult = exporter.export(jobId, authData, infoWithConvertedResource);
+    return originalResult.copyWithExportedData(
+        containerResourceConverter.apply(originalResult.getExportedData()));
+  }
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/AnyToAnyImporter.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/AnyToAnyImporter.java
@@ -1,0 +1,39 @@
+package org.datatransferproject.spi.transfer.provider.converter;
+
+import java.util.UUID;
+import java.util.function.Function;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.datatransferproject.types.transfer.auth.AuthData;
+
+/**
+ * Allows flexible bridging between adapters of different types with compatible functionality.
+ *
+ * @param <From> The container type supported by the available exporter.
+ * @param <To>   The container type that's desired.
+ */
+public class AnyToAnyImporter<
+    AD extends AuthData,
+    From extends ContainerResource,
+    To extends ContainerResource> implements Importer<AD, To> {
+
+  private final Importer<AD, From> importer;
+  private final Function<To, From> converter;
+
+  /**
+   * @param importer  existing importer
+   * @param converter function converting between the existing and desired containers.
+   */
+  public AnyToAnyImporter(Importer<AD, From> importer, Function<To, From> converter) {
+    this.importer = importer;
+    this.converter = converter;
+  }
+
+  @Override
+  public ImportResult importItem(UUID jobId, IdempotentImportExecutor idempotentExecutor,
+      AD authData, To data) throws Exception {
+    return importer.importItem(jobId, idempotentExecutor, authData, converter.apply(data));
+  }
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/MediaExporterDecorator.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/MediaExporterDecorator.java
@@ -1,0 +1,114 @@
+package org.datatransferproject.spi.transfer.provider.converter;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.datatransferproject.spi.transfer.provider.ExportResult;
+import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
+import org.datatransferproject.spi.transfer.provider.Exporter;
+import org.datatransferproject.spi.transfer.types.ContinuationData;
+import org.datatransferproject.types.common.ExportInformation;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.datatransferproject.types.common.models.media.MediaAlbum;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.common.models.videos.VideoAlbum;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
+import org.datatransferproject.types.transfer.auth.AuthData;
+
+/**
+ *  Allows using existing Photo and Video adapters to create a Media adapter.
+ */
+public class MediaExporterDecorator<AD extends AuthData> implements
+    Exporter<AD, MediaContainerResource> {
+
+  private final Exporter<AD, PhotosContainerResource> photosExporter;
+  private final Exporter<AD, VideosContainerResource> videosExporter;
+
+  public MediaExporterDecorator(Exporter<AD, PhotosContainerResource> photosExporter,
+      Exporter<AD, VideosContainerResource> videosExporter) {
+    this.photosExporter = photosExporter;
+    this.videosExporter = videosExporter;
+  }
+
+  @Override
+  public ExportResult<MediaContainerResource> export(UUID jobId, AD authData,
+      Optional<ExportInformation> exportInfo) throws Exception {
+    ExportResult<PhotosContainerResource> per = exportPhotos(jobId, authData, exportInfo);
+    if (per.getThrowable().isPresent()) {
+      return new ExportResult<>(per.getThrowable().get());
+    }
+
+    ExportResult<VideosContainerResource> ver = exportVideos(jobId, authData, exportInfo);
+    if (ver.getThrowable().isPresent()) {
+      return new ExportResult<>(ver.getThrowable().get());
+    }
+    return mergeResults(per, ver);
+  }
+
+  private ExportResult<MediaContainerResource> mergeResults(
+      ExportResult<PhotosContainerResource> photoResult,
+      ExportResult<VideosContainerResource> videoResult) {
+    ResultType resultType = ResultType.merge(photoResult.getType(), videoResult.getType());
+
+    Collection<MediaAlbum> albums = mergeAlbums(
+        photoResult.getExportedData().getAlbums(),
+        videoResult.getExportedData().getAlbums());
+
+    MediaContainerResource exportData = new MediaContainerResource(albums,
+        photoResult.getExportedData().getPhotos(),
+        videoResult.getExportedData().getVideos());
+
+    ContinuationData cd =
+        mergeContinuationData(photoResult.getContinuationData(), videoResult.getContinuationData());
+
+    return new ExportResult<>(resultType, exportData, cd);
+  }
+
+  private ExportResult<VideosContainerResource> exportVideos(UUID jobId, AD authData,
+      Optional<ExportInformation> exportInfo) throws Exception {
+    return videosExporter.export(jobId, authData, exportInfo.map((ei) -> {
+      ContainerResource cr = ei.getContainerResource();
+      if (cr instanceof MediaContainerResource) {
+        cr = MediaContainerResource.mediaToVideo((MediaContainerResource) cr);
+      }
+      return ei.copyWithResource(cr);
+    }));
+  }
+
+  private ExportResult<PhotosContainerResource> exportPhotos(UUID jobId, AD authData,
+      Optional<ExportInformation> exportInfo)
+      throws Exception {
+    return photosExporter.export(jobId, authData, exportInfo.map((ei) -> {
+      ContainerResource cr = ei.getContainerResource();
+      if (cr instanceof MediaContainerResource) {
+        cr = MediaContainerResource.mediaToPhoto((MediaContainerResource) cr);
+      }
+      return ei.copyWithResource(cr);
+    }));
+  }
+
+  private ContinuationData mergeContinuationData(ContinuationData cd1, ContinuationData cd2) {
+    if (cd1 == null) {
+      return cd2;
+    }
+    if (cd2 == null) {
+      return cd1;
+    }
+    ContinuationData res = new ContinuationData(cd1.getPaginationData());
+    res.addContainerResources(cd1.getContainerResources());
+    res.addContainerResources(cd2.getContainerResources());
+    return res;
+  }
+
+  private Collection<MediaAlbum> mergeAlbums(Collection<PhotoAlbum> a1,
+      Collection<VideoAlbum> a2) {
+    return Stream.concat(
+        a1.stream().map(MediaAlbum::photoToMediaAlbum),
+        a2.stream().map(MediaAlbum::videoToMediaAlbum)
+    ).distinct().collect(Collectors.toList());
+  }
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/MediaImporterDecorator.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/MediaImporterDecorator.java
@@ -1,0 +1,40 @@
+package org.datatransferproject.spi.transfer.provider.converter;
+
+import java.util.UUID;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
+import org.datatransferproject.types.transfer.auth.AuthData;
+
+/**
+ *  Allows using existing Photo and Video adapters to create a Media adapter.
+ */
+public class MediaImporterDecorator<AD extends AuthData> implements
+    Importer<AD, MediaContainerResource> {
+
+  private final Importer<AD, PhotosContainerResource> photosImporter;
+  private final Importer<AD, VideosContainerResource> videosImporter;
+
+  public MediaImporterDecorator(Importer<AD, PhotosContainerResource> photosImporter,
+      Importer<AD, VideosContainerResource> videosImporter) {
+    this.photosImporter = photosImporter;
+    this.videosImporter = videosImporter;
+  }
+
+  @Override
+  public ImportResult importItem(UUID jobId, IdempotentImportExecutor idempotentExecutor,
+      AD authData, MediaContainerResource data) throws Exception {
+    PhotosContainerResource photosResource = MediaContainerResource.mediaToPhoto(data);
+    ImportResult photosResult = photosImporter
+        .importItem(jobId, idempotentExecutor, authData, photosResource);
+
+    VideosContainerResource videosResource = MediaContainerResource.mediaToVideo(data);
+    ImportResult videosResult = videosImporter
+        .importItem(jobId, idempotentExecutor, authData, videosResource);
+
+    return ImportResult.merge(photosResult, videosResult);
+  }
+}

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/MediaToPhotoConversionImporter.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/MediaToPhotoConversionImporter.java
@@ -23,6 +23,7 @@ import java.util.UUID;
  */
 // TODO(#1065) fix primitives-obession causing us to key Providers on "PHOTOS" string rather
 // than underlying file types.
+@Deprecated // prefer AnyToAnyImporter
 public class MediaToPhotoConversionImporter<
     A extends AuthData,
     PCR extends PhotosContainerResource,

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/MediaToPhotoConversionImporter.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/MediaToPhotoConversionImporter.java
@@ -21,8 +21,6 @@ import java.util.UUID;
  *
  * This is intended for providers who do not support "MEDIA" as a special case.
  */
-// TODO(#1065) fix primitives-obession causing us to key Providers on "PHOTOS" string rather
-// than underlying file types.
 @Deprecated // prefer AnyToAnyImporter
 public class MediaToPhotoConversionImporter<
     A extends AuthData,

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/PhotoToMediaConversionExporter.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/PhotoToMediaConversionExporter.java
@@ -20,9 +20,7 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
  *
  * This is intended for providers who do not support "PHOTOS" as a special case.
  */
-// TODO(#1065) fix primitives-obession causing us to key Providers on "PHOTOS" string rather
-// than underlying file types.
-@Deprecated // prefer AnyToAnyImporter
+@Deprecated // prefer AnyToAnyExporter
 public class PhotoToMediaConversionExporter<
     A extends AuthData,
     PCR extends PhotosContainerResource,

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/PhotoToMediaConversionExporter.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/provider/converter/PhotoToMediaConversionExporter.java
@@ -22,6 +22,7 @@ import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
  */
 // TODO(#1065) fix primitives-obession causing us to key Providers on "PHOTOS" string rather
 // than underlying file types.
+@Deprecated // prefer AnyToAnyImporter
 public class PhotoToMediaConversionExporter<
     A extends AuthData,
     PCR extends PhotosContainerResource,

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/ContinuationData.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/types/ContinuationData.java
@@ -39,4 +39,9 @@ public class ContinuationData extends PortableType {
   public void addContainerResource(ContainerResource resource) {
     containerResources.add(resource);
   }
+
+  /** Adds a list of container resources. */
+  public void addContainerResources(List<ContainerResource> resources) {
+    containerResources.addAll(resources);
+  }
 }

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/ExportResultTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/ExportResultTest.java
@@ -1,0 +1,22 @@
+package org.datatransferproject.spi.transfer.provider;
+
+import static org.datatransferproject.spi.transfer.provider.ExportResult.ResultType.CONTINUE;
+import static org.datatransferproject.spi.transfer.provider.ExportResult.ResultType.END;
+import static org.datatransferproject.spi.transfer.provider.ExportResult.ResultType.ERROR;
+import static org.junit.Assert.assertEquals;
+
+import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
+import org.junit.jupiter.api.Test;
+
+public class ExportResultTest {
+
+  @Test
+  public void resultTypeMerge() {
+    assertEquals(ERROR, ResultType.merge(ERROR, END));
+    assertEquals(ERROR, ResultType.merge(END, ERROR));
+    assertEquals(CONTINUE, ResultType.merge(END, CONTINUE));
+    assertEquals(CONTINUE, ResultType.merge(CONTINUE, END));
+    assertEquals(END, ResultType.merge(END, END));
+  }
+
+}

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/ImportResultTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/ImportResultTest.java
@@ -1,0 +1,46 @@
+package org.datatransferproject.spi.transfer.provider;
+
+import static org.datatransferproject.spi.transfer.provider.ImportResult.OK;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import org.datatransferproject.spi.transfer.provider.ImportResult.ResultType;
+import org.junit.jupiter.api.Test;
+
+public class ImportResultTest {
+
+  @Test
+  public void mergeOk() {
+    assertEquals(OK, ImportResult.merge(OK, OK));
+  }
+
+  @Test
+  public void mergeError() {
+    ImportResult ir1 = new ImportResult(ResultType.ERROR);
+    assertEquals(ir1, ImportResult.merge(ir1, OK));
+    assertEquals(ir1, ImportResult.merge(OK, ir1));
+  }
+
+  @Test
+  public void mergeCountsEmpty() {
+    ImportResult ir1 = OK.copyWithCounts(Map.of("A", 10));
+    assertEquals(ir1, ImportResult.merge(ir1, OK));
+    assertEquals(ir1, ImportResult.merge(OK, ir1));
+  }
+
+  @Test
+  public void mergeCounts() {
+    ImportResult ir1 = OK.copyWithCounts(Map.of("A", 10, "B", 10));
+    ImportResult ir2 = OK.copyWithCounts(Map.of("A", 5, "C", 5));
+    ImportResult exp = OK.copyWithCounts(Map.of("A", 15, "B", 10, "C", 5));
+    assertEquals(exp, ImportResult.merge(ir1, ir2));
+  }
+
+  @Test
+  public void mergeBytes() {
+    ImportResult ir1 = OK.copyWithBytes(7L);
+    assertEquals(ir1, ImportResult.merge(ir1, OK));
+    assertEquals(ir1, ImportResult.merge(OK, ir1));
+    assertEquals(14L, ImportResult.merge(ir1, ir1).getBytes().get().longValue());
+  }
+}

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProviderTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProviderTest.java
@@ -1,6 +1,9 @@
 package org.datatransferproject.spi.transfer.provider;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.datatransferproject.types.common.models.DataVertical.MEDIA;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -21,66 +24,66 @@ public class TransferCompatibilityProviderTest {
   public void shouldPreferOriginalAdapterWhenAvailable() {
     TransferExtension ext = mock(TransferExtension.class);
     Importer importer = mock(Importer.class);
-    when(ext.getImporter(eq("MEDIA"))).thenReturn(importer);
-    when(ext.getImporter(eq("PHOTOS"))).thenReturn(mock(Importer.class));
-    when(ext.getImporter(eq("VIDEOS"))).thenReturn(mock(Importer.class));
+    when(ext.getImporter(eq(MEDIA))).thenReturn(importer);
+    when(ext.getImporter(eq(PHOTOS))).thenReturn(mock(Importer.class));
+    when(ext.getImporter(eq(VIDEOS))).thenReturn(mock(Importer.class));
     Exporter exporter = mock(Exporter.class);
-    when(ext.getExporter(eq("MEDIA"))).thenReturn(exporter);
-    when(ext.getExporter(eq("PHOTOS"))).thenReturn(mock(Exporter.class));
-    when(ext.getExporter(eq("VIDEOS"))).thenReturn(mock(Exporter.class));
+    when(ext.getExporter(eq(MEDIA))).thenReturn(exporter);
+    when(ext.getExporter(eq(PHOTOS))).thenReturn(mock(Exporter.class));
+    when(ext.getExporter(eq(VIDEOS))).thenReturn(mock(Exporter.class));
 
-    assertThat(compatibilityProvider.getCompatibleImporter(ext, "MEDIA")).isSameAs(importer);
-    assertThat(compatibilityProvider.getCompatibleExporter(ext, "MEDIA")).isSameAs(exporter);
+    assertThat(compatibilityProvider.getCompatibleImporter(ext, MEDIA)).isSameAs(importer);
+    assertThat(compatibilityProvider.getCompatibleExporter(ext, MEDIA)).isSameAs(exporter);
   }
 
   @Test
   public void shouldConstructMediaImporterFromPhotoAndVideo() {
     TransferExtension ext = mock(TransferExtension.class);
-    when(ext.getImporter(eq("PHOTOS"))).thenReturn(mock(Importer.class));
-    when(ext.getImporter(eq("VIDEOS"))).thenReturn(mock(Importer.class));
-    when(ext.getImporter(eq("MEDIA"))).thenReturn(null);
+    when(ext.getImporter(eq(PHOTOS))).thenReturn(mock(Importer.class));
+    when(ext.getImporter(eq(VIDEOS))).thenReturn(mock(Importer.class));
+    when(ext.getImporter(eq(MEDIA))).thenReturn(null);
 
-    Importer<?, ?> imp = compatibilityProvider.getCompatibleImporter(ext, "MEDIA");
+    Importer<?, ?> imp = compatibilityProvider.getCompatibleImporter(ext, MEDIA);
     assertThat(imp).isInstanceOf(MediaImporterDecorator.class);
   }
 
   @Test
   public void shouldConstructMediaExporterFromPhotoAndVideo() {
     TransferExtension ext = mock(TransferExtension.class);
-    when(ext.getExporter(eq("PHOTOS"))).thenReturn(mock(Exporter.class));
-    when(ext.getExporter(eq("VIDEOS"))).thenReturn(mock(Exporter.class));
-    when(ext.getExporter(eq("MEDIA"))).thenReturn(null);
+    when(ext.getExporter(eq(PHOTOS))).thenReturn(mock(Exporter.class));
+    when(ext.getExporter(eq(VIDEOS))).thenReturn(mock(Exporter.class));
+    when(ext.getExporter(eq(MEDIA))).thenReturn(null);
 
-    Exporter<?, ?> exp = compatibilityProvider.getCompatibleExporter(ext, "MEDIA");
+    Exporter<?, ?> exp = compatibilityProvider.getCompatibleExporter(ext, MEDIA);
     assertThat(exp).isInstanceOf(MediaExporterDecorator.class);
   }
 
   @Test
   public void shouldConstructPhotoAndVideoExportersFromMedia() {
     TransferExtension ext = mock(TransferExtension.class);
-    when(ext.getExporter(eq("MEDIA"))).thenReturn(mock(Exporter.class));
+    when(ext.getExporter(eq(MEDIA))).thenReturn(mock(Exporter.class));
 
-    assertThat(compatibilityProvider.getCompatibleExporter(ext, "PHOTOS"))
+    assertThat(compatibilityProvider.getCompatibleExporter(ext, PHOTOS))
         .isInstanceOf(AnyToAnyExporter.class);
-    assertThat(compatibilityProvider.getCompatibleExporter(ext, "VIDEOS"))
+    assertThat(compatibilityProvider.getCompatibleExporter(ext, VIDEOS))
         .isInstanceOf(AnyToAnyExporter.class);
   }
 
   @Test
   public void shouldConstructPhotoAndVideoImportersFromMedia() {
     TransferExtension ext = mock(TransferExtension.class);
-    when(ext.getImporter(eq("MEDIA"))).thenReturn(mock(Importer.class));
+    when(ext.getImporter(eq(MEDIA))).thenReturn(mock(Importer.class));
 
-    assertThat(compatibilityProvider.getCompatibleImporter(ext, "PHOTOS"))
+    assertThat(compatibilityProvider.getCompatibleImporter(ext, PHOTOS))
         .isInstanceOf(AnyToAnyImporter.class);
-    assertThat(compatibilityProvider.getCompatibleImporter(ext, "VIDEOS"))
+    assertThat(compatibilityProvider.getCompatibleImporter(ext, VIDEOS))
         .isInstanceOf(AnyToAnyImporter.class);
   }
 
   @Test
   public void shouldMaintainOriginalException() {
     TransferExtension ext = mock(TransferExtension.class);
-    when(ext.getExporter(eq("MEDIA"))).thenThrow(new RuntimeException());
-    assertThrows(Exception.class, () -> compatibilityProvider.getCompatibleExporter(ext, "MEDIA"));
+    when(ext.getExporter(eq(MEDIA))).thenThrow(new RuntimeException());
+    assertThrows(Exception.class, () -> compatibilityProvider.getCompatibleExporter(ext, MEDIA));
   }
 }

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProviderTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/TransferCompatibilityProviderTest.java
@@ -1,0 +1,86 @@
+package org.datatransferproject.spi.transfer.provider;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.datatransferproject.spi.transfer.extension.TransferExtension;
+import org.datatransferproject.spi.transfer.provider.converter.AnyToAnyExporter;
+import org.datatransferproject.spi.transfer.provider.converter.AnyToAnyImporter;
+import org.datatransferproject.spi.transfer.provider.converter.MediaExporterDecorator;
+import org.datatransferproject.spi.transfer.provider.converter.MediaImporterDecorator;
+import org.junit.jupiter.api.Test;
+
+public class TransferCompatibilityProviderTest {
+
+  TransferCompatibilityProvider compatibilityProvider = new TransferCompatibilityProvider();
+
+  @Test
+  public void shouldPreferOriginalAdapterWhenAvailable() {
+    TransferExtension ext = mock(TransferExtension.class);
+    Importer importer = mock(Importer.class);
+    when(ext.getImporter(eq("MEDIA"))).thenReturn(importer);
+    when(ext.getImporter(eq("PHOTOS"))).thenReturn(mock(Importer.class));
+    when(ext.getImporter(eq("VIDEOS"))).thenReturn(mock(Importer.class));
+    Exporter exporter = mock(Exporter.class);
+    when(ext.getExporter(eq("MEDIA"))).thenReturn(exporter);
+    when(ext.getExporter(eq("PHOTOS"))).thenReturn(mock(Exporter.class));
+    when(ext.getExporter(eq("VIDEOS"))).thenReturn(mock(Exporter.class));
+
+    assertThat(compatibilityProvider.getCompatibleImporter(ext, "MEDIA")).isSameAs(importer);
+    assertThat(compatibilityProvider.getCompatibleExporter(ext, "MEDIA")).isSameAs(exporter);
+  }
+
+  @Test
+  public void shouldConstructMediaImporterFromPhotoAndVideo() {
+    TransferExtension ext = mock(TransferExtension.class);
+    when(ext.getImporter(eq("PHOTOS"))).thenReturn(mock(Importer.class));
+    when(ext.getImporter(eq("VIDEOS"))).thenReturn(mock(Importer.class));
+    when(ext.getImporter(eq("MEDIA"))).thenReturn(null);
+
+    Importer<?, ?> imp = compatibilityProvider.getCompatibleImporter(ext, "MEDIA");
+    assertThat(imp).isInstanceOf(MediaImporterDecorator.class);
+  }
+
+  @Test
+  public void shouldConstructMediaExporterFromPhotoAndVideo() {
+    TransferExtension ext = mock(TransferExtension.class);
+    when(ext.getExporter(eq("PHOTOS"))).thenReturn(mock(Exporter.class));
+    when(ext.getExporter(eq("VIDEOS"))).thenReturn(mock(Exporter.class));
+    when(ext.getExporter(eq("MEDIA"))).thenReturn(null);
+
+    Exporter<?, ?> exp = compatibilityProvider.getCompatibleExporter(ext, "MEDIA");
+    assertThat(exp).isInstanceOf(MediaExporterDecorator.class);
+  }
+
+  @Test
+  public void shouldConstructPhotoAndVideoExportersFromMedia() {
+    TransferExtension ext = mock(TransferExtension.class);
+    when(ext.getExporter(eq("MEDIA"))).thenReturn(mock(Exporter.class));
+
+    assertThat(compatibilityProvider.getCompatibleExporter(ext, "PHOTOS"))
+        .isInstanceOf(AnyToAnyExporter.class);
+    assertThat(compatibilityProvider.getCompatibleExporter(ext, "VIDEOS"))
+        .isInstanceOf(AnyToAnyExporter.class);
+  }
+
+  @Test
+  public void shouldConstructPhotoAndVideoImportersFromMedia() {
+    TransferExtension ext = mock(TransferExtension.class);
+    when(ext.getImporter(eq("MEDIA"))).thenReturn(mock(Importer.class));
+
+    assertThat(compatibilityProvider.getCompatibleImporter(ext, "PHOTOS"))
+        .isInstanceOf(AnyToAnyImporter.class);
+    assertThat(compatibilityProvider.getCompatibleImporter(ext, "VIDEOS"))
+        .isInstanceOf(AnyToAnyImporter.class);
+  }
+
+  @Test
+  public void shouldMaintainOriginalException() {
+    TransferExtension ext = mock(TransferExtension.class);
+    when(ext.getExporter(eq("MEDIA"))).thenThrow(new RuntimeException());
+    assertThrows(Exception.class, () -> compatibilityProvider.getCompatibleExporter(ext, "MEDIA"));
+  }
+}

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/AnyToAnyExporterTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/AnyToAnyExporterTest.java
@@ -1,0 +1,45 @@
+package org.datatransferproject.spi.transfer.provider.converter;
+
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Optional;
+import org.datatransferproject.spi.transfer.provider.ExportResult;
+import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
+import org.datatransferproject.spi.transfer.provider.Exporter;
+import org.datatransferproject.types.common.ExportInformation;
+import org.datatransferproject.types.common.models.DateRangeContainerResource;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.AuthData;
+import org.junit.jupiter.api.Test;
+
+class AnyToAnyExporterTest {
+
+  @Test
+  public void shouldHandleConversionFromPhotoExporterToMediaExporterUsingAnyInputContainerResource()
+      throws Exception {
+    Exporter<AuthData, PhotosContainerResource> photosExporter =
+        (jobId, authData, exportInformation) ->
+            new ExportResult<>(
+                ResultType.END,
+                exportInformation
+                    .map(ei -> (PhotosContainerResource) ei.getContainerResource())
+                    .get());
+
+    AnyToAnyExporter<AuthData, PhotosContainerResource, MediaContainerResource> mediaExporter =
+        new AnyToAnyExporter<>(
+            photosExporter,
+            MediaContainerResource::photoToMedia,
+            (cr) -> {
+              assertThat(cr).isInstanceOf(DateRangeContainerResource.class);
+              return new PhotosContainerResource(null, null);
+            });
+    ExportInformation ei = new ExportInformation(null, new DateRangeContainerResource(0, 0));
+
+    ExportResult<MediaContainerResource> actual = mediaExporter.export(null, null, Optional.of(ei));
+
+    MediaContainerResource expected = new MediaContainerResource(null, null, null);
+    assertThat(actual.getExportedData()).isEqualTo(expected);
+  }
+}

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/AnyToAnyImporterTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/AnyToAnyImporterTest.java
@@ -1,0 +1,28 @@
+package org.datatransferproject.spi.transfer.provider.converter;
+
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.AuthData;
+import org.junit.jupiter.api.Test;
+
+class AnyToAnyImporterTest {
+
+  @Test
+  public void shouldHandleConversionFromPhotoImporterToMediaImporter()
+      throws Exception {
+    Importer<AuthData, PhotosContainerResource> photosImporter =
+        (jobId, idempotentExecutor, authData, data) -> ImportResult.OK;
+
+    MediaContainerResource mcr = new MediaContainerResource(null, null, null);
+    AnyToAnyImporter<AuthData, PhotosContainerResource, MediaContainerResource> mediaExporter =
+        new AnyToAnyImporter<>(photosImporter, MediaContainerResource::mediaToPhoto);
+
+    ImportResult res = mediaExporter.importItem(null, null, null, mcr);
+    assertThat(res).isEqualTo(ImportResult.OK);
+  }
+}

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/MediaExporterDecoratorTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/MediaExporterDecoratorTest.java
@@ -1,0 +1,118 @@
+package org.datatransferproject.spi.transfer.provider.converter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Optional;
+import org.datatransferproject.spi.transfer.provider.ExportResult;
+import org.datatransferproject.spi.transfer.provider.ExportResult.ResultType;
+import org.datatransferproject.spi.transfer.provider.Exporter;
+import org.datatransferproject.types.common.ExportInformation;
+import org.datatransferproject.types.common.models.media.MediaAlbum;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
+import org.datatransferproject.types.transfer.auth.AuthData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MediaExporterDecoratorTest {
+
+  private MediaExporterDecorator<AuthData> mediaExporter;
+  private List<MediaAlbum> albums;
+  private List<PhotoModel> photos;
+  private List<VideoModel> videos;
+  private Exporter<AuthData, PhotosContainerResource> photosExporter;
+  private Exporter<AuthData, VideosContainerResource> videosExporter;
+
+
+  @BeforeEach
+  public void setUp() {
+    photosExporter = (jobId, authData, exportInformation) -> new ExportResult<>(ResultType.END,
+        exportInformation.map(ei -> (PhotosContainerResource) ei.getContainerResource())
+            .orElse(new PhotosContainerResource(null, null)));
+    videosExporter = (jobId, authData, exportInformation) -> new ExportResult<>(ResultType.END,
+        exportInformation.map(ei -> (VideosContainerResource) ei.getContainerResource())
+            .orElse(new VideosContainerResource(null, null)));
+    mediaExporter = new MediaExporterDecorator<>(photosExporter, videosExporter);
+
+    albums = List.of(new MediaAlbum("album1", "name1", "desc1"),
+        new MediaAlbum("album2", "name2", "desc2"),
+        new MediaAlbum("album3", "name3", "desc3"));
+
+    photos = List.of(
+        new PhotoModel("p1", "", null, null, "d1", null,  false, null, null),
+        new PhotoModel("p2", "", null, null, "d2", "a1", false, null, null),
+        new PhotoModel("p3", "", null, null, "d3", "a2", false, null, null));
+
+    videos = List.of(
+        new VideoModel("v1", "", null, null, "d4", null, false),
+        new VideoModel("v2", "", null, null, "d5", "a3", false),
+        new VideoModel("v3", "", null, null, "d6", null, false));
+  }
+
+  @Test
+  public void shouldHandleEmptyExportInfomationAndEmptyResults() throws Exception {
+    ExportResult<MediaContainerResource> res = mediaExporter.export(null, null, Optional.empty());
+    ExportResult<MediaContainerResource> exp = new ExportResult<>(
+        ResultType.END, new MediaContainerResource(null, null, null));
+    assertEquals(exp, res);
+  }
+
+  @Test
+  public void shouldMergePhotoAndVideoResults() throws Exception {
+    MediaContainerResource mcr = new MediaContainerResource(albums, photos, videos);
+    ExportResult<MediaContainerResource> exp = new ExportResult<>(ResultType.END, mcr);
+
+    Optional<ExportInformation> ei = Optional.of(new ExportInformation(null, mcr));
+    ExportResult<MediaContainerResource> res = mediaExporter.export(null, null, ei);
+    assertEquals(exp, res);
+  }
+
+  @Test
+  public void shouldHandleOnlyPhotos() throws Exception {
+    MediaContainerResource mcr = new MediaContainerResource(albums, photos, null);
+    ExportResult<MediaContainerResource> exp = new ExportResult<>(ResultType.END, mcr);
+
+    Optional<ExportInformation> ei = Optional.of(new ExportInformation(null, mcr));
+    ExportResult<MediaContainerResource> res = mediaExporter.export(null, null, ei);
+    assertEquals(exp, res);
+  }
+
+  @Test
+  public void shouldHandleOnlyVideos() throws Exception {
+    MediaContainerResource mcr = new MediaContainerResource(albums, null, videos);
+    ExportResult<MediaContainerResource> exp = new ExportResult<>(ResultType.END, mcr);
+
+    Optional<ExportInformation> ei = Optional.of(new ExportInformation(null, mcr));
+    ExportResult<MediaContainerResource> res = mediaExporter.export(null, null, ei);
+    assertEquals(exp, res);
+  }
+
+  @Test
+  public void shouldHandleErrorInPhotos() throws Exception {
+    Exception throwable = new Exception();
+    mediaExporter =
+        new MediaExporterDecorator<>((id, ad, ei) -> new ExportResult<>(throwable), videosExporter);
+
+    MediaContainerResource mcr = new MediaContainerResource(albums, photos, videos);
+    Optional<ExportInformation> ei = Optional.of(new ExportInformation(null, mcr));
+    ExportResult<MediaContainerResource> res = mediaExporter.export(null, null, ei);
+    assertEquals(new ExportResult<>(throwable), res);
+  }
+
+
+  @Test
+  public void shouldHandleErrorInVideos() throws Exception {
+    Exception throwable = new Exception();
+    mediaExporter =
+        new MediaExporterDecorator<>(photosExporter, (id, ad, ei) -> new ExportResult<>(throwable));
+
+    MediaContainerResource mcr = new MediaContainerResource(albums, photos, videos);
+    Optional<ExportInformation> ei = Optional.of(new ExportInformation(null, mcr));
+    ExportResult<MediaContainerResource> res = mediaExporter.export(null, null, ei);
+    assertEquals(new ExportResult<>(throwable), res);
+  }
+}

--- a/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/MediaImporterDecoratorTest.java
+++ b/portability-spi-transfer/src/test/java/org/datatransferproject/spi/transfer/provider/converter/MediaImporterDecoratorTest.java
@@ -1,0 +1,87 @@
+package org.datatransferproject.spi.transfer.provider.converter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.types.common.models.media.MediaAlbum;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
+import org.datatransferproject.types.transfer.auth.AuthData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MediaImporterDecoratorTest {
+
+  private MediaImporterDecorator<AuthData> mediaImporter;
+  private List<MediaAlbum> albums;
+  private List<PhotoModel> photos;
+  private List<VideoModel> videos;
+  private Importer<AuthData, PhotosContainerResource> photosImporter;
+  private Importer<AuthData, VideosContainerResource> videosImporter;
+
+  @BeforeEach
+  public void setUp() {
+    photosImporter = (id, ex, ad, data) -> ImportResult.OK;
+    videosImporter = (id, ex, ad, data) -> ImportResult.OK;
+    mediaImporter = new MediaImporterDecorator<>(photosImporter, videosImporter);
+
+    albums = List.of(
+        new MediaAlbum("album1", "name1", "desc1"),
+        new MediaAlbum("album2", "name2", "desc2"),
+        new MediaAlbum("album3", "name3", "desc3"));
+
+    photos = List.of(
+        new PhotoModel("p1", "", null, null, "d1", null, false, null, null),
+        new PhotoModel("p2", "", null, null, "d2", "a1", false, null, null),
+        new PhotoModel("p3", "", null, null, "d3", "a2", false, null, null));
+
+    videos = List.of(
+        new VideoModel("v1", "", null, null, "d4", null, false),
+        new VideoModel("v2", "", null, null, "d5", "a3", false),
+        new VideoModel("v3", "", null, null, "d6", null, false));
+  }
+
+  @Test
+  public void shouldHandleVariousInputs() throws Exception {
+    assertEquals(ImportResult.OK,
+        mediaImporter.importItem(null, null, null, new MediaContainerResource(null, null, null)));
+    assertEquals(ImportResult.OK,
+        mediaImporter
+            .importItem(null, null, null, new MediaContainerResource(albums, null, videos)));
+    assertEquals(ImportResult.OK,
+        mediaImporter
+            .importItem(null, null, null, new MediaContainerResource(albums, photos, null)));
+    assertEquals(ImportResult.OK,
+        mediaImporter
+            .importItem(null, null, null, new MediaContainerResource(albums, photos, videos)));
+  }
+
+  @Test
+  public void shouldHandleErrorInPhotos() throws Exception {
+    Exception throwable = new Exception();
+    mediaImporter = new MediaImporterDecorator<>((id, ex, ad, data) -> new ImportResult(throwable),
+        videosImporter);
+
+    MediaContainerResource mcr = new MediaContainerResource(albums, photos, videos);
+    ImportResult res = mediaImporter.importItem(null, null, null, mcr);
+    assertEquals(new ImportResult(throwable), res);
+  }
+
+
+  @Test
+  public void shouldHandleErrorInVideos() throws Exception {
+    Exception throwable = new Exception();
+    mediaImporter = new MediaImporterDecorator<>(photosImporter,
+        (id, ex, ad, data) -> new ImportResult(throwable));
+
+    MediaContainerResource mcr = new MediaContainerResource(albums, photos, videos);
+    ImportResult res = mediaImporter.importItem(null, null, null, mcr);
+    assertEquals(new ImportResult(throwable), res);
+  }
+
+}

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobMetadata.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobMetadata.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 
 import java.util.UUID;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * A class that contains metadata for a transfer worker's job.
@@ -33,7 +34,7 @@ import java.util.UUID;
 public final class JobMetadata {
   private static byte[] encodedPrivateKey = null;
   private static UUID jobId = null;
-  private static String dataType = null;
+  private static DataVertical dataType = null;
   private static String exportService = null;
   private static String importService = null;
   private static Stopwatch stopWatch = null;
@@ -50,7 +51,7 @@ public final class JobMetadata {
   static void init(
       UUID initJobId,
       byte[] initEncodedPrivateKey,
-      String initDataType,
+      DataVertical initDataType,
       String initExportService,
       String initImportService,
       Stopwatch initStopWatch) {
@@ -83,7 +84,7 @@ public final class JobMetadata {
     return jobId;
   }
 
-  public static String getDataType() {
+  public static DataVertical getDataType() {
     Preconditions.checkState(isInitialized(), "JobMetadata must be initialized");
     return dataType;
   }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
@@ -45,6 +45,7 @@ import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.hooks.JobHooks;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorLoader;
+import org.datatransferproject.spi.transfer.provider.TransferCompatibilityProvider;
 import org.datatransferproject.spi.transfer.security.SecurityExtension;
 import org.datatransferproject.spi.transfer.security.SecurityExtensionLoader;
 
@@ -123,7 +124,8 @@ public class WorkerMain {
                   securityExtension,
                   idempotentImportExecutor,
                   symmetricKeyGenerator,
-                  jobHooks));
+                  jobHooks,
+                  new TransferCompatibilityProvider()));
     } catch (Exception e) {
       monitor.severe(() -> "Unable to initialize Guice in Worker", e);
       throw e;

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityAbstractInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityAbstractInMemoryDataCopier.java
@@ -19,7 +19,9 @@ import com.google.common.base.Stopwatch;
 import com.google.inject.Provider;
 import java.io.IOException;
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -44,6 +46,7 @@ import org.datatransferproject.transfer.JobMetadata;
 import org.datatransferproject.types.common.DownloadableItem;
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.models.DataModel;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.AuthData;
@@ -234,6 +237,11 @@ public abstract class PortabilityAbstractInMemoryDataCopier implements InMemoryD
       items = ((PhotosContainerResource) exportedData).getPhotos();
     } else if (exportedData instanceof VideosContainerResource) {
       items = ((VideosContainerResource) exportedData).getVideos();
+    } else if (exportedData instanceof MediaContainerResource) {
+      MediaContainerResource mcr = (MediaContainerResource) exportedData;
+      List<DownloadableItem> list = new ArrayList<>(mcr.getVideos());
+      list.addAll(mcr.getPhotos());
+      items = list;
     } else {
       return;
     }

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/JobPollingServiceTest.java
@@ -34,6 +34,7 @@ import org.datatransferproject.spi.transfer.security.SecurityException;
 import org.datatransferproject.spi.transfer.security.TransferKeyGenerator;
 import org.datatransferproject.spi.transfer.security.TransferKeyGenerator.WorkerKeyPair;
 
+import org.datatransferproject.types.common.models.DataVertical;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -115,7 +116,7 @@ public class JobPollingServiceTest {
     // API inserts an job in initial authorization state
     job =
         PortabilityJob.builder()
-            .setTransferDataType("photo")
+            .setTransferDataType(DataVertical.PHOTOS)
             .setExportService("DummyExportService")
             .setImportService("DummyImportService")
             .setAndValidateJobAuthorization(

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/WorkerModuleTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/WorkerModuleTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import org.datatransferproject.api.launcher.ExtensionContext;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
@@ -54,12 +55,12 @@ public class WorkerModuleTest {
       }
 
       @Override
-      public Exporter<?, ?> getExporter(String transferDataType) {
+      public Exporter<?, ?> getExporter(DataVertical transferDataType) {
         return null;
       }
 
       @Override
-      public Importer<?, ?> getImporter(String transferDataType) {
+      public Importer<?, ?> getImporter(DataVertical transferDataType) {
         return null;
       }
 

--- a/portability-types-client/src/main/java/org/datatransferproject/types/client/datatype/DataTypes.java
+++ b/portability-types-client/src/main/java/org/datatransferproject/types/client/datatype/DataTypes.java
@@ -19,18 +19,19 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Set;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /** The result of a request to list data types available for export and import. */
 public class DataTypes {
 
-  private final Set<String> dataTypes;
+  private final Set<DataVertical> dataTypes;
 
   @JsonCreator
-  public DataTypes(@JsonProperty("transferDataTypes") Set<String> dataTypes) {
+  public DataTypes(@JsonProperty("transferDataTypes") Set<DataVertical> dataTypes) {
     this.dataTypes = dataTypes;
   }
 
-  public Set<String> getDataTypes() {
+  public Set<DataVertical> getDataTypes() {
     return dataTypes;
   }
 }

--- a/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/CreateTransferJob.java
+++ b/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/CreateTransferJob.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.common.ExportInformation;
 
 import javax.annotation.Nullable;
@@ -30,7 +31,7 @@ public class CreateTransferJob {
   private final String importService;
   private final String exportCallbackUrl;
   private final String importCallbackUrl;
-  private final String dataType;
+  private final DataVertical dataType;
   private final ExportInformation exportInformation;
   private final String encryptionScheme;
 
@@ -40,7 +41,7 @@ public class CreateTransferJob {
       @JsonProperty(value = "importService", required = true) String importService,
       @JsonProperty(value = "exportCallbackUrl", required = true) String exportCallbackUrl,
       @JsonProperty(value = "importCallbackUrl", required = true) String importCallbackUrl,
-      @JsonProperty(value = "dataType", required = true) String dataType,
+      @JsonProperty(value = "dataType", required = true) DataVertical dataType,
       @JsonProperty(value = "exportInformation", required = false) ExportInformation exportInformation,
       @JsonProperty(value = "encryptionScheme", required = true) String encryptionScheme) {
     this.exportService = exportService;
@@ -76,7 +77,7 @@ public class CreateTransferJob {
   }
 
   @ApiModelProperty(value = "The type of data to transfer", dataType = "string", required = true)
-  public String getDataType() {
+  public DataVertical getDataType() {
     return dataType;
   }
 

--- a/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/GetTransferServices.java
+++ b/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/GetTransferServices.java
@@ -16,17 +16,18 @@
 package org.datatransferproject.types.client.transfer;
 
 import java.util.Objects;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /** Request to list services available for export and import for the given type. */
 public class GetTransferServices {
-  private final String transferDataType;
+  private final DataVertical transferDataType;
 
-  public GetTransferServices(String transferDataType) {
+  public GetTransferServices(DataVertical transferDataType) {
     Objects.requireNonNull(transferDataType);
     this.transferDataType = transferDataType;
   }
 
-  public String getTransferDataType() {
+  public DataVertical getTransferDataType() {
     return transferDataType;
   }
 }

--- a/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/TransferJob.java
+++ b/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/TransferJob.java
@@ -17,6 +17,8 @@ package org.datatransferproject.types.client.transfer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.datatransferproject.types.common.models.DataVertical;
+
 import static org.datatransferproject.types.common.PortabilityCommon.AuthProtocol;
 
 /**
@@ -35,7 +37,7 @@ public class TransferJob {
     private final String id;
     private final String exportService;
     private final String importService;
-    private final String dataType;
+    private final DataVertical dataType;
     private final State state = State.CREATED;
     private final String exportUrl;
     private final String importUrl;
@@ -49,7 +51,7 @@ public class TransferJob {
             @JsonProperty(value = "id", required = true) String id,
             @JsonProperty(value = "exportService", required = true) String exportService,
             @JsonProperty(value = "importService", required = true) String importService,
-            @JsonProperty(value = "dataType", required = true) String dataType,
+            @JsonProperty(value = "dataType", required = true) DataVertical dataType,
             @JsonProperty(value = "exportUrl", required = true) String exportUrl,
             @JsonProperty(value = "importUrl", required = true) String importUrl,
             @JsonProperty(value = "exportTokenUrl", required = true) String exportTokenUrl,
@@ -80,7 +82,7 @@ public class TransferJob {
         return importService;
     }
 
-    public String getDataType() {
+    public DataVertical getDataType() {
         return dataType;
     }
 

--- a/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/TransferServices.java
+++ b/portability-types-client/src/main/java/org/datatransferproject/types/client/transfer/TransferServices.java
@@ -21,16 +21,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Set;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /** Export and import services that support the provided data type. */
 public class TransferServices {
-  private final String transferDataType;
+  private final DataVertical transferDataType;
   private final Set<String> exportServices;
   private final Set<String> importServices;
 
   @JsonCreator
   public TransferServices(
-      @JsonProperty(value = "transferDataType", required = true) String transferDataType,
+      @JsonProperty(value = "transferDataType", required = true) DataVertical transferDataType,
       @JsonProperty(value = "exportServices", required = true) Set<String> exportServices,
       @JsonProperty(value = "importServices", required = true) Set<String> importServices) {
     this.transferDataType = transferDataType;
@@ -49,7 +50,7 @@ public class TransferServices {
   }
 
   @ApiModelProperty
-  public String getTransferDataType() {
+  public DataVertical getTransferDataType() {
     return this.transferDataType;
   }
 }

--- a/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/CreateTransferJobTest.java
+++ b/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/CreateTransferJobTest.java
@@ -16,7 +16,10 @@
 
 package org.datatransferproject.types.client.transfer;
 
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.datatransferproject.types.common.models.DataVertical;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +37,7 @@ public class CreateTransferJobTest {
                 "testDestination",
                 "https://localhost:3000/callback/testSource",
                 "https://localhost:3000/callback/testDestination",
-                "PHOTOS",
+                PHOTOS,
                 null,
                 "cleartext"));
 
@@ -46,6 +49,6 @@ public class CreateTransferJobTest {
         "https://localhost:3000/callback/testSource", deserialized.getExportCallbackUrl());
     Assert.assertEquals(
         "https://localhost:3000/callback/testDestination", deserialized.getImportCallbackUrl());
-    Assert.assertEquals("PHOTOS", deserialized.getDataType());
+    Assert.assertEquals(PHOTOS, deserialized.getDataType());
   }
 }

--- a/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/TransferJobTest.java
+++ b/portability-types-client/src/test/java/org/datatransferproject/types/client/transfer/TransferJobTest.java
@@ -21,6 +21,7 @@ import org.datatransferproject.types.common.PortabilityCommon;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 
 /* Test for TransferJob */
 public class TransferJobTest {
@@ -34,7 +35,7 @@ public class TransferJobTest {
             "1-2-3",
             "testExportService",
             "testImportService",
-            "PHOTOS",
+            PHOTOS,
             "exportUrl",
             "importUrl",
             "exportTokenUrl",
@@ -49,7 +50,7 @@ public class TransferJobTest {
     assertThat("1-2-3").isEqualTo(deserialized.getId());
     assertThat("testExportService").isEqualTo(deserialized.getExportService());
     assertThat("testImportService").isEqualTo(deserialized.getImportService());
-    assertThat("PHOTOS").isEqualTo(deserialized.getDataType());
+    assertThat(PHOTOS).isEqualTo(deserialized.getDataType());
     assertThat("exportUrl").isEqualTo(deserialized.getExportUrl());
     assertThat("importUrl").isEqualTo(deserialized.getImportUrl());
     assertThat("exportTokenUrl").isEqualTo(deserialized.getExportTokenUrl());

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/ExportInformation.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/ExportInformation.java
@@ -45,6 +45,10 @@ public class ExportInformation extends PortableType {
     return containerResource;
   }
 
+  public ExportInformation copyWithResource(ContainerResource cr) {
+    return new ExportInformation(getPaginationData(), cr);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/ContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/ContainerResource.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.datatransferproject.types.common.models.calendar.CalendarContainerResource;
 import org.datatransferproject.types.common.models.mail.MailContainerResource;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.common.models.playlists.PlaylistContainerResource;
 import org.datatransferproject.types.common.models.social.SocialActivityContainerResource;
@@ -20,6 +21,7 @@ import org.datatransferproject.types.common.models.videos.VideosContainerResourc
 @JsonSubTypes({
         @JsonSubTypes.Type(PhotosContainerResource.class),
         @JsonSubTypes.Type(VideosContainerResource.class),
+        @JsonSubTypes.Type(MediaContainerResource.class),
         @JsonSubTypes.Type(MailContainerResource.class),
         @JsonSubTypes.Type(CalendarContainerResource.class),
         @JsonSubTypes.Type(TaskContainerResource.class),

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/DataVertical.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/DataVertical.java
@@ -1,0 +1,49 @@
+package org.datatransferproject.types.common.models;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Represents the data type of a transfer job
+ */
+public enum DataVertical {
+  // TODO consider if we can reference data models directly rather than enums; for now beware
+  //  that each item in this enum is represented by one and only one common data model.
+  BLOBS("BLOBS"),
+  CALENDAR("CALENDAR"),
+  CONTACTS("CONTACTS"),
+  MAIL("MAIL"),
+  MEDIA("MEDIA"),
+  NOTES("NOTES"),
+  OFFLINE_DATA("OFFLINE-DATA"),
+  PHOTOS("PHOTOS"),
+  PLAYLISTS("PLAYLISTS"),
+  SOCIAL_POSTS("SOCIAL-POSTS"),
+  TASKS("TASKS"),
+  VIDEOS("VIDEOS");
+
+  private final String dataType;
+
+  DataVertical(String dataType) {
+    this.dataType = dataType;
+  }
+
+  @JsonValue
+  public String getDataType() {
+    return dataType;
+  }
+
+  private static final Map<String, DataVertical> BY_TYPE = new HashMap<>();
+
+  static {
+    for (DataVertical e : values()) {
+      BY_TYPE.put(e.dataType, e);
+    }
+  }
+
+  public static DataVertical fromDataType(String dataType) {
+    return BY_TYPE.get(dataType);
+  }
+}

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaAlbum.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaAlbum.java
@@ -13,6 +13,7 @@ import org.datatransferproject.types.common.ImportableItem;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 
 import javax.annotation.Nonnull;
+import org.datatransferproject.types.common.models.videos.VideoAlbum;
 
 public class MediaAlbum implements ImportableItem {
   private final String id;
@@ -45,6 +46,20 @@ public class MediaAlbum implements ImportableItem {
    */
   public static PhotoAlbum mediaToPhotoAlbum(MediaAlbum mediaAlbum) {
     return new PhotoAlbum(mediaAlbum.getId(), mediaAlbum.getName(), mediaAlbum.getDescription());
+  }
+
+  /**
+   * Extracts videos-specific data from a MediaAlbum
+   */
+  public static VideoAlbum mediaToVideoAlbum(MediaAlbum mediaAlbum) {
+    return new VideoAlbum(mediaAlbum.getId(), mediaAlbum.getName(), mediaAlbum.getDescription());
+  }
+
+  /**
+   * Converts a VideoAlbum to MediaAlbum
+   */
+  public static MediaAlbum videoToMediaAlbum(VideoAlbum videoAlbum) {
+    return new MediaAlbum(videoAlbum.getId(), videoAlbum.getName(), videoAlbum.getDescription());
   }
 
   @JsonIgnore(false)

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/media/MediaContainerResource.java
@@ -16,6 +16,7 @@ import org.datatransferproject.types.common.models.TransmogrificationConfig;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 
 @JsonTypeName("MediaContainerResource")
 public class MediaContainerResource extends ContainerResource {
@@ -46,7 +47,7 @@ public class MediaContainerResource extends ContainerResource {
         photosContainer
             .getAlbums()
             .stream()
-            .map(a -> MediaAlbum.photoToMediaAlbum(a))
+            .map(MediaAlbum::photoToMediaAlbum)
             .collect(Collectors.toList()),
         photosContainer.getPhotos(),
         null /*videos*/);
@@ -61,9 +62,38 @@ public class MediaContainerResource extends ContainerResource {
         mediaContainer
             .getAlbums()
             .stream()
-            .map(a -> MediaAlbum.mediaToPhotoAlbum(a))
+            .map(MediaAlbum::mediaToPhotoAlbum)
             .collect(Collectors.toList()),
         mediaContainer.getPhotos());
+  }
+
+  /**
+   * Builds a MediaContainerResource without video by mapping a PhotosContainerResource's fields
+   * 1:1 to MediaContainerResource.
+   */
+  public static MediaContainerResource videoToMedia(VideosContainerResource videosContainer) {
+    return new MediaContainerResource(
+        videosContainer
+            .getAlbums()
+            .stream()
+            .map(MediaAlbum::videoToMediaAlbum)
+            .collect(Collectors.toList()),
+        null,
+        videosContainer.getVideos());
+  }
+
+  /**
+   * Extracts a new VideosContainerResource from the relevant matching fields in a given
+   * MediaContainerResource.
+   */
+  public static VideosContainerResource mediaToVideo(MediaContainerResource mediaContainer) {
+    return new VideosContainerResource(
+        mediaContainer
+            .getAlbums()
+            .stream()
+            .map(MediaAlbum::mediaToVideoAlbum)
+            .collect(Collectors.toList()),
+        mediaContainer.getVideos());
   }
 
   public Collection<MediaAlbum> getAlbums() {

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/DataVerticalTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/DataVerticalTest.java
@@ -1,0 +1,20 @@
+package org.datatransferproject.types.common.models;
+
+import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class DataVerticalTest {
+
+  @Test
+  void shouldSerializeSocialPostsCorrectly() throws JsonProcessingException {
+    ObjectMapper om = new ObjectMapper();
+    String json = "\"SOCIAL-POSTS\"";
+    assertEquals(SOCIAL_POSTS, om.readValue(json, DataVertical.class));
+    assertEquals(SOCIAL_POSTS, DataVertical.fromDataType("SOCIAL-POSTS"));
+    assertEquals(json, om.writeValueAsString(SOCIAL_POSTS));
+  }
+}

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/media/MediaContainerResourceTest.java
@@ -1,5 +1,7 @@
 package org.datatransferproject.types.common.models.media;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -11,12 +13,16 @@ import org.datatransferproject.types.common.models.TransmogrificationConfig;
 import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.common.models.videos.VideoAlbum;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.junit.jupiter.api.Test;
 
 // TODO(#1060) this code was ported over without unit tests; below is a mostly 1:1-port
 // backfill but the new video handling logic in MediaContainerResource should have test coverage
 // too.
 public class MediaContainerResourceTest {
+
   @Test
   public void verifySerializeDeserialize() throws Exception {
     ObjectMapper objectMapper = new ObjectMapper();
@@ -108,6 +114,7 @@ public class MediaContainerResourceTest {
       public String getAlbumNameForbiddenCharacters() {
         return ":!";
       }
+
       public char getAlbumNameReplacementCharacter() {
         return '?';
       }
@@ -352,25 +359,57 @@ public class MediaContainerResourceTest {
     PhotosContainerResource generatedPhotoData = MediaContainerResource.mediaToPhoto(data);
     Truth
         .assertThat(generatedPhotoData.getAlbums()
-                        .stream()
-                        .map(a -> a.getId())
-                        .collect(Collectors.toList()))
+            .stream()
+            .map(a -> a.getId())
+            .collect(Collectors.toList()))
         .containsExactlyElementsIn(
             albums.stream().map(a -> a.getId()).collect(Collectors.toList()));
     Truth
         .assertThat(generatedPhotoData.getAlbums()
-                        .stream()
-                        .map(a -> a.getName())
-                        .collect(Collectors.toList()))
+            .stream()
+            .map(a -> a.getName())
+            .collect(Collectors.toList()))
         .containsExactlyElementsIn(
             albums.stream().map(a -> a.getName()).collect(Collectors.toList()));
     Truth
         .assertThat(generatedPhotoData.getAlbums()
-                        .stream()
-                        .map(a -> a.getDescription())
-                        .collect(Collectors.toList()))
+            .stream()
+            .map(a -> a.getDescription())
+            .collect(Collectors.toList()))
         .containsExactlyElementsIn(
             albums.stream().map(a -> a.getDescription()).collect(Collectors.toList()));
     Truth.assertThat(generatedPhotoData.getPhotos()).containsExactlyElementsIn(photos);
+  }
+
+  @Test
+  public void verifyMediaToVideoContainer() {
+    List<MediaAlbum> mediaAlbums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
+    List<VideoAlbum> videoAlbums =
+        ImmutableList.of(new VideoAlbum("id1", "albumb1", "This:a fake album!"));
+    List<VideoModel> videos = ImmutableList.of(
+        new VideoModel("Vid1", "http://fake.com/1.mp4", "A vid", "mediatype", "p1", "id1", false),
+        new VideoModel("Vid3", "http://fake.com/2.mp4", "A vid", "mediatype", "p3", "id1", false));
+    MediaContainerResource data = new MediaContainerResource(mediaAlbums, null, videos);
+
+    VideosContainerResource expected = new VideosContainerResource(videoAlbums, videos);
+    VideosContainerResource actual = MediaContainerResource.mediaToVideo(data);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void verifyVideoToMediaContainer() {
+    List<MediaAlbum> mediaAlbums =
+        ImmutableList.of(new MediaAlbum("id1", "albumb1", "This:a fake album!"));
+    List<VideoAlbum> videoAlbums =
+        ImmutableList.of(new VideoAlbum("id1", "albumb1", "This:a fake album!"));
+    List<VideoModel> videos = ImmutableList.of(
+        new VideoModel("Vid1", "http://fake.com/1.mp4", "A vid", "mediatype", "p1", "id1", false),
+        new VideoModel("Vid3", "http://fake.com/2.mp4", "A vid", "mediatype", "p3", "id1", false));
+    VideosContainerResource data = new VideosContainerResource(videoAlbums, videos);
+
+    MediaContainerResource expected = new MediaContainerResource(mediaAlbums, null, videos);
+    MediaContainerResource actual = MediaContainerResource.videoToMedia(data);
+    assertEquals(expected, actual);
   }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryingCallable.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryingCallable.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.Callable;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.types.common.models.DataVertical;
 
 /**
  * Class for retrying a {@link Callable} given a {@link RetryStrategyLibrary}.
@@ -35,7 +36,7 @@ public class RetryingCallable<T> implements Callable<T> {
   private final RetryStrategyLibrary retryStrategyLibrary;
   private final Clock clock;
   private final Monitor monitor;
-  private final String dataType;
+  private final DataVertical dataType;
   private final String service;
 
   private volatile int attempts;
@@ -46,7 +47,7 @@ public class RetryingCallable<T> implements Callable<T> {
       RetryStrategyLibrary retryStrategyLibrary,
       Clock clock,
       Monitor monitor,
-      String dataType,
+      DataVertical dataType,
       String service) {
     this.callable = callable;
     this.retryStrategyLibrary = retryStrategyLibrary;


### PR DESCRIPTION
makes progress against #1065 by building on top of https://github.com/google/data-transfer-project/pull/1062 by further expanding support for automatically handling media jobs.

It allows not writing dedicated media adapters in cases where the existing photo/video functionality is satisfactory. It also provides automatic interoperability with destinations that only provide a Media adapter.

Main contributions:
- replaced `MediaToPhotoConversionImporter` and `MediaToPhotoConversionExporter` with generic versions that can support conversion between any two adapters: `AnyToAnyImporter` and `AnyToAnyExporter`
- added special case adapters `MediaExporterDecorator` and `MediaImporterDecorator` which combine existing photo and video adapters to seamlessly cover the media job type.
- added a compatibility layer `TransferCompatibilityProvider` which attempts to build a substitute adapter upon not finding a real one. E.g. when a media job can't find a media importer, it will combine existing photo and video importers to perform the job.
- added a `DataVertical` enum which replaces the hardcoded type strings like `"PHOTOS"`.

Review the commit separately as the `DataVertical` commit is very monotonic.


----

note: this PR has a lot in it due to https://github.com/google/data-transfer-project/pull/1136#issuecomment-1231640367