### PR TITLE
Throw invalid token exception for video import

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -32,6 +32,7 @@
 package org.datatransferproject.datatransfer.google.videos;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.UnauthenticatedException;
 import com.google.auth.oauth2.AccessToken;
@@ -325,6 +326,13 @@ public class GoogleVideosImporter
         uploadToken = uploadResponse.getUploadToken().get();
       }
       return Pair.of(uploadToken, tmp.length());
+    } catch (ApiException ex) {
+      Throwable cause = ex.getCause();
+      String message = cause.getMessage();
+      if (message.contains("invalid_grant")) {
+        throw new InvalidTokenException("Token has been expired or revoked", cause);
+      }
+      throw new IOException("An error was encountered while uploading the video.", cause);
     } finally {
       //noinspection ResultOfMethodCallIgnored
       tmp.delete();

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/videos/GoogleVideosImporter.java
@@ -327,6 +327,7 @@ public class GoogleVideosImporter
       }
       return Pair.of(uploadToken, tmp.length());
     } catch (ApiException ex) {
+      // temp check as exception is not captured and wrapped into UploadMediaItemResponse
       Throwable cause = ex.getCause();
       String message = cause.getMessage();
       if (message.contains("invalid_grant")) {


### PR DESCRIPTION
Summary: Capture and throw invalid token exception for video import. This is a temporary check as exception is not properly captured and wrapped into UploadMediaItemResponse error field for videos.

Test Plan: ./gradlew test