### PR TITLE
Improvements to backblaze data transfer

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeConstants.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeConstants.java
@@ -1,0 +1,7 @@
+package org.datatransferproject.datatransfer.backblaze.common;
+
+public interface BackblazeConstants {
+    String VIDEOS_BASE_FOLDER_NAME = "Video Transfer";
+    String PHOTOS_BASE_FOLDER_NAME = "Photo Transfer";
+    String MEDIA_BASE_FOLDER_NAME = "Media Transfer";
+}

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
@@ -41,22 +41,24 @@ import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
 public class BackblazePhotosImporter
     implements Importer<TokenSecretAuthData, PhotosContainerResource> {
 
-  private static final String PHOTO_TRANSFER_MAIN_FOLDER = "Photo Transfer";
-
   private final TemporaryPerJobDataStore jobStore;
   private final ConnectionProvider connectionProvider;
   private final Monitor monitor;
   private final BackblazeDataTransferClientFactory b2ClientFactory;
 
+  private final String baseFolderName;
+
   public BackblazePhotosImporter(
       Monitor monitor,
       TemporaryPerJobDataStore jobStore,
       ConnectionProvider connectionProvider,
-      BackblazeDataTransferClientFactory b2ClientFactory) {
+      BackblazeDataTransferClientFactory b2ClientFactory,
+      String baseFolderName) {
     this.monitor = monitor;
     this.jobStore = jobStore;
     this.connectionProvider = connectionProvider;
     this.b2ClientFactory = b2ClientFactory;
+    this.baseFolderName = baseFolderName;
   }
 
   @Override
@@ -115,7 +117,7 @@ public class BackblazePhotosImporter
     }
     String response =
         b2Client.uploadFile(
-            String.format("%s/%s/%s.jpg", PHOTO_TRANSFER_MAIN_FOLDER, albumName, photo.getDataId()),
+            String.format("%s/%s/%s.jpg", baseFolderName, albumName, photo.getDataId()),
             file);
     long size = file.length();
 

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporter.java
@@ -117,8 +117,10 @@ public class BackblazePhotosImporter
     }
     String response =
         b2Client.uploadFile(
-            String.format("%s/%s/%s.jpg", baseFolderName, albumName, photo.getDataId()),
-            file);
+            String.format("%s/%s/%s", baseFolderName, albumName, photo.getTitle()),
+            file,
+            photo.getUploadedTime()
+        );
     long size = file.length();
 
     try {

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -100,7 +100,7 @@ public class BackblazeVideosImporter
       File file = jobStore.getTempFileFromInputStream(videoFileStream, video.getDataId(), ".mp4");
       String res =
           b2Client.uploadFile(
-              String.format("%s/%s.mp4", baseFolderName, video.getDataId()), file);
+              String.format("%s/%s", baseFolderName, video.getName()), file, video.getUploadedTime());
       return ItemImportResult.success(res, file.length());
     } catch (FileNotFoundException e) {
       monitor.info(

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/main/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporter.java
@@ -46,15 +46,19 @@ public class BackblazeVideosImporter
   private final Monitor monitor;
   private final BackblazeDataTransferClientFactory b2ClientFactory;
 
+  private final String baseFolderName;
+
   public BackblazeVideosImporter(
       Monitor monitor,
       TemporaryPerJobDataStore jobStore,
       ConnectionProvider connectionProvider,
-      BackblazeDataTransferClientFactory b2ClientFactory) {
+      BackblazeDataTransferClientFactory b2ClientFactory,
+      String baseFolderName) {
     this.monitor = monitor;
     this.jobStore = jobStore;
     this.connectionProvider = connectionProvider;
     this.b2ClientFactory = b2ClientFactory;
+    this.baseFolderName = baseFolderName;
   }
 
   @Override
@@ -96,7 +100,7 @@ public class BackblazeVideosImporter
       File file = jobStore.getTempFileFromInputStream(videoFileStream, video.getDataId(), ".mp4");
       String res =
           b2Client.uploadFile(
-              String.format("%s/%s.mp4", VIDEO_TRANSFER_MAIN_FOLDER, video.getDataId()), file);
+              String.format("%s/%s.mp4", baseFolderName, video.getDataId()), file);
       return ItemImportResult.success(res, file.length());
     } catch (FileNotFoundException e) {
       monitor.info(

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/common/BackblazeDataTransferClientTest.java
@@ -28,6 +28,10 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.backblaze.exception.BackblazeCredentialsException;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,6 +67,7 @@ public class BackblazeDataTransferClientTest {
   @Mock
   private S3Client s3Client;
   private static File testFile;
+  private static Date testUploadedDate = new GregorianCalendar(2023, Calendar.FEBRUARY,23, 15, 0).getTime();
   private static final String KEY_ID = "keyId";
   private static final String APP_KEY = "appKey";
   private static final String EXPORT_SERVICE = "exp-serv";
@@ -156,7 +161,7 @@ public class BackblazeDataTransferClientTest {
   public void testUploadFileNonInitialized() throws IOException {
     BackblazeDataTransferClient client = createDefaultClient();
     assertThrows(IllegalStateException.class, () -> {
-      client.uploadFile(FILE_KEY, testFile);
+      client.uploadFile(FILE_KEY, testFile, testUploadedDate);
     });
   }
 
@@ -168,7 +173,8 @@ public class BackblazeDataTransferClientTest {
         .thenReturn(PutObjectResponse.builder().versionId(expectedVersionId).build());
     BackblazeDataTransferClient client = createDefaultClient();
     client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
-    String actualVersionId = client.uploadFile(FILE_KEY, testFile);
+    String actualVersionId = client.uploadFile(FILE_KEY, testFile,
+            new GregorianCalendar(2023, Calendar.FEBRUARY,23, 15, 0).getTime());
     verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     assertEquals(expectedVersionId, actualVersionId);
   }
@@ -181,7 +187,7 @@ public class BackblazeDataTransferClientTest {
     BackblazeDataTransferClient client = createDefaultClient();
     client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
     assertThrows(IOException.class, () -> {
-      client.uploadFile(FILE_KEY, testFile);
+      client.uploadFile(FILE_KEY, testFile, testUploadedDate);
     });
   }
 
@@ -201,7 +207,7 @@ public class BackblazeDataTransferClientTest {
     BackblazeDataTransferClient client =
         new BackblazeDataTransferClient(monitor, backblazeS3ClientFactory, fileSize / 2, partSize);
     client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
-    String actualVersionId = client.uploadFile(FILE_KEY, testFile);
+    String actualVersionId = client.uploadFile(FILE_KEY, testFile, testUploadedDate);
     verify(s3Client, times((int) expectedParts))
         .uploadPart(any(UploadPartRequest.class), any(RequestBody.class));
     assertEquals(expectedVersionId, actualVersionId);
@@ -220,7 +226,7 @@ public class BackblazeDataTransferClientTest {
             fileSize / 8);
     client.init(KEY_ID, APP_KEY, EXPORT_SERVICE);
     assertThrows(IOException.class, () -> {
-      client.uploadFile(FILE_KEY, testFile);
+      client.uploadFile(FILE_KEY, testFile, testUploadedDate);
     });
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeConstants;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
 import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
@@ -43,11 +44,13 @@ import org.datatransferproject.types.common.models.photos.PhotoAlbum;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BackblazePhotosImporterTest {
   Monitor monitor;
   TemporaryPerJobDataStore dataStore;
@@ -56,8 +59,9 @@ public class BackblazePhotosImporterTest {
   IdempotentImportExecutor executor;
   TokenSecretAuthData authData;
   BackblazeDataTransferClient client;
+  BackblazePhotosImporter photosImporter;
 
-  @BeforeEach
+  @BeforeAll
   public void setUp() {
     monitor = mock(Monitor.class);
     dataStore = mock(TemporaryPerJobDataStore.class);
@@ -66,27 +70,26 @@ public class BackblazePhotosImporterTest {
     executor = mock(IdempotentImportExecutor.class);
     authData = mock(TokenSecretAuthData.class);
     client = mock(BackblazeDataTransferClient.class);
+    photosImporter = new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory,
+            BackblazeConstants.PHOTOS_BASE_FOLDER_NAME);
   }
 
   @TempDir public Path folder;
 
   @Test
   public void testNullData() throws Exception {
-    BackblazePhotosImporter sut =
-        new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
-    ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, null);
+    ImportResult result = photosImporter.importItem(UUID.randomUUID(), executor, authData, null);
     assertEquals(ImportResult.OK, result);
   }
 
   @Test
   public void testNullPhotosAndAlbums() throws Exception {
+    System.out.println(photosImporter);
     PhotosContainerResource data = mock(PhotosContainerResource.class);
     when(data.getAlbums()).thenReturn(null);
     when(data.getPhotos()).thenReturn(null);
 
-    BackblazePhotosImporter sut =
-        new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
-    ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, data);
+    ImportResult result = photosImporter.importItem(UUID.randomUUID(), executor, authData, data);
     assertEquals(ImportResult.ResultType.OK, result.getType());
   }
 
@@ -96,9 +99,7 @@ public class BackblazePhotosImporterTest {
     when(data.getAlbums()).thenReturn(new ArrayList<>());
     when(data.getPhotos()).thenReturn(new ArrayList<>());
 
-    BackblazePhotosImporter sut =
-        new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
-    ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, data);
+    ImportResult result = photosImporter.importItem(UUID.randomUUID(), executor, authData, data);
     assertEquals(ImportResult.ResultType.OK, result.getType());
   }
 
@@ -126,9 +127,7 @@ public class BackblazePhotosImporterTest {
     File file = folder.toFile();
     when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(file);
 
-    BackblazePhotosImporter sut =
-        new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
-    sut.importItem(jobId, executor, authData, data);
+    photosImporter.importItem(jobId, executor, authData, data);
 
     ArgumentCaptor<ImportFunction<PhotoModel, String>> importCapture =
         ArgumentCaptor.forClass(ImportFunction.class);
@@ -148,9 +147,7 @@ public class BackblazePhotosImporterTest {
     PhotosContainerResource data = mock(PhotosContainerResource.class);
     when(data.getAlbums()).thenReturn(albums);
 
-    BackblazePhotosImporter sut =
-        new BackblazePhotosImporter(monitor, dataStore, streamProvider, clientFactory);
-    sut.importItem(UUID.randomUUID(), executor, authData, data);
+    photosImporter.importItem(UUID.randomUUID(), executor, authData, data);
 
     verify(executor, times(1))
         .executeAndSwallowIOExceptions(

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/photos/BackblazePhotosImporterTest.java
@@ -121,7 +121,7 @@ public class BackblazePhotosImporterTest {
     when(streamProvider.getInputStreamForItem(jobId, photoModel))
         .thenReturn(new InputStreamWrapper(IOUtils.toInputStream("photo content", "UTF-8")));
 
-    when(client.uploadFile(eq("Photo Transfer/albumName/dataId.jpg"), any())).thenReturn(response);
+    when(client.uploadFile(eq("Photo Transfer/albumName/dataId.jpg"), any(), any())).thenReturn(response);
     when(clientFactory.getOrCreateB2Client(jobId, authData)).thenReturn(client);
 
     File file = folder.toFile();

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
@@ -29,8 +29,10 @@ import java.util.ArrayList;
 import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.backblaze.common.BackblazeConstants;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
+import org.datatransferproject.datatransfer.backblaze.photos.BackblazePhotosImporter;
 import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
@@ -40,11 +42,15 @@ import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
+import org.junit.Before;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BackblazeVideosImporterTest {
 
   Monitor monitor;
@@ -54,9 +60,11 @@ public class BackblazeVideosImporterTest {
   IdempotentImportExecutor executor;
   TokenSecretAuthData authData;
   BackblazeDataTransferClient client;
+  BackblazeDataTransferClientFactory b2ClientFactory;
+  BackblazeVideosImporter videosImporter;
   @TempDir public Path folder;
 
-  @BeforeEach
+  @BeforeAll
   public void setUp() {
     monitor = mock(Monitor.class);
     dataStore = mock(TemporaryPerJobDataStore.class);
@@ -65,13 +73,13 @@ public class BackblazeVideosImporterTest {
     executor = mock(IdempotentImportExecutor.class);
     authData = mock(TokenSecretAuthData.class);
     client = mock(BackblazeDataTransferClient.class);
+    videosImporter = new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory,
+            BackblazeConstants.VIDEOS_BASE_FOLDER_NAME);
   }
 
   @Test
   public void testNullData() throws Exception {
-    BackblazeVideosImporter sut =
-        new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
-    ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, null);
+    ImportResult result = videosImporter.importItem(UUID.randomUUID(), executor, authData, null);
     assertEquals(ImportResult.OK, result);
   }
 
@@ -80,9 +88,7 @@ public class BackblazeVideosImporterTest {
     VideosContainerResource data = mock(VideosContainerResource.class);
     when(data.getVideos()).thenReturn(null);
 
-    BackblazeVideosImporter sut =
-        new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
-    ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, data);
+    ImportResult result = videosImporter.importItem(UUID.randomUUID(), executor, authData, data);
     assertEquals(ImportResult.ResultType.OK, result.getType());
   }
 
@@ -91,9 +97,7 @@ public class BackblazeVideosImporterTest {
     VideosContainerResource data = mock(VideosContainerResource.class);
     when(data.getVideos()).thenReturn(new ArrayList<>());
 
-    BackblazeVideosImporter sut =
-        new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
-    ImportResult result = sut.importItem(UUID.randomUUID(), executor, authData, data);
+    ImportResult result = videosImporter.importItem(UUID.randomUUID(), executor, authData, data);
     assertEquals(ImportResult.ResultType.OK, result.getType());
   }
 
@@ -125,9 +129,7 @@ public class BackblazeVideosImporterTest {
     when(client.uploadFile(eq("Video Transfer/dataId.mp4"), any())).thenReturn(response);
     when(clientFactory.getOrCreateB2Client(jobId, authData)).thenReturn(client);
 
-    BackblazeVideosImporter sut =
-        new BackblazeVideosImporter(monitor, dataStore, streamProvider, clientFactory);
-    sut.importItem(jobId, executor, authData, data);
+    videosImporter.importItem(jobId, executor, authData, data);
 
     ArgumentCaptor<ImportFunction<VideoModel, String>> importCapture =
         ArgumentCaptor.forClass(ImportFunction.class);

--- a/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-backblaze/src/test/java/org/datatransferproject/datatransfer/backblaze/videos/BackblazeVideosImporterTest.java
@@ -32,7 +32,6 @@ import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeConstants;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClient;
 import org.datatransferproject.datatransfer.backblaze.common.BackblazeDataTransferClientFactory;
-import org.datatransferproject.datatransfer.backblaze.photos.BackblazePhotosImporter;
 import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
@@ -42,9 +41,7 @@ import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.common.models.videos.VideosContainerResource;
 import org.datatransferproject.types.transfer.auth.TokenSecretAuthData;
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
@@ -126,7 +123,7 @@ public class BackblazeVideosImporterTest {
         .thenReturn(new InputStreamWrapper(IOUtils.toInputStream("video content", "UTF-8")));
 
     when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(folder.toFile());
-    when(client.uploadFile(eq("Video Transfer/dataId.mp4"), any())).thenReturn(response);
+    when(client.uploadFile(eq("Video Transfer/dataId.mp4"), any(), any())).thenReturn(response);
     when(clientFactory.getOrCreateB2Client(jobId, authData)).thenReturn(client);
 
     videosImporter.importItem(jobId, executor, authData, data);


### PR DESCRIPTION
- Add support for MEDIA transfer
- Add support for photos and videos in the same folder
- Use media name instead of id
- Store media creation time as S3 object metadata (it is not possible to set the creation date in S3 since it is automatically set by the server)