### PR TITLE
Junit4 @Rule migrations to Junit 5

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/photos/DaybookPhotosImporterTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.UUID;
@@ -47,10 +48,9 @@ import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempoten
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
 public class DaybookPhotosImporterTest {
@@ -62,10 +62,10 @@ public class DaybookPhotosImporterTest {
   private PhotosContainerResource data;
   private OkHttpClient client;
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  public Path folder;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     monitor = mock(Monitor.class);
     jobStore = mock(TemporaryPerJobDataStore.class);
@@ -80,7 +80,7 @@ public class DaybookPhotosImporterTest {
     InputStream inputStream = new ByteArrayInputStream(expectedImageData);
     TemporaryPerJobDataStore.InputStreamWrapper inputStreamWrapper =
         new TemporaryPerJobDataStore.InputStreamWrapper(inputStream);
-    File file = folder.newFile();
+    File file = folder.toFile();
     when(jobStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(file);
     when(jobStore.getStream(any(), any())).thenReturn(inputStreamWrapper);
 

--- a/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/social/DaybookPostsImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-daybook/src/test/java/org/datatransferproject/transfer/daybook/social/DaybookPostsImporterTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.UUID;
@@ -46,10 +47,9 @@ import org.datatransferproject.types.common.models.social.SocialActivityLocation
 import org.datatransferproject.types.common.models.social.SocialActivityModel;
 import org.datatransferproject.types.common.models.social.SocialActivityType;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
 public class DaybookPostsImporterTest {
@@ -59,7 +59,8 @@ public class DaybookPostsImporterTest {
   private TokensAndUrlAuthData authData;
   private OkHttpClient client;
 
-  @Rule public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  public Path folder;
 
   @BeforeEach
   public void setUp() {

--- a/portability-api/src/test/java/org/datatransferproject/api/auth/PortabilityAuthServiceExtensionRegistryTest.java
+++ b/portability-api/src/test/java/org/datatransferproject/api/auth/PortabilityAuthServiceExtensionRegistryTest.java
@@ -20,6 +20,8 @@ import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
 import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,14 +35,10 @@ import org.datatransferproject.spi.api.auth.AuthDataGenerator;
 import org.datatransferproject.spi.api.auth.AuthServiceProviderRegistry;
 import org.datatransferproject.spi.api.auth.extension.AuthServiceExtension;
 import org.datatransferproject.types.common.models.DataVertical;
-import org.junit.Rule;
 
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class PortabilityAuthServiceExtensionRegistryTest {
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   private AuthServiceExtension getMockedAuthProvider(
       List<DataVertical> supportedImportTypes, List<DataVertical> supportedExportTypes, String serviceId) {
@@ -60,12 +58,12 @@ public class PortabilityAuthServiceExtensionRegistryTest {
 
     AuthServiceExtension mockAuthProvider = getMockedAuthProvider(
         supportedImportTypes, supportedExportTypes, "mockAuthProvider");
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("available for import but not export");
 
-    AuthServiceProviderRegistry registry =
-        new PortabilityAuthServiceProviderRegistry(
-            ImmutableMap.of("mockServiceProvider", mockAuthProvider));
+    Throwable throwable = assertThrows(IllegalArgumentException.class, () -> {
+      new PortabilityAuthServiceProviderRegistry(
+          ImmutableMap.of("mockServiceProvider", mockAuthProvider));
+    });
+    assertTrue(throwable.getMessage().contains("available for import but not export"));
   }
 
   @Test


### PR DESCRIPTION
Rules are deprecated in Junit5 hence migrated existing https://github.com/rule to junit 5 equivalents.