### PR TITLE
Update the photo and video importers of Koofr and Backblaze to log bytes transferred

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/photos/KoofrPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-koofr/src/main/java/org/datatransferproject/transfer/koofr/photos/KoofrPhotosImporter.java
@@ -15,16 +15,16 @@
  */
 package org.datatransferproject.transfer.koofr.photos;
 
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.atomic.LongAdder;
+
 import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.common.ImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
@@ -34,7 +34,9 @@ import org.apache.commons.io.IOUtils;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
 import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.ItemImportResult;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
@@ -54,7 +56,6 @@ import static java.lang.String.format;
 public class KoofrPhotosImporter
     implements Importer<TokensAndUrlAuthData, PhotosContainerResource> {
 
-  private static final String SKIPPED_FILE_RESULT_FORMAT = "skipped-%s";
   private static final String TITLE_DATE_FORMAT = "yyyy-MM-dd HH.mm.ss ";
   private final KoofrClientFactory koofrClientFactory;
   private final JobStore jobStore;
@@ -103,13 +104,20 @@ public class KoofrPhotosImporter
           album.getId(), album.getName(), () -> createAlbumFolder(album, koofrClient));
     }
 
+    final LongAdder totalImportedFilesSizes = new LongAdder();
     for (PhotoModel photoModel : resource.getPhotos()) {
-      idempotentImportExecutor.executeAndSwallowIOExceptions(
-          photoModel.getIdempotentId(),
-          photoModel.getTitle(),
-          () -> importSinglePhoto(photoModel, jobId, idempotentImportExecutor, koofrClient));
+      idempotentImportExecutor.importAndSwallowIOExceptions(
+          photoModel,
+          photo -> {
+            ItemImportResult<String> fileImportResult =
+                    importSinglePhoto(photoModel, jobId, idempotentImportExecutor, koofrClient);
+            if (fileImportResult.hasBytes()) {
+              totalImportedFilesSizes.add(fileImportResult.getBytes());
+            }
+            return fileImportResult;
+          });
     }
-    return ImportResult.OK;
+    return ImportResult.OK.copyWithBytes(totalImportedFilesSizes.longValue());
   }
 
   private String createAlbumFolder(PhotoAlbum album, KoofrClient koofrClient)
@@ -132,61 +140,71 @@ public class KoofrPhotosImporter
     return fullPath;
   }
 
-  private String importSinglePhoto(
+  private ItemImportResult<String> importSinglePhoto(
       PhotoModel photo,
       UUID jobId,
       IdempotentImportExecutor idempotentImportExecutor,
       KoofrClient koofrClient)
-      throws IOException, InvalidTokenException, DestinationMemoryFullException {
+          throws IOException, InvalidTokenException, DestinationMemoryFullException {
     monitor.debug(() -> String.format("Import single photo %s", photo.getTitle()));
+    Long size = null;
+    try {
+      InputStreamWrapper inputStreamWrapper =
+              connectionProvider.getInputStreamForItem(jobId, photo);
+      ItemImportResult<String> response;
 
-    try (InputStream inputStream =
-        connectionProvider.getInputStreamForItem(jobId, photo).getStream()) {
-      final byte[] bytes = IOUtils.toByteArray(inputStream);
+      try (InputStream inputStream = inputStreamWrapper.getStream()) {
+        final byte[] bytes = IOUtils.toByteArray(inputStream);
 
-      Date dateCreated = getDateCreated(photo, bytes);
+        Date dateCreated = getDateCreated(photo, bytes);
 
-      String title = buildPhotoTitle(jobId, photo.getTitle(), dateCreated);
-      String description = KoofrClient.trimDescription(photo.getDescription());
+        String title = buildPhotoTitle(jobId, photo.getTitle(), dateCreated);
+        String description = KoofrClient.trimDescription(photo.getDescription());
 
-      String parentPath = idempotentImportExecutor.getCachedValue(photo.getAlbumId());
-      String fullPath = parentPath + "/" + title;
+        String parentPath = idempotentImportExecutor.getCachedValue(photo.getAlbumId());
+        String fullPath = parentPath + "/" + title;
 
-      if (koofrClient.fileExists(fullPath)) {
-        monitor.debug(() -> String.format("Photo already exists %s", photo.getTitle()));
+        if (koofrClient.fileExists(fullPath)) {
+          monitor.debug(() -> String.format("Photo already exists %s", photo.getTitle()));
 
-        return fullPath;
-      }
-
-      final ByteArrayInputStream inMemoryInputStream = new ByteArrayInputStream(bytes);
-
-      String response;
-
-      try {
-        response = koofrClient.uploadFile(
-                parentPath, title, inMemoryInputStream, photo.getMediaType(), dateCreated, description);
-      } catch (KoofrClientIOException e) {
-        if (e.getCode() == 404) {
-          monitor.info(() -> String.format("Can't find album during importSingleItem for id: %s", photo.getDataId()), e);
-          response = "skipped-"+photo.getDataId();
+          return ItemImportResult.success(fullPath);
         }
-        else {
-          throw e;
-        }
-      }
 
-      try {
-        if (photo.isInTempStore()) {
-          jobStore.removeData(jobId, photo.getFetchableUrl());
+        final ByteArrayInputStream inMemoryInputStream = new ByteArrayInputStream(bytes);
+
+        try {
+          long inputStreamBytes = inputStreamWrapper.getBytes();
+          response = ItemImportResult.success(
+                  koofrClient.uploadFile(
+                  parentPath, title, inMemoryInputStream, photo.getMediaType(), dateCreated, description),
+                  inputStreamBytes);
+          size = inputStreamBytes;
+        } catch (KoofrClientIOException exception) {
+          if (exception.getCode() == 404) {
+            monitor.info(() -> String.format("Can't find album during importSingleItem for id: %s", photo.getDataId()), exception);
+            response = ItemImportResult.success("skipped-" + photo.getDataId());
+          } else {
+            Long finalSize = size;
+            return ItemImportResult.error(exception, finalSize);
+          }
         }
-      } catch (Exception e) {
-        // Swallow the exception caused by Remove data so that existing flows continue
-        monitor.info(
-                () -> format("Exception swallowed while removing data for jobId %s, localPath %s",
-                        jobId, photo.getFetchableUrl()), e);
+
+        try {
+          if (photo.isInTempStore()) {
+            jobStore.removeData(jobId, photo.getFetchableUrl());
+          }
+        } catch (Exception e) {
+          // Swallow the exception caused by Remove data so that existing flows continue
+          monitor.info(
+                  () -> format("Exception swallowed while removing data for jobId %s, localPath %s",
+                          jobId, photo.getFetchableUrl()), e);
+        }
       }
 
       return response;
+    } catch (KoofrClientIOException exception) {
+      Long finalSize = size;
+      return ItemImportResult.error(exception, finalSize);
     }
   }
 

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/social/SocialActivityAttachment.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/social/SocialActivityAttachment.java
@@ -18,10 +18,12 @@ package org.datatransferproject.types.common.models.social;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.datatransferproject.types.common.ImportableItem;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
-public class SocialActivityAttachment {
+public class SocialActivityAttachment implements ImportableItem {
   private SocialActivityAttachmentType type;
   private String url;
   private String name;
@@ -70,4 +72,8 @@ public class SocialActivityAttachment {
   public int hashCode() {
     return Objects.hash(getType(), getUrl(), getName(), getContent());
   }
+
+  @Nullable
+  @Override
+  public String getIdempotentId() { return getUrl(); }
 }

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/social/SocialActivityModel.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/social/SocialActivityModel.java
@@ -19,12 +19,14 @@ package org.datatransferproject.types.common.models.social;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import org.datatransferproject.types.common.ImportableItem;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Objects;
 
-public class SocialActivityModel {
+public class SocialActivityModel implements ImportableItem {
   private String id;
   private Instant published;
   private SocialActivityType type;
@@ -114,4 +116,14 @@ public class SocialActivityModel {
   public String getUrl() {
     return url;
   }
+
+  @Nullable
+  @Override
+  public String getIdempotentId() {
+    return Integer.toString(hashCode());
+  }
+
+  @Nullable
+  @Override
+  public String getName() { return title; }
 }


### PR DESCRIPTION
**Summary :**
1. Update the photo and video importers of Koofr and Backblaze to log the number of bytes transferred. [D41550603](https://www.internalfb.com/diff/D41550603) [D41550846](https://www.internalfb.com/diff/D41550846)
2. Updated SocialActivityAttachment and SocialActivityModel classes to implement ImportableItem class. [D41646527](https://www.internalfb.com/diff/D41646527)