### PR TITLE
Separate getErrors from copy, so it isn't skipped when copy throws.

### DIFF
--- a/extensions/copier/portability-stack-copier/src/main/java/org/datatransferproject/copier/stack/PortabilityStackInMemoryDataCopier.java
+++ b/extensions/copier/portability-stack-copier/src/main/java/org/datatransferproject/copier/stack/PortabilityStackInMemoryDataCopier.java
@@ -17,7 +17,6 @@
 package org.datatransferproject.copier.stack;
 
 import com.google.inject.Provider;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Stack;
@@ -38,7 +37,6 @@ import org.datatransferproject.transfer.copier.PortabilityAbstractInMemoryDataCo
 import org.datatransferproject.types.common.ExportInformation;
 import org.datatransferproject.types.common.models.ContainerResource;
 import org.datatransferproject.types.transfer.auth.AuthData;
-import org.datatransferproject.types.transfer.errors.ErrorDetail;
 import org.datatransferproject.types.transfer.retry.RetryStrategyLibrary;
 
 /** Implementation of {@link InMemoryDataCopier}. */
@@ -83,7 +81,7 @@ public class PortabilityStackInMemoryDataCopier extends PortabilityAbstractInMem
    * @param exportInfo Any pagination or resource information to use for subsequent calls.
    */
   @Override
-  public Collection<ErrorDetail> copy(
+  public void copy(
       AuthData exportAuthData,
       AuthData importAuthData,
       UUID jobId,
@@ -132,7 +130,6 @@ public class PortabilityStackInMemoryDataCopier extends PortabilityAbstractInMem
           copyIteration,
           exportResult.getContinuationData());
     }
-    return idempotentImportExecutor.getErrors();
   }
 
   private void updateStackAfterCopyIteration(

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/JobProcessor.java
@@ -150,10 +150,11 @@ class JobProcessor {
     } finally {
       final Collection<ErrorDetail> errors = copier.getErrors(jobId);
       final int numErrors = errors.size();
-      monitor.debug(
-          () -> format("Finished copy for jobId: %s with %d error(s).", jobId, numErrors));
+      // success is set to true above if copy returned without throwing
       success &= errors.isEmpty();
-      monitor.debug(() -> "Finished processing jobId: " + jobId, EventCode.WORKER_JOB_FINISHED);
+      monitor.debug(
+          () -> format("Finished processing jobId: %s with %d error(s).", jobId, numErrors),
+          EventCode.WORKER_JOB_FINISHED);
       addErrorsAndMarkJobFinished(jobId, success, errors);
       hooks.jobFinished(jobId, success);
       dtpInternalMetricRecorder.finishedJob(

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/InMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/InMemoryDataCopier.java
@@ -28,9 +28,11 @@ import java.util.UUID;
 /** In-memory Copier interface */
 public interface InMemoryDataCopier {
   /* Copies the provided dataType from exportService to importService */
-  Collection<ErrorDetail> copy(
+  void copy(
           AuthData exportAuthData,
           AuthData importAuthData,
           UUID jobId, Optional<ExportInformation> exportInfo)
       throws IOException, CopyException;
+
+  Collection<ErrorDetail> getErrors(UUID jobId);
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityAbstractInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityAbstractInMemoryDataCopier.java
@@ -90,12 +90,18 @@ public abstract class PortabilityAbstractInMemoryDataCopier implements InMemoryD
 
   /** Kicks off transfer job {@code jobId} from {@code exporter} to {@code importer}. */
   @Override
-  public abstract Collection<ErrorDetail> copy(
+  public abstract void copy(
       AuthData exportAuthData,
       AuthData importAuthData,
       UUID jobId,
       Optional<ExportInformation> exportInfo)
       throws IOException, CopyException;
+
+  @Override
+  public Collection<ErrorDetail> getErrors(UUID jobId) {
+    idempotentImportExecutor.setJobId(jobId);
+    return idempotentImportExecutor.getErrors();
+  }
 
   protected ExportResult<?> copyIteration(
       UUID jobId,

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityInMemoryDataCopier.java
@@ -71,14 +71,14 @@ public class PortabilityInMemoryDataCopier extends PortabilityAbstractInMemoryDa
 
   /** Kicks off transfer job {@code jobId} from {@code exporter} to {@code importer}. */
   @Override
-  public Collection<ErrorDetail> copy(
+  public void copy(
       AuthData exportAuthData,
       AuthData importAuthData,
       UUID jobId,
       Optional<ExportInformation> exportInfo)
       throws IOException, CopyException {
     idempotentImportExecutor.setJobId(jobId);
-    return copyHelper(exportAuthData, importAuthData, jobId, exportInfo);
+    copyHelper(exportAuthData, importAuthData, jobId, exportInfo);
   }
 
   /**
@@ -91,7 +91,7 @@ public class PortabilityInMemoryDataCopier extends PortabilityAbstractInMemoryDa
    * @param importAuthData The auth data for the import
    * @param exportInfo Any pagination or resource information to use for subsequent calls.
    */
-  private Collection<ErrorDetail> copyHelper(
+  private void copyHelper(
       AuthData exportAuthData,
       AuthData importAuthData,
       UUID jobId,
@@ -147,6 +147,5 @@ public class PortabilityInMemoryDataCopier extends PortabilityAbstractInMemoryDa
         }
       }
     }
-    return idempotentImportExecutor.getErrors();
   }
 }

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/JobProcessorTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/JobProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Data Transfer Project Authors.
+ * Copyright 2023 The Data Transfer Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/JobProcessorTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/JobProcessorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer;
+
+import com.google.common.base.Stopwatch;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.datatransferproject.api.launcher.DtpInternalMetricRecorder;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.transfer.hooks.JobHooks;
+import org.datatransferproject.spi.transfer.types.CopyException;
+import org.datatransferproject.transfer.copier.InMemoryDataCopier;
+import org.datatransferproject.types.common.ExportInformation;
+import org.datatransferproject.types.common.models.DataVertical;
+import org.datatransferproject.types.transfer.auth.AuthData;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class JobProcessorTest {
+
+  private UUID jobId;
+  private ExportInformation exportInfo;
+  private AuthData exportAuthData;
+  private AuthData importAuthData;
+  private InMemoryDataCopier copier;
+
+  private static class TestJobProcessor extends JobProcessor {
+
+    public TestJobProcessor(InMemoryDataCopier copier) {
+      super(
+          Mockito.mock(JobStore.class),
+          Mockito.mock(JobHooks.class),
+          null,
+          copier,
+          null,
+          Mockito.mock(Monitor.class),
+          Mockito.mock(DtpInternalMetricRecorder.class)
+      );
+    }
+  }
+
+  private TestJobProcessor processor;
+
+  @Before
+  public void setUp() {
+    importAuthData = exportAuthData = Mockito.mock(AuthData.class);
+    jobId = UUID.randomUUID();
+    exportInfo = Mockito.mock(ExportInformation.class);
+    copier = Mockito.mock(InMemoryDataCopier.class);
+    processor = Mockito.spy(new TestJobProcessor(copier));
+    JobMetadata.reset();
+    JobMetadata.init(
+        jobId,
+        "".getBytes(),
+        DataVertical.BLOBS,
+        "",
+        "",
+        Stopwatch.createStarted());
+  }
+
+  @After
+  public void cleanUp() {
+    JobMetadata.reset();
+  }
+
+  @Test
+  public void processJobGetsErrorsEvenWhenCopyThrows() throws CopyException, IOException {
+    Mockito.doThrow(new CopyException("error", new Exception())).when(copier)
+        .copy(importAuthData, exportAuthData, jobId, Optional.of(exportInfo));
+    processor.processJob();
+    Mockito.verify(copier).getErrors(jobId);
+  }
+}


### PR DESCRIPTION
This should fix an issue where the errors from the idempotent executor weren't being added to the datastore when the job completed.