### PR TITLE
Store entire Throwable in ErrorDetail class

### DIFF
--- a/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleCloudIdempotentImportExecutor.java
+++ b/extensions/cloud/portability-cloud-google/src/main/java/org/datatransferproject/cloud/google/GoogleCloudIdempotentImportExecutor.java
@@ -88,7 +88,7 @@ public class GoogleCloudIdempotentImportExecutor implements IdempotentImportExec
           ErrorDetail.builder()
               .setId(idempotentId)
               .setTitle(itemName)
-              .setException(Throwables.getStackTraceAsString(e))
+              .setThrowable(e)
               .build();
       addError(idempotentId, errorDetail);
       monitor.severe(() -> jobIdPrefix + "Problem with importing item: " + errorDetail);
@@ -232,6 +232,8 @@ public class GoogleCloudIdempotentImportExecutor implements IdempotentImportExec
   @VisibleForTesting
   Entity createErrorEntity(String idempotentId, UUID jobId, ErrorDetail error)
       throws IOException {
+    System.out.println("AQAQAQAQ");
+    System.out.println(objectMapper.writeValueAsString(error));
     return GoogleCloudUtils.createEntityBuilder(
         getErrorKey(idempotentId, jobId),
         ImmutableMap.of(

--- a/extensions/cloud/portability-cloud-google/src/test/java/org/datatransferproject/cloud/google/GoogleCloudIdempotentImportExecutorTest.java
+++ b/extensions/cloud/portability-cloud-google/src/test/java/org/datatransferproject/cloud/google/GoogleCloudIdempotentImportExecutorTest.java
@@ -57,7 +57,7 @@ public class GoogleCloudIdempotentImportExecutorTest {
     assertEquals(googleExecutor.getCachedValue("id3"), "idempotentId3");
     assertEquals(googleExecutor.getErrors().size(), 1);
     assertTrue(googleExecutor.getErrors().contains(
-        ErrorDetail.builder().setId("id4").setTitle("title").setException("error").build()));
+        ErrorDetail.builder().setId("id4").setTitle("title").setThrowable(new IOException("error")).build()));
 
     // we shouldn't load any items belonging to JOB_ID_2
     assertFalse(googleExecutor.isKeyCached("id1_job2"));
@@ -68,7 +68,7 @@ public class GoogleCloudIdempotentImportExecutorTest {
     initializeDS();
     googleExecutor.setJobId(JOB_ID);
     assertTrue(googleExecutor.getErrors().contains(
-        ErrorDetail.builder().setId("id4").setTitle("title").setException("error").build()));
+        ErrorDetail.builder().setId("id4").setTitle("title").setThrowable(new IOException("error")).build()));
 
     // now execute a successful import of id4
     googleExecutor.executeAndSwallowIOExceptions("id4", ITEM_NAME, () -> "idempotentId4");
@@ -86,7 +86,7 @@ public class GoogleCloudIdempotentImportExecutorTest {
     t.put(googleExecutor.createResultEntity("id2", JOB_ID, "idempotentId2"));
     t.put(googleExecutor.createResultEntity("id3", JOB_ID, "idempotentId3"));
     t.put(googleExecutor.createErrorEntity("id4", JOB_ID,
-        ErrorDetail.builder().setId("id4").setTitle("title").setException("error").build()));
+        ErrorDetail.builder().setId("id4").setTitle("title").setThrowable(new IOException("error")).build()));
 
     t.put(googleExecutor.createResultEntity("id1_job2", JOB_ID_2, "idempotentId1_job2"));
     t.commit();

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutor.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutor.java
@@ -81,7 +81,7 @@ public class InMemoryIdempotentImportExecutor implements IdempotentImportExecuto
           ErrorDetail.builder()
               .setId(idempotentId)
               .setTitle(itemName)
-              .setException(Throwables.getStackTraceAsString(e))
+              .setThrowable(e)
               .build();
       errors.put(idempotentId, errorDetail);
       recentErrors.put(idempotentId, errorDetail);

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/errors/ErrorDetail.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/errors/ErrorDetail.java
@@ -46,7 +46,11 @@ public abstract class ErrorDetail {
   public abstract String title();
 
   @JsonProperty("exception")
-  public abstract String exception();
+  public String exception() {
+    return Throwables.getStackTraceAsString(throwable());
+  }
+
+  public abstract Throwable throwable();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -63,7 +67,6 @@ public abstract class ErrorDetail {
     @JsonProperty("title")
     public abstract Builder setTitle(String title);
 
-    @JsonProperty("exception")
-    public abstract Builder setException(String exception);
+    public abstract Builder setThrowable(Throwable throwable);
   }
 }


### PR DESCRIPTION
There is a place at [CallableImporter](https://github.com/google/data-transfer-project/blob/889f1fa92fc54046b42a9448b53d9de0df84912c/portability-transfer/src/main/java/org/datatransferproject/transfer/CallableImporter.java#L77) where we leak the exception trace into raw logs by wrapping the `ErrorDetail` contents in an `IOException`.

```
throw new IOException(
  "Problem with importer, forcing a retry, "
    + "first error: "
    + (errors.iterator().hasNext() ? errors.iterator().next().exception() : "none"));
```

This is bad for 3 reasons:
- The actual root cause of the problem is masked with a generic `IOException`;
- The full trace of the original exception is leaked into the exception message, bloating the logs;
- If the original exception was itself a wrapper, we'd lose the underlying cause completely.

As a first step towards fixing that, we want to modify `ErrorDetail` to store the `Throwable` instance instead of its trace in the `String` format.