### PR TITLE
Add de- and serialisation for blobby container resource

### DIFF
--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/ContainerResource.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/ContainerResource.java
@@ -18,6 +18,7 @@ package org.datatransferproject.types.common.models;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.datatransferproject.types.common.models.blob.BlobbyStorageContainerResource;
 import org.datatransferproject.types.common.models.calendar.CalendarContainerResource;
 import org.datatransferproject.types.common.models.mail.MailContainerResource;
 import org.datatransferproject.types.common.models.media.MediaContainerResource;
@@ -46,6 +47,7 @@ import org.datatransferproject.types.common.models.videos.VideosContainerResourc
   @JsonSubTypes.Type(SocialActivityContainerResource.class),
   @JsonSubTypes.Type(IdOnlyContainerResource.class),
   @JsonSubTypes.Type(DateRangeContainerResource.class),
-  @JsonSubTypes.Type(MusicContainerResource.class)
+  @JsonSubTypes.Type(MusicContainerResource.class),
+  @JsonSubTypes.Type(BlobbyStorageContainerResource.class)
 })
 public abstract class ContainerResource extends DataModel {}

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/blob/DigitalDocumentWrapper.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/blob/DigitalDocumentWrapper.java
@@ -1,7 +1,9 @@
 package org.datatransferproject.types.common.models.blob;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
 import org.datatransferproject.types.common.models.DataModel;
 
 /**
@@ -10,6 +12,7 @@ import org.datatransferproject.types.common.models.DataModel;
  * this class represent DTP specific data that doesn't fit into the schema.org representation.
  */
 public class DigitalDocumentWrapper extends DataModel {
+
   private final DtpDigitalDocument dtpDigitalDocument;
   private final String originalEncodingFormat;
   // This isn't in the schema.org spec and is only needed to store the bytes DTP will transfer
@@ -36,5 +39,11 @@ public class DigitalDocumentWrapper extends DataModel {
 
   public String getOriginalEncodingFormat() {
     return originalEncodingFormat;
+  }
+
+  @JsonIgnore
+  @Override
+  public Map<String, Integer> getCounts() {
+    return super.getCounts();
   }
 }

--- a/portability-types-common/src/test/java/org/datatransferproject/types/common/models/blob/BlobbyStorageContainerResourceTest.java
+++ b/portability-types-common/src/test/java/org/datatransferproject/types/common/models/blob/BlobbyStorageContainerResourceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.types.common.models.blob;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+import org.datatransferproject.types.common.models.ContainerResource;
+import org.junit.jupiter.api.Test;
+
+class BlobbyStorageContainerResourceTest {
+
+  @Test
+  public void verifySerializeDeserialize() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerSubtypes(BlobbyStorageContainerResource.class);
+
+    DigitalDocumentWrapper documentWrapper = new DigitalDocumentWrapper(
+        new DtpDigitalDocument("doc-name", "2020-02-02", "UTF-8"), "UTF-8", "123456");
+    BlobbyStorageContainerResource containerResource = new BlobbyStorageContainerResource("name",
+        "id", ImmutableList.of(documentWrapper), ImmutableList.of());
+    String serialized = objectMapper.writeValueAsString(containerResource);
+
+    ContainerResource deserializedModel = objectMapper.readValue(serialized,
+        ContainerResource.class);
+
+    Truth.assertThat(deserializedModel).isNotNull();
+    Truth.assertThat(deserializedModel).isInstanceOf(BlobbyStorageContainerResource.class);
+    BlobbyStorageContainerResource deserialized = (BlobbyStorageContainerResource) deserializedModel;
+    Truth.assertThat(deserialized.getFiles()).hasSize(1);
+    Truth.assertThat(deserialized.getFolders()).isEmpty();
+  }
+}


### PR DESCRIPTION
Adding `@JsonIgnore` to `getCounts` to make deserialisation work. It's unclear why the document wrapper class inherits `DataModel` in the first place. A better solution would be to remove the inheritance. Scary though

---

This PR is a hotfix so I'll prepare a small release when this diff is merged.