### PR TITLE
google internal refactoring: factor out batch-import logic so we can (later PR) delete duplication that lives in GooglePhotosImporter

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2023 The Data Transfer Project Authors.
  *
@@ -76,7 +75,18 @@ import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
-
+/**
+ * Upload content to the Google Photos servers' APIs - be it photos, video, etc.
+ *
+ * APIs offered aim to be agnostic to file types, and try to be the general wrapper for all upload
+ * needs for the Photos SDKs, is in contrast to the predecessors used in the DTP codebase like
+ * {@link PhotosLibraryClient} or {@link GooglePhotosInterface} which are each used and/or managed
+ * for a specific use-case and we hope to delete in favor of classes in this package.
+ *
+ * WARNING: this should be constructed PER request so as to not conflate job IDs or auth data across
+ * processes. That is: do NOT cache an instance of this object across your requests, say by storing
+ * the instance as a member of your adapter's Importer or Exporter implementations.
+ */
 // TODO(aksingh737,jzacsh) finish refactoring Google{Photos,Video,Media}{Importer,Exporter} classes
 // so they're not all drifting-forks of each other, and instead share code with the help of small
 // interfaces. We can start by using some of the de-duplication that happened in
@@ -91,6 +101,11 @@ public class GPhotosUpload {
   // https://developers.google.com/photos/library/guides/upload-media#creating-media-item
   private static final int BATCH_UPLOAD_SIZE = 49;
 
+  /**
+   * WARNING: this should be constructed PER request so as to not conflate job IDs or auth data
+   * across processes. That is: do NOT cache an instance of this object across your requests, say by
+   * storing the instance as a member of your adapter's Importer or Exporter implementations.
+   */
   public GPhotosUpload(
       UUID jobId,
       IdempotentImportExecutor executor,

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.datatransferproject.datatransfer.google.common;
+package org.datatransferproject.datatransfer.google.common.gphotos;
 
 import static java.lang.String.format;
 import static org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface.ERROR_HASH_MISMATCH;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
@@ -67,7 +67,7 @@ import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException
 import org.datatransferproject.spi.transfer.types.InvalidTokenException;
 import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
 import org.datatransferproject.spi.transfer.types.UploadErrorException;
-import org.datatransferproject.types.common.DownloadableItem;
+import org.datatransferproject.types.common.DownloadableFile;
 import org.datatransferproject.types.common.ImportableItem;
 import org.datatransferproject.types.common.models.media.MediaContainerResource;
 import org.datatransferproject.types.common.models.media.MediaAlbum;
@@ -109,12 +109,8 @@ public class GPhotosUpload {
   // TODO(aksingh737,jzacsh) WARNING: delete the duplicated GooglePhotosImporter code by pulling
   // this out of Media into a new GphotoMedia class that exposes these methods for _both_
   // GoogleMediaImporter _and_ GooglePhotosImporter to use.
-  public <T extends DownloadableItem> long uploadItemsViaBatching(
+  public <T extends DownloadableFile> long uploadItemsViaBatching(
       Collection<T> items,
-      // TODO we could just specify we have FolderItem interface objects and call getFolderId, and
-      // drop this getAlbumId parameter (FolderItem was introduced for similar purposes in via
-      // MicrosoftMedia* work).
-      Function<T, String> getAlbumId,
       ItemBatchUploader<T> importer)
       throws Exception {
     long bytes = 0L;
@@ -124,7 +120,7 @@ public class GPhotosUpload {
     Map<String, List<T>> itemsByAlbumId =
         items.stream()
             .filter(item -> !executor.isKeyCached(item.getIdempotentId()))
-            .collect(Collectors.groupingBy(getAlbumId));
+            .collect(Collectors.groupingBy(DownloadableFile::getFolderId));
 
     for (Entry<String, List<T>> albumEntry : itemsByAlbumId.entrySet()) {
       String originalAlbumId = albumEntry.getKey();

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
@@ -77,7 +77,6 @@ import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 
- /* DO NOT MERGE - rename this to GPhotosUploader and org.datatransferproject.datatransfer.google.common.gphotos */
 // TODO(aksingh737,jzacsh) finish refactoring Google{Photos,Video,Media}{Importer,Exporter} classes
 // so they're not all drifting-forks of each other, and instead share code with the help of small
 // interfaces. We can start by using some of the de-duplication that happened in

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java
@@ -1,0 +1,168 @@
+
+/*
+ * Copyright 2023 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.datatransfer.google.common;
+
+import static java.lang.String.format;
+import static org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface.ERROR_HASH_MISMATCH;
+import static org.datatransferproject.datatransfer.google.videos.GoogleVideosInterface.uploadBatchOfVideos;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.json.JsonFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.UnmodifiableIterator;
+import com.google.photos.library.v1.PhotosLibraryClient;
+import com.google.rpc.Code;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
+import org.datatransferproject.datatransfer.google.common.GooglePhotosImportUtils;
+import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemResponse;
+import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
+import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
+import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemResult;
+import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
+import org.datatransferproject.datatransfer.google.mediaModels.Status;
+import org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface;
+import org.datatransferproject.datatransfer.google.photos.PhotoResult;
+import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
+import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
+import org.datatransferproject.spi.cloud.types.PortabilityJob;
+import org.datatransferproject.spi.transfer.i18n.BaseMultilingualDictionary;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.ItemImportResult;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
+import org.datatransferproject.spi.transfer.types.InvalidTokenException;
+import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
+import org.datatransferproject.spi.transfer.types.UploadErrorException;
+import org.datatransferproject.types.common.DownloadableItem;
+import org.datatransferproject.types.common.ImportableItem;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.media.MediaAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+
+
+ /* DO NOT MERGE - rename this to GPhotosUploader and org.datatransferproject.datatransfer.google.common.gphotos */
+// TODO(aksingh737,jzacsh) finish refactoring Google{Photos,Video,Media}{Importer,Exporter} classes
+// so they're not all drifting-forks of each other, and instead share code with the help of small
+// interfaces. We can start by using some of the de-duplication that happened in
+// org.datatransferproject.datatransfer.google.common.gphotos package
+public class GPhotosUpload {
+  private UUID jobId;
+  private IdempotentImportExecutor executor;
+  private TokensAndUrlAuthData authData;
+
+  public GPhotosUpload(
+      UUID jobId,
+      IdempotentImportExecutor executor,
+      TokensAndUrlAuthData authData) {
+    this.jobId = jobId;
+    this.executor = executor;
+    this.authData = authData;
+  }
+
+  /**
+   * Imports all `items` by fanning out to `batchImporter` upload calls as specified by the.
+   *
+   * Returns the number of uploaded bytes, as summed across all `items` that were uploaded.
+   */
+  // TODO(aksingh737,jzacsh) WARNING: delete the duplicated GooglePhotosImporter code by pulling
+  // this out of Media into a new GphotoMedia class that exposes these methods for _both_
+  // GoogleMediaImporter _and_ GooglePhotosImporter to use.
+  public <T extends DownloadableItem> long uploadItemsViaBatching(
+      Collection<T> items,
+      // TODO we could just specify we have FolderItem interface objects and call getFolderId, and
+      // drop this getAlbumId parameter (FolderItem was introduced for similar purposes in via
+      // MicrosoftMedia* work).
+      Function<T, String> getAlbumId,
+      int batchSize,
+      ItemBatchUploader<T> importer)
+      throws Exception {
+    long bytes = 0L;
+    if (items == null || items.size() <= 0) {
+      return bytes;
+    }
+    Map<String, List<T>> itemsByAlbumId =
+        items.stream()
+            .filter(item -> !executor.isKeyCached(item.getIdempotentId()))
+            .collect(Collectors.groupingBy(getAlbumId));
+
+    for (Entry<String, List<T>> albumEntry : itemsByAlbumId.entrySet()) {
+      String originalAlbumId = albumEntry.getKey();
+      String googleAlbumId;
+      if (Strings.isNullOrEmpty(originalAlbumId)) {
+        // This is ok, since NewMediaItemUpload will ignore all null values and it's possible to
+        // upload a NewMediaItem without a corresponding album id.
+        googleAlbumId = null;
+      } else {
+        // Note this will throw if creating the album failed, which is what we want
+        // because that will also mark this photo as being failed.
+        googleAlbumId = executor.getCachedValue(originalAlbumId);
+      }
+
+      UnmodifiableIterator<List<T>> batches =
+          Iterators.partition(albumEntry.getValue().iterator(), batchSize);
+      while (batches.hasNext()) {
+        long batchBytes =
+            importer.uploadToAlbum(jobId, authData, batches.next(), executor, googleAlbumId);
+        bytes += batchBytes;
+      }
+    }
+    return bytes;
+  }
+
+  // TODO(aksingh737,jzacsh) consider renaming lower-level gphotos code (ie: anything of the "google
+  // photos" product but not a "photo" from "google"; examples: the GooglePhotosInterface that
+  // interacts with gphotos teams' upstream SDKs, interfaces like this one below, PhotoResult,
+  // etc.). eg maybe start a org.datatransferproject.datatransfer.google.gphotos package for things
+  // that are wrapping the gphotos SDKs (the examples already mentioned) and make that package
+  // importable by the other google adapters.
+  @FunctionalInterface
+  public interface ItemBatchUploader<T> {
+    /**
+     * Returns the number of uploaded bytes, as summed across all `items` that were uploaded in this
+     * batch.
+     */
+    public long uploadToAlbum(
+        UUID jobId,
+        TokensAndUrlAuthData authData,
+        List<T> batch,
+        IdempotentImportExecutor executor,
+        String targetAlbumId) throws Exception;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
@@ -193,7 +193,6 @@ public class GoogleMediaImporter
       throws Exception {
     return gPhotosUpload.uploadItemsViaBatching(
         photos,
-        PhotoModel::getAlbumId,
         this::importPhotoBatch);
   }
 
@@ -314,7 +313,6 @@ public class GoogleMediaImporter
       throws Exception {
     return gPhotosUpload.uploadItemsViaBatching(
         videos,
-        VideoModel::getAlbumId,
         this::importVideosBatch);
   }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
@@ -156,6 +156,9 @@ public class GoogleMediaImporter
       // Nothing to do
       return ImportResult.OK;
     }
+    // WARNING: this should be constructed PER request so as to not conflate job IDs or auth data
+    // across processes. That is: do NOT cache an instance of this object across your requests, say
+    // by storing the instance as a member of your adapter's Importer or Exporter implementations.
     final GPhotosUpload gPhotosUpload = new GPhotosUpload(jobId, idempotentImportExecutor, authData);
 
     // Uploads album metadata

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
@@ -172,6 +172,9 @@ public class GoogleMediaImporter
     return result.copyWithBytes(bytes);
   }
 
+  // TODO(aksingh737,jzacsh) fix unit tests across Google adapters to stop testing internal methods
+  // like these, and just test importItem() (of
+  // org.datatransferproject.spi.transfer.provider.Importer interface).
   @VisibleForTesting
   String importSingleAlbum(UUID jobId, TokensAndUrlAuthData authData, MediaAlbum inputAlbum)
       throws IOException, InvalidTokenException, PermissionDeniedException, UploadErrorException {

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
@@ -156,7 +156,7 @@ public class GoogleMediaImporter
       // Nothing to do
       return ImportResult.OK;
     }
-    final GPhotosUpload gPhotosApi = new GPhotosUpload(jobId, idempotentImportExecutor, authData);
+    final GPhotosUpload gPhotosUpload = new GPhotosUpload(jobId, idempotentImportExecutor, authData);
 
     // Uploads album metadata
     for (MediaAlbum album : data.getAlbums()) {
@@ -165,8 +165,8 @@ public class GoogleMediaImporter
     }
 
     long bytes =
-        importPhotos(data.getPhotos(), gPhotosApi)
-        + importVideos(data.getVideos(), gPhotosApi);
+        importPhotos(data.getPhotos(), gPhotosUpload)
+        + importVideos(data.getVideos(), gPhotosUpload);
 
     final ImportResult result = ImportResult.OK;
     return result.copyWithBytes(bytes);
@@ -189,12 +189,11 @@ public class GoogleMediaImporter
 
   long importPhotos(
       Collection<PhotoModel> photos,
-      GPhotosUpload gPhotosApi)
+      GPhotosUpload gPhotosUpload)
       throws Exception {
-    return gPhotosApi.uploadItemsViaBatching(
+    return gPhotosUpload.uploadItemsViaBatching(
         photos,
         PhotoModel::getAlbumId,
-        BATCH_UPLOAD_SIZE,
         this::importPhotoBatch);
   }
 
@@ -311,12 +310,11 @@ public class GoogleMediaImporter
 
   long importVideos(
       Collection<VideoModel> videos,
-      GPhotosUpload gPhotosApi)
+      GPhotosUpload gPhotosUpload)
       throws Exception {
-    return gPhotosApi.uploadItemsViaBatching(
+    return gPhotosUpload.uploadItemsViaBatching(
         videos,
         VideoModel::getAlbumId,
-        BATCH_UPLOAD_SIZE,
         this::importVideosBatch);
   }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
@@ -44,7 +44,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.common.GooglePhotosImportUtils;
-import org.datatransferproject.datatransfer.google.common.GPhotosUpload;
+import org.datatransferproject.datatransfer.google.common.gphotos.GPhotosUpload;
 import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Data Transfer Project Authors.
+ * Copyright 2023 The Data Transfer Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
 import org.datatransferproject.datatransfer.google.common.GooglePhotosImportUtils;
+import org.datatransferproject.datatransfer.google.common.GPhotosUpload;
 import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
@@ -155,6 +156,7 @@ public class GoogleMediaImporter
       // Nothing to do
       return ImportResult.OK;
     }
+    final GPhotosUpload gPhotosApi = new GPhotosUpload(jobId, idempotentImportExecutor, authData);
 
     // Uploads album metadata
     for (MediaAlbum album : data.getAlbums()) {
@@ -163,8 +165,8 @@ public class GoogleMediaImporter
     }
 
     long bytes =
-        importPhotos(data.getPhotos(), idempotentImportExecutor, jobId, authData)
-        + importVideos(data.getVideos(), idempotentImportExecutor, jobId, authData);
+        importPhotos(data.getPhotos(), gPhotosApi)
+        + importVideos(data.getVideos(), gPhotosApi);
 
     final ImportResult result = ImportResult.OK;
     return result.copyWithBytes(bytes);
@@ -184,17 +186,12 @@ public class GoogleMediaImporter
 
   long importPhotos(
       Collection<PhotoModel> photos,
-      IdempotentImportExecutor executor,
-      UUID jobId,
-      TokensAndUrlAuthData authData)
+      GPhotosUpload gPhotosApi)
       throws Exception {
-    return importItemsViaBatching(
+    return gPhotosApi.uploadItemsViaBatching(
         photos,
         PhotoModel::getAlbumId,
         BATCH_UPLOAD_SIZE,
-        executor,
-        jobId,
-        authData,
         this::importPhotoBatch);
   }
 
@@ -311,17 +308,12 @@ public class GoogleMediaImporter
 
   long importVideos(
       Collection<VideoModel> videos,
-      IdempotentImportExecutor executor,
-      UUID jobId,
-      TokensAndUrlAuthData authData)
+      GPhotosUpload gPhotosApi)
       throws Exception {
-    return importItemsViaBatching(
+    return gPhotosApi.uploadItemsViaBatching(
         videos,
         VideoModel::getAlbumId,
         BATCH_UPLOAD_SIZE,
-        executor,
-        jobId,
-        authData,
         this::importVideosBatch);
   }
 
@@ -358,59 +350,6 @@ public class GoogleMediaImporter
     } catch (Exception ex) {
       monitor.info(() -> format("Can't find album during getAlbum call"), ex);
     }
-  }
-
-  /**
-   * Imports all `items` by fanning out to `batchImporter` upload calls as specified by the.
-   *
-   * Returns the number of uploaded bytes, as summed across all `items` that were uploaded.
-   */
-  // TODO(aksingh737,jzacsh) WARNING: delete the duplicated GooglePhotosImporter code by pulling
-  // this out of Media into a new GphotoMedia class that exposes these methods for _both_
-  // GoogleMediaImporter _and_ GooglePhotosImporter to use.
-  private <T extends DownloadableItem> long importItemsViaBatching(
-      Collection<T> items,
-      // TODO we could just specify we have FolderItem interface objects and call getFolderId, and
-      // drop this getAlbumId parameter (FolderItem was introduced for similar purposes in via
-      // MicrosoftMedia* work).
-      Function<T, String> getAlbumId,
-      int batchSize,
-      IdempotentImportExecutor executor,
-      UUID jobId,
-      TokensAndUrlAuthData authData,
-      ItemBatchImporter<T> importer)
-      throws Exception {
-    long bytes = 0L;
-    if (items == null || items.size() <= 0) {
-      return bytes;
-    }
-    Map<String, List<T>> itemsByAlbumId =
-        items.stream()
-            .filter(item -> !executor.isKeyCached(item.getIdempotentId()))
-            .collect(Collectors.groupingBy(getAlbumId));
-
-    for (Entry<String, List<T>> albumEntry : itemsByAlbumId.entrySet()) {
-      String originalAlbumId = albumEntry.getKey();
-      String googleAlbumId;
-      if (Strings.isNullOrEmpty(originalAlbumId)) {
-        // This is ok, since NewMediaItemUpload will ignore all null values and it's possible to
-        // upload a NewMediaItem without a corresponding album id.
-        googleAlbumId = null;
-      } else {
-        // Note this will throw if creating the album failed, which is what we want
-        // because that will also mark this photo as being failed.
-        googleAlbumId = executor.getCachedValue(originalAlbumId);
-      }
-
-      UnmodifiableIterator<List<T>> batches =
-          Iterators.partition(albumEntry.getValue().iterator(), batchSize);
-      while (batches.hasNext()) {
-        long batchBytes =
-            importer.importToAlbum(jobId, authData, batches.next(), executor, googleAlbumId);
-        bytes += batchBytes;
-      }
-    }
-    return bytes;
   }
 
   private long processMediaResult(
@@ -470,30 +409,5 @@ public class GoogleMediaImporter
     }
 
     return multilingualStrings.get(jobId);
-  }
-
-  // TODO(aksingh737,jzacsh) refactor Google{Photos,Video,Media}{Importer,Exporter} classes so they're
-  // not all drifting-forks of each other, and instead share code with the help of small interfaces.
-  // We can start by using some of the de-duplication that happened, with the interfaces below, in
-  // the creation of this particular importer
-
-  // TODO(aksingh737,jzacsh) consider renaming lower-level gphotos code (ie: anything of the "google
-  // photos" product but not a "photo" from "google"; examples: the GooglePhotosInterface that
-  // interacts with gphotos teams' upstream SDKs, interfaces like this one below, PhotoResult,
-  // etc.). eg maybe start a org.datatransferproject.datatransfer.google.gphotos package for things
-  // that are wrapping the gphotos SDKs (the examples already mentioned) and make that package
-  // importable by the other google adapters.
-  @FunctionalInterface
-  private interface ItemBatchImporter<T> {
-    /**
-     * Returns the number of uploaded bytes, as summed across all `items` that were uploaded in this
-     * batch.
-     */
-    public long importToAlbum(
-        UUID jobId,
-        TokensAndUrlAuthData authData,
-        List<T> batch,
-        IdempotentImportExecutor executor,
-        String targetAlbumId) throws Exception;
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.datatransfer.google.media;
+
+import static java.lang.String.format;
+import static org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface.ERROR_HASH_MISMATCH;
+import static org.datatransferproject.datatransfer.google.videos.GoogleVideosInterface.uploadBatchOfVideos;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.json.JsonFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.UnmodifiableIterator;
+import com.google.photos.library.v1.PhotosLibraryClient;
+import com.google.rpc.Code;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
+import org.datatransferproject.datatransfer.google.common.GooglePhotosImportUtils;
+import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemResponse;
+import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
+import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItem;
+import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemResult;
+import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
+import org.datatransferproject.datatransfer.google.mediaModels.Status;
+import org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface;
+import org.datatransferproject.datatransfer.google.photos.PhotoResult;
+import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
+import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
+import org.datatransferproject.spi.cloud.types.PortabilityJob;
+import org.datatransferproject.spi.transfer.i18n.BaseMultilingualDictionary;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.ItemImportResult;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
+import org.datatransferproject.spi.transfer.types.InvalidTokenException;
+import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
+import org.datatransferproject.spi.transfer.types.UploadErrorException;
+import org.datatransferproject.types.common.DownloadableItem;
+import org.datatransferproject.types.common.ImportableItem;
+import org.datatransferproject.types.common.models.media.MediaContainerResource;
+import org.datatransferproject.types.common.models.media.MediaAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+
+public class GoogleMediaImporter
+    implements Importer<TokensAndUrlAuthData, MediaContainerResource> {
+
+  private final GoogleCredentialFactory credentialFactory;
+  private final JobStore jobStore;
+  // TODO(aksingh737) why does one half of the Google photos interactions rely on DTP's
+  // TemporaryPerJobDataStore and the other half on. JobStore - how do these relate? can they be
+  // consilidated everywhere? at least in this class?
+  private final TemporaryPerJobDataStore dataStore;
+  private final JsonFactory jsonFactory;
+  private final ConnectionProvider connectionProvider;
+  private final Monitor monitor;
+  private final double writesPerSecond;
+  private final Map<UUID, GooglePhotosInterface> photosInterfacesMap;
+  // TODO(aksingh737) delete the two interface-management approaches (map vs. singleton); the
+  // singleton appears to have been left behind during PR #882
+  private final GooglePhotosInterface photosInterface;
+  private final HashMap<UUID, BaseMultilingualDictionary> multilingualStrings = new HashMap<>();
+  private final PhotosLibraryClient photosLibraryClient;
+
+  // We partition into groups of 49 as 50 is the maximum number of items that can be created
+  // in one call. (We use 49 to avoid potential off by one errors)
+  // https://developers.google.com/photos/library/guides/upload-media#creating-media-item
+  private static final int BATCH_UPLOAD_SIZE = 49;
+
+  public GoogleMediaImporter(
+      GoogleCredentialFactory credentialFactory,
+      JobStore jobStore,
+      TemporaryPerJobDataStore dataStore,
+      JsonFactory jsonFactory,
+      Monitor monitor,
+      double writesPerSecond) {
+    this(
+        credentialFactory,
+        jobStore,
+        dataStore,
+        jsonFactory,
+        new HashMap<>(),  /*photosInterfacesMap*/
+        null,  /*photosInterface*/
+        null,  /*photosLibraryClient*/
+        new ConnectionProvider(jobStore),
+        monitor,
+        writesPerSecond);
+  }
+
+  @VisibleForTesting
+  GoogleMediaImporter(
+      GoogleCredentialFactory credentialFactory,
+      JobStore jobStore,
+      TemporaryPerJobDataStore dataStore,
+      JsonFactory jsonFactory,
+      Map<UUID, GooglePhotosInterface> photosInterfacesMap,
+      GooglePhotosInterface photosInterface,
+      PhotosLibraryClient photosLibraryClient,
+      ConnectionProvider connectionProvider,
+      Monitor monitor,
+      double writesPerSecond) {
+    this.credentialFactory = credentialFactory;
+    this.jobStore = jobStore;
+    this.dataStore = dataStore;
+    this.jsonFactory = jsonFactory;
+    this.photosInterfacesMap = photosInterfacesMap;
+    this.photosInterface = photosInterface;
+    this.photosLibraryClient = photosLibraryClient;
+    this.connectionProvider = connectionProvider;
+    this.monitor = monitor;
+    this.writesPerSecond = writesPerSecond;
+  }
+
+  @Override
+  public ImportResult importItem(
+      UUID jobId,
+      IdempotentImportExecutor idempotentImportExecutor,
+      TokensAndUrlAuthData authData,
+      MediaContainerResource data)
+      throws Exception {
+    if (data == null) {
+      // Nothing to do
+      return ImportResult.OK;
+    }
+
+    // Uploads album metadata
+    for (MediaAlbum album : data.getAlbums()) {
+      idempotentImportExecutor.executeAndSwallowIOExceptions(
+          album.getId(), album.getName(), () -> importSingleAlbum(jobId, authData, album));
+    }
+
+    long bytes =
+        importPhotos(data.getPhotos(), idempotentImportExecutor, jobId, authData)
+        + importVideos(data.getVideos(), idempotentImportExecutor, jobId, authData);
+
+    final ImportResult result = ImportResult.OK;
+    return result.copyWithBytes(bytes);
+  }
+
+  @VisibleForTesting
+  String importSingleAlbum(UUID jobId, TokensAndUrlAuthData authData, MediaAlbum inputAlbum)
+      throws IOException, InvalidTokenException, PermissionDeniedException, UploadErrorException {
+    // Set up album
+    GoogleAlbum googleAlbum = new GoogleAlbum();
+    googleAlbum.setTitle(GooglePhotosImportUtils.cleanAlbumTitle(inputAlbum.getName()));
+
+    GoogleAlbum responseAlbum =
+        getOrCreatePhotosInterface(jobId, authData).createAlbum(googleAlbum);
+    return responseAlbum.getId();
+  }
+
+  long importPhotos(
+      Collection<PhotoModel> photos,
+      IdempotentImportExecutor executor,
+      UUID jobId,
+      TokensAndUrlAuthData authData)
+      throws Exception {
+    return importItemsViaBatching(
+        photos,
+        PhotoModel::getAlbumId,
+        BATCH_UPLOAD_SIZE,
+        executor,
+        jobId,
+        authData,
+        this::importPhotoBatch);
+  }
+
+  // TODO(aksingh737,jzacsh) if we consolidate underlying gphtoos SDK approaches, then this and the
+  // GoogleVideosInterface.uploadBatchOfVideos function can be de-duped. Right now they interact with
+  // differnet APIs and while maybe possible, probably better to spend time on de-duping the
+  // underlying SDK wrappers first.
+  private long importPhotoBatch(
+      UUID jobId,
+      TokensAndUrlAuthData authData,
+      List<PhotoModel> photos,
+      IdempotentImportExecutor executor,
+      String albumId)
+      throws Exception {
+    final ArrayList<NewMediaItem> mediaItems = new ArrayList<>();
+    final HashMap<String, PhotoModel> uploadTokenToDataId = new HashMap<>();
+    final HashMap<String, Long> uploadTokenToLength = new HashMap<>();
+
+    // TODO: resumable uploads https://developers.google.com/photos/library/guides/resumable-uploads
+    //  Resumable uploads would allow the upload of larger media that don't fit in memory.  To do
+    //  this however, seems to require knowledge of the total file size.
+    for (PhotoModel photo : photos) {
+      Long size = null;
+      try {
+        InputStreamWrapper streamWrapper = connectionProvider
+            .getInputStreamForItem(jobId, photo);
+
+        try (InputStream s = streamWrapper.getStream()) {
+          String uploadToken = getOrCreatePhotosInterface(jobId, authData).uploadMediaContent(s,
+              photo.getSha1());
+          String description = GooglePhotosImportUtils.cleanDescription(photo.getDescription());
+          mediaItems.add(new NewMediaItem(description, uploadToken));
+          uploadTokenToDataId.put(uploadToken, photo);
+          size = streamWrapper.getBytes();
+          uploadTokenToLength.put(uploadToken, size);
+        } catch (UploadErrorException e) {
+          if (e.getMessage().contains(ERROR_HASH_MISMATCH)) {
+            monitor.severe(
+                () -> format("%s: SHA-1 (%s) mismatch during upload", jobId, photo.getSha1()));
+          }
+
+          Long finalSize = size;
+          executor.importAndSwallowIOExceptions(photo, p -> ItemImportResult.error(e, finalSize));
+        }
+
+        try {
+          if (photo.isInTempStore()) {
+            jobStore.removeData(jobId, photo.getFetchableUrl());
+          }
+        } catch (Exception e) {
+          // Swallow the exception caused by Remove data so that existing flows continue
+          monitor.info(
+              () ->
+                  format(
+                      "%s: Exception swallowed in removeData call for localPath %s",
+                      jobId, photo.getFetchableUrl()),
+              e);
+        }
+      } catch (IOException exception) {
+        Long finalSize = size;
+        executor.importAndSwallowIOExceptions(
+            photo, p -> ItemImportResult.error(exception, finalSize));
+      }
+    }
+
+    if (mediaItems.isEmpty()) {
+      // Either we were not passed in any videos or we failed upload on all of them.
+      return 0L;
+    }
+
+    long totalBytes = 0L;
+    NewMediaItemUpload uploadItem = new NewMediaItemUpload(albumId, mediaItems);
+    try {
+      BatchMediaItemResponse photoCreationResponse =
+          getOrCreatePhotosInterface(jobId, authData).createPhotos(uploadItem);
+      Preconditions.checkNotNull(photoCreationResponse);
+      NewMediaItemResult[] mediaItemResults = photoCreationResponse.getResults();
+      Preconditions.checkNotNull(mediaItemResults);
+      for (NewMediaItemResult mediaItem : mediaItemResults) {
+        PhotoModel photo = uploadTokenToDataId.get(mediaItem.getUploadToken());
+        totalBytes +=
+            processMediaResult(
+                mediaItem, photo, executor, uploadTokenToLength.get(mediaItem.getUploadToken()));
+        uploadTokenToDataId.remove(mediaItem.getUploadToken());
+      }
+
+      if (!uploadTokenToDataId.isEmpty()) {
+        for (Entry<String, PhotoModel> entry : uploadTokenToDataId.entrySet()) {
+          PhotoModel photo = entry.getValue();
+          executor.importAndSwallowIOExceptions(
+              photo,
+              p ->
+                  ItemImportResult.error(
+                      new IOException("Photo was missing from results list."),
+                      uploadTokenToLength.get(entry.getKey())));
+        }
+      }
+    } catch (IOException e) {
+      if (StringUtils.contains(
+          e.getMessage(), "The remaining storage in the user's account is not enough")) {
+        throw new DestinationMemoryFullException("Google destination storage full", e);
+      } else if (StringUtils.contains(
+          e.getMessage(), "The provided ID does not match any albums")) {
+        // which means the album was likely deleted by the user
+        // we skip this batch and log some data to understand it better
+        logMissingAlbumDetails(jobId, authData, albumId, e);
+      } else {
+        throw e;
+      }
+    }
+
+    return totalBytes;
+  }
+
+  long importVideos(
+      Collection<VideoModel> videos,
+      IdempotentImportExecutor executor,
+      UUID jobId,
+      TokensAndUrlAuthData authData)
+      throws Exception {
+    return importItemsViaBatching(
+        videos,
+        VideoModel::getAlbumId,
+        BATCH_UPLOAD_SIZE,
+        executor,
+        jobId,
+        authData,
+        this::importVideosBatch);
+  }
+
+
+  private long importVideosBatch(
+      UUID jobId,
+      TokensAndUrlAuthData authData,
+      List<VideoModel> batch,
+      IdempotentImportExecutor executor,
+      String albumId)
+      throws Exception {
+    return uploadBatchOfVideos(
+          jobId,
+          batch,
+          dataStore,
+          photosLibraryClient,
+          executor,
+          connectionProvider,
+          monitor);
+  }
+
+  private void logMissingAlbumDetails(
+      UUID jobId, TokensAndUrlAuthData authData, String albumId, IOException e) {
+    monitor.info(
+        () -> format("Can't find album during createPhotos call, album is likely deleted"), e);
+    try {
+      GoogleAlbum album = getOrCreatePhotosInterface(jobId, authData).getAlbum(albumId);
+      monitor.debug(
+          () ->
+              format(
+                  "Can't find album during createPhotos call, album info: isWriteable %b, mediaItemsCount %d",
+                  album.getIsWriteable(), album.getMediaItemsCount()),
+          e);
+    } catch (Exception ex) {
+      monitor.info(() -> format("Can't find album during getAlbum call"), ex);
+    }
+  }
+
+  /**
+   * Imports all `items` by fanning out to `batchImporter` upload calls as specified by the.
+   *
+   * Returns the number of uploaded bytes, as summed across all `items` that were uploaded.
+   */
+  // TODO(aksingh737,jzacsh) WARNING: delete the duplicated GooglePhotosImporter code by pulling
+  // this out of Media into a new GphotoMedia class that exposes these methods for _both_
+  // GoogleMediaImporter _and_ GooglePhotosImporter to use.
+  private <T extends DownloadableItem> long importItemsViaBatching(
+      Collection<T> items,
+      // TODO we could just specify we have FolderItem interface objects and call getFolderId, and
+      // drop this getAlbumId parameter (FolderItem was introduced for similar purposes in via
+      // MicrosoftMedia* work).
+      Function<T, String> getAlbumId,
+      int batchSize,
+      IdempotentImportExecutor executor,
+      UUID jobId,
+      TokensAndUrlAuthData authData,
+      ItemBatchImporter<T> importer)
+      throws Exception {
+    long bytes = 0L;
+    if (items == null || items.size() <= 0) {
+      return bytes;
+    }
+    Map<String, List<T>> itemsByAlbumId =
+        items.stream()
+            .filter(item -> !executor.isKeyCached(item.getIdempotentId()))
+            .collect(Collectors.groupingBy(getAlbumId));
+
+    for (Entry<String, List<T>> albumEntry : itemsByAlbumId.entrySet()) {
+      String originalAlbumId = albumEntry.getKey();
+      String googleAlbumId;
+      if (Strings.isNullOrEmpty(originalAlbumId)) {
+        // This is ok, since NewMediaItemUpload will ignore all null values and it's possible to
+        // upload a NewMediaItem without a corresponding album id.
+        googleAlbumId = null;
+      } else {
+        // Note this will throw if creating the album failed, which is what we want
+        // because that will also mark this photo as being failed.
+        googleAlbumId = executor.getCachedValue(originalAlbumId);
+      }
+
+      UnmodifiableIterator<List<T>> batches =
+          Iterators.partition(albumEntry.getValue().iterator(), batchSize);
+      while (batches.hasNext()) {
+        long batchBytes =
+            importer.importToAlbum(jobId, authData, batches.next(), executor, googleAlbumId);
+        bytes += batchBytes;
+      }
+    }
+    return bytes;
+  }
+
+  private long processMediaResult(
+      NewMediaItemResult mediaItem,
+      ImportableItem item,
+      IdempotentImportExecutor executor,
+      long bytes)
+      throws Exception {
+    Status status = mediaItem.getStatus();
+    if (status.getCode() == Code.OK_VALUE) {
+      PhotoResult photoResult = new PhotoResult(mediaItem.getMediaItem().getId(), bytes);
+      executor.importAndSwallowIOExceptions(
+          item, itemToImport -> ItemImportResult.success(photoResult, bytes));
+      return bytes;
+    } else {
+      executor.importAndSwallowIOExceptions(
+          item,
+          itemToImport ->
+              ItemImportResult.error(
+                  new IOException(
+                      String.format(
+                          "Media item could not be created. Code: %d Message: %s",
+                          status.getCode(), status.getMessage())),
+                  bytes));
+      return 0;
+    }
+  }
+
+  private synchronized GooglePhotosInterface getOrCreatePhotosInterface(
+      UUID jobId, TokensAndUrlAuthData authData) {
+
+    if (photosInterface != null) {
+      return photosInterface;
+    }
+
+    if (photosInterfacesMap.containsKey(jobId)) {
+      return photosInterfacesMap.get(jobId);
+    }
+
+    GooglePhotosInterface newInterface = makePhotosInterface(authData);
+    photosInterfacesMap.put(jobId, newInterface);
+
+    return newInterface;
+  }
+
+  private synchronized GooglePhotosInterface makePhotosInterface(TokensAndUrlAuthData authData) {
+    Credential credential = credentialFactory.createCredential(authData);
+    return new GooglePhotosInterface(
+        credentialFactory, credential, jsonFactory, monitor, writesPerSecond);
+  }
+
+  private synchronized BaseMultilingualDictionary getOrCreateStringDictionary(UUID jobId) {
+    if (!multilingualStrings.containsKey(jobId)) {
+      PortabilityJob job = jobStore.findJob(jobId);
+      String locale = job != null ? job.userLocale() : null;
+      multilingualStrings.put(jobId, new BaseMultilingualDictionary(locale));
+    }
+
+    return multilingualStrings.get(jobId);
+  }
+
+  // TODO(aksingh737,jzacsh) refactor Google{Photos,Video,Media}{Importer,Exporter} classes so they're
+  // not all drifting-forks of each other, and instead share code with the help of small interfaces.
+  // We can start by using some of the de-duplication that happened, with the interfaces below, in
+  // the creation of this particular importer
+
+  // TODO(aksingh737,jzacsh) consider renaming lower-level gphotos code (ie: anything of the "google
+  // photos" product but not a "photo" from "google"; examples: the GooglePhotosInterface that
+  // interacts with gphotos teams' upstream SDKs, interfaces like this one below, PhotoResult,
+  // etc.). eg maybe start a org.datatransferproject.datatransfer.google.gphotos package for things
+  // that are wrapping the gphotos SDKs (the examples already mentioned) and make that package
+  // importable by the other google adapters.
+  @FunctionalInterface
+  private interface ItemBatchImporter<T> {
+    /**
+     * Returns the number of uploaded bytes, as summed across all `items` that were uploaded in this
+     * batch.
+     */
+    public long importToAlbum(
+        UUID jobId,
+        TokensAndUrlAuthData authData,
+        List<T> batch,
+        IdempotentImportExecutor executor,
+        String targetAlbumId) throws Exception;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -154,7 +154,7 @@ public class GooglePhotosImporter
     return responseAlbum.getId();
   }
 
-  // TODO(aksingh737) WARNING: stop maintaining this code here; use newer GPhotosUploader instead
+  // TODO(aksingh737) WARNING: stop maintaining this code here; use newer GPhotosUpload instead
   long importPhotos(
       Collection<PhotoModel> photos,
       IdempotentImportExecutor executor,
@@ -197,7 +197,7 @@ public class GooglePhotosImporter
     return bytes;
   }
 
-  // TODO(aksingh737) WARNING: stop maintaining this code here; use newer GPhotosUploader instead
+  // TODO(aksingh737) WARNING: stop maintaining this code here; use newer GPhotosUpload instead
   private long importPhotoBatch(
       UUID jobId,
       TokensAndUrlAuthData authData,

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -154,6 +154,7 @@ public class GooglePhotosImporter
     return responseAlbum.getId();
   }
 
+  // DO NOT MERGE; delete and use newer GPhotosUploader class for this, instead
   // TODO(aksingh737) WARNING: stop maintaining this code here; this needs to be reconciled against
   // a generic version so we don't have feature/bug development drift against our forks; see the
   // slowly-progressing effort to factor this code out with small interfaces, over in
@@ -201,6 +202,7 @@ public class GooglePhotosImporter
     return bytes;
   }
 
+  // DO NOT MERGE; delete and use newer GPhotosUploader class for this, instead
   // TODO(aksingh737) WARNING: stop maintaining this code here; this needs to be reconciled against
   // a generic version so we don't have feature/bug development drift against our forks; see the
   // slowly-progressing effort to factor this code out with small interfaces, over in

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java
@@ -154,12 +154,7 @@ public class GooglePhotosImporter
     return responseAlbum.getId();
   }
 
-  // DO NOT MERGE; delete and use newer GPhotosUploader class for this, instead
-  // TODO(aksingh737) WARNING: stop maintaining this code here; this needs to be reconciled against
-  // a generic version so we don't have feature/bug development drift against our forks; see the
-  // slowly-progressing effort to factor this code out with small interfaces, over in
-  // GoogleMediaImporter. (eg: once GoogleMediaImporter factors its importItemsViaBatching function
-  // out, all of this code can be deleted).
+  // TODO(aksingh737) WARNING: stop maintaining this code here; use newer GPhotosUploader instead
   long importPhotos(
       Collection<PhotoModel> photos,
       IdempotentImportExecutor executor,
@@ -202,11 +197,7 @@ public class GooglePhotosImporter
     return bytes;
   }
 
-  // DO NOT MERGE; delete and use newer GPhotosUploader class for this, instead
-  // TODO(aksingh737) WARNING: stop maintaining this code here; this needs to be reconciled against
-  // a generic version so we don't have feature/bug development drift against our forks; see the
-  // slowly-progressing effort to factor this code out with small interfaces, over in
-  // GoogleMediaImporter.
+  // TODO(aksingh737) WARNING: stop maintaining this code here; use newer GPhotosUploader instead
   private long importPhotoBatch(
       UUID jobId,
       TokensAndUrlAuthData authData,

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporterTest.java
@@ -1,0 +1,544 @@
+/*
+ * Copyright 2018 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.datatransferproject.datatransfer.google.media;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.Lists;
+import com.google.rpc.Code;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.UUID;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.cloud.local.LocalJobStore;
+import com.google.photos.library.v1.PhotosLibraryClient;
+import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemResponse;
+import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
+import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
+import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemResult;
+import org.datatransferproject.datatransfer.google.mediaModels.NewMediaItemUpload;
+import org.datatransferproject.datatransfer.google.mediaModels.Status;
+import org.datatransferproject.datatransfer.google.photos.GooglePhotosInterface;
+import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
+import org.datatransferproject.spi.cloud.storage.JobStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore.InputStreamWrapper;
+import org.datatransferproject.spi.cloud.types.PortabilityJob;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.InMemoryIdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.types.InvalidTokenException;
+import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
+import org.datatransferproject.spi.transfer.types.UploadErrorException;
+import org.datatransferproject.types.common.models.media.MediaAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.datatransferproject.types.transfer.errors.ErrorDetail;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class GoogleMediaImporterTest {
+
+  private static final String OLD_ALBUM_ID = "OLD_ALBUM_ID";
+  private static final String NEW_ALBUM_ID = "NEW_ALBUM_ID";
+  private String PHOTO_TITLE = "Model photo title";
+  private String PHOTO_DESCRIPTION = "Model photo description";
+  private String IMG_URI = "image uri";
+  private String JPEG_MEDIA_TYPE = "image/jpeg";
+  private String SHA1 = "11aa11AAff11aa11AAFF11aa11AAff11aa11AAFF";
+  private UUID uuid = UUID.randomUUID();
+  private GoogleMediaImporter googlePhotosImporter;
+  private GooglePhotosInterface googlePhotosInterface;
+  private PhotosLibraryClient photosLibraryClient;
+  private IdempotentImportExecutor executor;
+  private ConnectionProvider connectionProvider;
+  private Monitor monitor;
+
+  @Before
+  public void setUp() throws Exception {
+    googlePhotosInterface = mock(GooglePhotosInterface.class);
+    monitor = mock(Monitor.class);
+
+    // Initialize the executor with an old album ID -> new album ID mapping.
+    executor = new InMemoryIdempotentImportExecutor(monitor);
+    executor.executeOrThrowException(OLD_ALBUM_ID, "unused_item_name", () -> NEW_ALBUM_ID);
+
+    Mockito.when(googlePhotosInterface.makePostRequest(anyString(), any(), any(), any(),
+            eq(NewMediaItemResult.class)))
+        .thenReturn(mock(NewMediaItemResult.class));
+
+    JobStore jobStore = new LocalJobStore();
+    TemporaryPerJobDataStore dataStore = mock(TemporaryPerJobDataStore.class);
+
+    InputStream inputStream = mock(InputStream.class);
+    connectionProvider = mock(ConnectionProvider.class);
+    InputStreamWrapper is = new InputStreamWrapper(inputStream, 32L);
+    Mockito.when(connectionProvider.getInputStreamForItem(any(), any())).thenReturn(is);
+    photosLibraryClient = mock(PhotosLibraryClient.class);
+
+    googlePhotosImporter =
+        new GoogleMediaImporter(
+            null,  /*credentialFactory*/
+            jobStore,
+            dataStore,
+            null,  /*jsonFactory*/
+            null,  /*photosInterfacesMap*/
+            googlePhotosInterface,
+            photosLibraryClient,
+            connectionProvider,
+            monitor,
+            1.0  /*writesPerSecond*/);
+  }
+
+  @Test
+  public void importAlbum() throws Exception {
+    // Set up
+    String albumName = "Album Name";
+    String albumDescription = "Album description";
+    MediaAlbum albumModel = new MediaAlbum(OLD_ALBUM_ID, albumName, albumDescription);
+
+    GoogleAlbum responseAlbum = new GoogleAlbum();
+    responseAlbum.setId(NEW_ALBUM_ID);
+    Mockito.when(googlePhotosInterface.createAlbum(any(GoogleAlbum.class)))
+        .thenReturn(responseAlbum);
+
+    // Run test
+    googlePhotosImporter.importSingleAlbum(uuid, null, albumModel);
+
+    // Check results
+    ArgumentCaptor<GoogleAlbum> albumArgumentCaptor = ArgumentCaptor.forClass(GoogleAlbum.class);
+    Mockito.verify(googlePhotosInterface).createAlbum(albumArgumentCaptor.capture());
+    assertEquals(albumArgumentCaptor.getValue().getTitle(), albumName);
+    assertNull(albumArgumentCaptor.getValue().getId());
+  }
+
+  @Test
+  public void importTwoPhotos() throws Exception {
+    PhotoModel photoModel1 =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID1",
+            OLD_ALBUM_ID,
+            false,
+            SHA1);
+    Mockito.when(googlePhotosInterface.uploadMediaContent(any(), eq(SHA1))).thenReturn("token1");
+
+    PhotoModel photoModel2 =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID2",
+            OLD_ALBUM_ID,
+            false);
+    Mockito.when(googlePhotosInterface.uploadMediaContent(any(), eq(null)))
+        .thenReturn("token2");
+
+    BatchMediaItemResponse batchMediaItemResponse =
+        new BatchMediaItemResponse(
+            new NewMediaItemResult[]{
+                buildMediaItemResult("token1", Code.OK_VALUE),
+                buildMediaItemResult("token2", Code.OK_VALUE)
+            });
+    Mockito.when(googlePhotosInterface.createPhotos(any(NewMediaItemUpload.class)))
+        .thenReturn(batchMediaItemResponse);
+
+    long length = googlePhotosImporter.importPhotos(Lists.newArrayList(photoModel1, photoModel2),
+        executor, UUID.randomUUID(), mock(TokensAndUrlAuthData.class));
+    // Two photos of 32L each imported
+    assertEquals(64L, length);
+    assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1")));
+    assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID2")));
+  }
+
+  private NewMediaItemResult buildMediaItemResult(String uploadToken, int code) {
+    // We do a lot of mocking as building the actual objects would require changing the constructors
+    // which messed up deserialization so best to leave them unchanged.
+    GoogleMediaItem mediaItem = mock(GoogleMediaItem.class);
+    Mockito.when(mediaItem.getId()).thenReturn("newId");
+    Status status = mock(Status.class);
+    Mockito.when(status.getCode()).thenReturn(code);
+    NewMediaItemResult result = mock(NewMediaItemResult.class);
+    Mockito.when(result.getUploadToken()).thenReturn(uploadToken);
+    Mockito.when(result.getStatus()).thenReturn(status);
+    Mockito.when(result.getMediaItem()).thenReturn(mediaItem);
+    return result;
+  }
+
+  @Test
+  public void importTwoPhotosWithFailure() throws Exception {
+    PhotoModel photoModel1 =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID1",
+            OLD_ALBUM_ID,
+            false);
+    PhotoModel photoModel2 =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID2",
+            OLD_ALBUM_ID,
+            false);
+
+    Mockito.when(googlePhotosInterface.uploadMediaContent(any(), eq(null)))
+        .thenReturn("token1", "token2");
+    BatchMediaItemResponse batchMediaItemResponse =
+        new BatchMediaItemResponse(
+            new NewMediaItemResult[]{
+                buildMediaItemResult("token1", Code.OK_VALUE),
+                buildMediaItemResult("token2", Code.UNAUTHENTICATED_VALUE)
+            });
+    Mockito.when(googlePhotosInterface.createPhotos(any(NewMediaItemUpload.class)))
+        .thenReturn(batchMediaItemResponse);
+
+    long length = googlePhotosImporter.importPhotos(Lists.newArrayList(photoModel1, photoModel2),
+        executor, UUID.randomUUID(), mock(TokensAndUrlAuthData.class));
+    // Only one photo of 32L imported
+    assertEquals(32L, length);
+
+    assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1")));
+    String failedDataId = String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID2");
+    assertFalse(executor.isKeyCached(failedDataId));
+    ErrorDetail errorDetail = executor.getErrors().iterator().next();
+    assertEquals(failedDataId, errorDetail.id());
+    assertThat(
+        errorDetail.exception(), CoreMatchers.containsString("Media item could not be created."));
+  }
+
+  @Test
+  public void importOnePhotoWithHashMismatch() throws Exception {
+    PhotoModel photoModel =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID1",
+            OLD_ALBUM_ID,
+            false,
+            SHA1);
+
+    Mockito.when(googlePhotosInterface.uploadMediaContent(any(), eq(SHA1)))
+        .thenThrow(new UploadErrorException("Hash mismatch will be thrown", new Throwable()));
+    BatchMediaItemResponse batchMediaItemResponse = new BatchMediaItemResponse(
+        new NewMediaItemResult[]{});
+    Mockito.when(googlePhotosInterface.createPhotos(any(NewMediaItemUpload.class)))
+        .thenReturn(batchMediaItemResponse);
+
+    // No photo imported and will return a hash mismatch error for investigation.
+    assertThrows(UploadErrorException.class,
+        () -> googlePhotosImporter.importPhotos(Lists.newArrayList(photoModel), executor,
+            UUID.randomUUID(), mock(TokensAndUrlAuthData.class)));
+
+    String failedDataId = String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1");
+    assertFalse(executor.isKeyCached(failedDataId));
+
+    ErrorDetail errorDetail = executor.getErrors().iterator().next();
+    assertEquals(failedDataId, errorDetail.id());
+    assertThat(
+        errorDetail.exception(), CoreMatchers.containsString("Hash mismatch"));
+  }
+
+  @Test
+  public void importAlbumWithITString()
+      throws PermissionDeniedException, InvalidTokenException, IOException, UploadErrorException {
+    String albumId = "Album Id";
+    String albumName = "Album Name";
+    String albumDescription = "Album Description";
+
+    MediaAlbum albumModel = new MediaAlbum(albumId, albumName, albumDescription);
+
+    PortabilityJob portabilityJob = mock(PortabilityJob.class);
+    Mockito.when(portabilityJob.userLocale()).thenReturn("it");
+    JobStore jobStore = mock(JobStore.class);
+    Mockito.when(jobStore.findJob(uuid)).thenReturn(portabilityJob);
+    GoogleAlbum responseAlbum = new GoogleAlbum();
+    responseAlbum.setId(NEW_ALBUM_ID);
+    Mockito.when(googlePhotosInterface.createAlbum(any(GoogleAlbum.class)))
+        .thenReturn(responseAlbum);
+    PhotosLibraryClient photosLibraryClient = mock(PhotosLibraryClient.class);
+
+    GoogleMediaImporter sut =
+        new GoogleMediaImporter(
+            null,  /*credentialFactory*/
+            jobStore,
+            mock(TemporaryPerJobDataStore.class),
+            null,  /*jsonFactory*/
+            null,  /*photosInterfacesMap*/
+            googlePhotosInterface,
+            photosLibraryClient,
+            connectionProvider,
+            monitor,
+            1.0  /*writesPerSecond*/);
+
+    sut.importSingleAlbum(uuid, null, albumModel);
+    ArgumentCaptor<GoogleAlbum> albumArgumentCaptor = ArgumentCaptor.forClass(GoogleAlbum.class);
+    Mockito.verify(googlePhotosInterface).createAlbum(albumArgumentCaptor.capture());
+    assertEquals(albumArgumentCaptor.getValue().getTitle(), albumName);
+  }
+
+  @Test
+  public void retrieveAlbumStringOnlyOnce()
+      throws PermissionDeniedException, InvalidTokenException, IOException, UploadErrorException {
+    String albumId = "Album Id";
+    String albumName = "Album Name";
+    String albumDescription = "Album Description";
+
+    MediaAlbum albumModel = new MediaAlbum(albumId, albumName, albumDescription);
+
+    PortabilityJob portabilityJob = mock(PortabilityJob.class);
+    Mockito.when(portabilityJob.userLocale()).thenReturn("it");
+    JobStore jobStore = mock(JobStore.class);
+    Mockito.when(jobStore.findJob(uuid)).thenReturn(portabilityJob);
+    GoogleAlbum responseAlbum = new GoogleAlbum();
+    responseAlbum.setId(NEW_ALBUM_ID);
+    Mockito.when(googlePhotosInterface.createAlbum(any(GoogleAlbum.class)))
+        .thenReturn(responseAlbum);
+    PhotosLibraryClient photosLibraryClient = mock(PhotosLibraryClient.class);
+
+    GoogleMediaImporter sut =
+        new GoogleMediaImporter(
+            null,  /*credentialFactory*/
+            jobStore,
+            mock(TemporaryPerJobDataStore.class),
+            null,  /*jsonFactory*/
+            null,  /*photosInterfacesMap*/
+            googlePhotosInterface,
+            photosLibraryClient,
+            connectionProvider,
+            monitor,
+            1.0  /*writesPerSecond*/);
+
+    sut.importSingleAlbum(uuid, null, albumModel);
+    sut.importSingleAlbum(uuid, null, albumModel);
+    Mockito.verify(jobStore, atMostOnce()).findJob(uuid);
+  }
+
+  @Test
+  public void importPhotoInTempStore() throws Exception {
+    PhotoModel photoModel =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID1",
+            OLD_ALBUM_ID,
+            true);
+
+    Mockito.when(googlePhotosInterface.uploadMediaContent(any(), eq(null))).thenReturn("token1");
+    PhotosLibraryClient photosLibraryClient = mock(PhotosLibraryClient.class);
+    JobStore jobStore = mock(LocalJobStore.class);
+    Mockito.when(jobStore.getStream(any(), any()))
+        .thenReturn(
+            new TemporaryPerJobDataStore.InputStreamWrapper(
+                new ByteArrayInputStream("TestingBytes".getBytes())));
+    Mockito.doNothing().when(jobStore).removeData(any(), anyString());
+
+    ConnectionProvider connectionProvider = new ConnectionProvider(jobStore);
+    GoogleMediaImporter googlePhotosImporter =
+        new GoogleMediaImporter(
+            null,  /*credentialFactory*/
+            jobStore,
+            mock(TemporaryPerJobDataStore.class),
+            null,  /*jsonFactory*/
+            null,  /*photosInterfacesMap*/
+            googlePhotosInterface,
+            photosLibraryClient,
+            connectionProvider,
+            monitor,
+            1.0  /*writesPerSecond*/);
+
+    BatchMediaItemResponse batchMediaItemResponse =
+        new BatchMediaItemResponse(
+            new NewMediaItemResult[]{buildMediaItemResult("token1", Code.OK_VALUE)});
+
+    Mockito.when(googlePhotosInterface.createPhotos(any(NewMediaItemUpload.class)))
+        .thenReturn(batchMediaItemResponse);
+
+    UUID jobId = UUID.randomUUID();
+
+    googlePhotosImporter.importPhotos(Lists.newArrayList(photoModel), executor, jobId,
+        mock(TokensAndUrlAuthData.class));
+    assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1")));
+    Mockito.verify(jobStore, Mockito.times(1)).removeData(any(), anyString());
+    Mockito.verify(jobStore, Mockito.times(1)).getStream(any(), anyString());
+  }
+
+  @Test
+  public void importPhotoInTempStoreFailure() throws Exception {
+    PhotoModel photoModel =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID1",
+            OLD_ALBUM_ID,
+            true);
+
+    Mockito.when(googlePhotosInterface.uploadMediaContent(any(), eq(null)))
+        .thenThrow(new IOException("Unit Testing"));
+    PhotosLibraryClient photosLibraryClient = mock(PhotosLibraryClient.class);
+    JobStore jobStore = mock(LocalJobStore.class);
+    Mockito.when(jobStore.getStream(any(), any()))
+        .thenReturn(
+            new TemporaryPerJobDataStore.InputStreamWrapper(
+                new ByteArrayInputStream("TestingBytes".getBytes())));
+    Mockito.doNothing().when(jobStore).removeData(any(), anyString());
+
+    ConnectionProvider connectionProvider = new ConnectionProvider(jobStore);
+    GoogleMediaImporter googlePhotosImporter =
+        new GoogleMediaImporter(
+            null,  /*credentialFactory*/
+            jobStore,
+            mock(TemporaryPerJobDataStore.class),
+            null,  /*jsonFactory*/
+            null,  /*photosInterfacesMap*/
+            googlePhotosInterface,
+            photosLibraryClient,
+            connectionProvider,
+            monitor,
+            1.0  /*writesPerSecond*/);
+
+    BatchMediaItemResponse batchMediaItemResponse =
+        new BatchMediaItemResponse(
+            new NewMediaItemResult[] {buildMediaItemResult("token1", Code.OK_VALUE)});
+
+    Mockito.when(googlePhotosInterface.createPhotos(any(NewMediaItemUpload.class)))
+        .thenReturn(batchMediaItemResponse);
+
+    UUID jobId = UUID.randomUUID();
+
+    googlePhotosImporter.importPhotos(Lists.newArrayList(photoModel), executor, jobId,
+        mock(TokensAndUrlAuthData.class));
+    Mockito.verify(jobStore, Mockito.times(0)).removeData(any(), anyString());
+    Mockito.verify(jobStore, Mockito.times(1)).getStream(any(), anyString());
+  }
+
+  @Test
+  public void importPhotoFailedToFindAlbum() throws Exception {
+    PhotoModel photoModel =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID1",
+            OLD_ALBUM_ID,
+            true);
+
+    Mockito.when(googlePhotosInterface.uploadMediaContent(any(), eq(null)))
+        .thenReturn("token1", "token2");
+    PhotosLibraryClient photosLibraryClient = mock(PhotosLibraryClient.class);
+    JobStore jobStore = mock(LocalJobStore.class);
+    Mockito.when(jobStore.getStream(any(), any()))
+        .thenReturn(
+            new TemporaryPerJobDataStore.InputStreamWrapper(
+                new ByteArrayInputStream("TestingBytes".getBytes())));
+    googlePhotosImporter =
+        new GoogleMediaImporter(
+            null,  /*credentialFactory*/
+            jobStore,
+            mock(TemporaryPerJobDataStore.class),
+            null,  /*jsonFactory*/
+            null,  /*photosInterfacesMap*/
+            googlePhotosInterface,
+            photosLibraryClient,
+            connectionProvider,
+            monitor,
+            1.0  /*writesPerSecond*/);
+    Mockito.when(googlePhotosInterface.createPhotos(any(NewMediaItemUpload.class)))
+        .thenThrow(new IOException("The provided ID does not match any albums"));
+
+    GoogleAlbum responseAlbum = new GoogleAlbum();
+    Mockito.when(googlePhotosInterface.getAlbum(any())).thenReturn(responseAlbum);
+
+    long bytes = googlePhotosImporter.importPhotos(Lists.newArrayList(photoModel), executor, uuid,
+        mock(TokensAndUrlAuthData.class));
+
+    // didn't throw
+    assertEquals(0, bytes);
+  }
+
+  @Test
+  public void importPhotoCreatePhotosOtherException() throws Exception {
+    PhotoModel photoModel =
+        new PhotoModel(
+            PHOTO_TITLE,
+            IMG_URI,
+            PHOTO_DESCRIPTION,
+            JPEG_MEDIA_TYPE,
+            "oldPhotoID1",
+            OLD_ALBUM_ID,
+            true);
+
+    Mockito.when(googlePhotosInterface.uploadMediaContent(any(), eq(null)))
+        .thenReturn("token1", "token2");
+    PhotosLibraryClient photosLibraryClient = mock(PhotosLibraryClient.class);
+    JobStore jobStore = mock(LocalJobStore.class);
+    Mockito.when(jobStore.getStream(any(), any()))
+        .thenReturn(
+            new TemporaryPerJobDataStore.InputStreamWrapper(
+                new ByteArrayInputStream("TestingBytes".getBytes())));
+    googlePhotosImporter =
+        new GoogleMediaImporter(
+            null,  /*credentialFactory*/
+            jobStore,
+            mock(TemporaryPerJobDataStore.class),
+            null,  /*jsonFactory*/
+            null,  /*photosInterfacesMap*/
+            googlePhotosInterface,
+            photosLibraryClient,
+            connectionProvider,
+            monitor,
+            1.0  /*writesPerSecond*/);
+
+    Mockito.when(googlePhotosInterface.createPhotos(any(NewMediaItemUpload.class)))
+        .thenThrow(new IOException("Some other exception"));
+
+    GoogleAlbum responseAlbum = new GoogleAlbum();
+    Mockito.when(googlePhotosInterface.getAlbum(any())).thenReturn(responseAlbum);
+
+    assertThrows(IOException.class,
+        () -> googlePhotosImporter.importPhotos(Lists.newArrayList(photoModel), executor, uuid,
+            mock(TokensAndUrlAuthData.class)));
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporterTest.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.cloud.local.LocalJobStore;
 import com.google.photos.library.v1.PhotosLibraryClient;
+import org.datatransferproject.datatransfer.google.common.gphotos.GPhotosUpload;
 import org.datatransferproject.datatransfer.google.mediaModels.BatchMediaItemResponse;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleAlbum;
 import org.datatransferproject.datatransfer.google.mediaModels.GoogleMediaItem;
@@ -175,7 +176,7 @@ public class GoogleMediaImporterTest {
         .thenReturn(batchMediaItemResponse);
 
     long length = googleMediaImporter.importPhotos(Lists.newArrayList(photoModel1, photoModel2),
-        executor, UUID.randomUUID(), mock(TokensAndUrlAuthData.class));
+        new GPhotosUpload(UUID.randomUUID(), executor, mock(TokensAndUrlAuthData.class)));
     // Two photos of 32L each imported
     assertEquals(64L, length);
     assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1")));
@@ -229,7 +230,7 @@ public class GoogleMediaImporterTest {
         .thenReturn(batchMediaItemResponse);
 
     long length = googleMediaImporter.importPhotos(Lists.newArrayList(photoModel1, photoModel2),
-        executor, UUID.randomUUID(), mock(TokensAndUrlAuthData.class));
+        new GPhotosUpload(UUID.randomUUID(), executor, mock(TokensAndUrlAuthData.class)));
     // Only one photo of 32L imported
     assertEquals(32L, length);
 
@@ -264,8 +265,8 @@ public class GoogleMediaImporterTest {
 
     // No photo imported and will return a hash mismatch error for investigation.
     assertThrows(UploadErrorException.class,
-        () -> googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), executor,
-            UUID.randomUUID(), mock(TokensAndUrlAuthData.class)));
+        () -> googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), new GPhotosUpload(UUID.randomUUID(), executor,
+            mock(TokensAndUrlAuthData.class))));
 
     String failedDataId = String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1");
     assertFalse(executor.isKeyCached(failedDataId));
@@ -395,8 +396,8 @@ public class GoogleMediaImporterTest {
 
     UUID jobId = UUID.randomUUID();
 
-    googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), executor, jobId,
-        mock(TokensAndUrlAuthData.class));
+    googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), new GPhotosUpload(jobId, executor,
+        mock(TokensAndUrlAuthData.class)));
     assertTrue(executor.isKeyCached(String.format("%s-%s", OLD_ALBUM_ID, "oldPhotoID1")));
     Mockito.verify(jobStore, Mockito.times(1)).removeData(any(), anyString());
     Mockito.verify(jobStore, Mockito.times(1)).getStream(any(), anyString());
@@ -447,8 +448,8 @@ public class GoogleMediaImporterTest {
 
     UUID jobId = UUID.randomUUID();
 
-    googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), executor, jobId,
-        mock(TokensAndUrlAuthData.class));
+    googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), new GPhotosUpload(jobId, executor,
+        mock(TokensAndUrlAuthData.class)));
     Mockito.verify(jobStore, Mockito.times(0)).removeData(any(), anyString());
     Mockito.verify(jobStore, Mockito.times(1)).getStream(any(), anyString());
   }
@@ -491,8 +492,8 @@ public class GoogleMediaImporterTest {
     GoogleAlbum responseAlbum = new GoogleAlbum();
     Mockito.when(googlePhotosInterface.getAlbum(any())).thenReturn(responseAlbum);
 
-    long bytes = googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), executor, uuid,
-        mock(TokensAndUrlAuthData.class));
+    long bytes = googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), new GPhotosUpload(uuid, executor,
+        mock(TokensAndUrlAuthData.class)));
 
     // didn't throw
     assertEquals(0, bytes);
@@ -538,7 +539,7 @@ public class GoogleMediaImporterTest {
     Mockito.when(googlePhotosInterface.getAlbum(any())).thenReturn(responseAlbum);
 
     assertThrows(IOException.class,
-        () -> googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), executor, uuid,
-            mock(TokensAndUrlAuthData.class)));
+        () -> googleMediaImporter.importPhotos(Lists.newArrayList(photoModel), new GPhotosUpload(uuid, executor,
+            mock(TokensAndUrlAuthData.class))));
   }
 }


### PR DESCRIPTION
- [x] WARNING: this PR shouldn't be merged until #1233 is submitted.

## prose-explanation of this merge

this is a noop (just refactoring) change to enable a _later_ merge to finally delete duplicate code we took from the GooglePhotosImporter's internals (in the making of GoogleMediaImporter); specifically for the moment, [these lines of code](https://github.com/jzacsh/data-transfer-project/blob/master/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java#L157-L202) ([permalink](https://github.com/jzacsh/data-transfer-project/blob/2c2336cdbdd63609b88cd40a9a001dde5ab3a05e/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/photos/GooglePhotosImporter.java#L157-L202)).

we're factoring the code out into a new gphotos package, effectively **also** tackling one of our other TODOs to have a photos/video agnostic place to share logic (and allow the future consideration of [`GooglePhotosInterface` vs. `PhotosLibraryClient` usages](https://github.com/jzacsh/data-transfer-project/blob/2c2336cdbdd63609b88cd40a9a001dde5ab3a05e/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java#L480-L485) be tackled separately).

## diff-explanation of this merge

here's much more succinct diffs of the actual code as it moved and what changed.

### diff of core batch-importing function:

<details>
<summary>diff of `GoogleMediaImporter#importItemsViaBatching` being renamed to `GPhotosUpload#uploadItemsViaBatching`
</summary>

below is the `diff` output for the code `GoogleMediaImporter#importItemsViaBatching` being renamed to `GPhotosUpload#uploadItemsViaBatching` generated via:

```sh
$ diff -u \
    <(
        git show master:extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java |
        sed -n 363,414p
    ) \
    <(
        git show GMediaPhotosDedupe:extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java |
        sed -n 104,149p
    )
```

```diff
--- /dev/fd/63	2023-04-17 07:47:17.158102144 -0500
+++ /dev/fd/62	2023-04-17 07:47:17.159102216 -0500
@@ -6,17 +6,9 @@
   // TODO(aksingh737,jzacsh) WARNING: delete the duplicated GooglePhotosImporter code by pulling
   // this out of Media into a new GphotoMedia class that exposes these methods for _both_
   // GoogleMediaImporter _and_ GooglePhotosImporter to use.
-  private <T extends DownloadableItem> long importItemsViaBatching(
+  public <T extends DownloadableFile> long uploadItemsViaBatching(
       Collection<T> items,
-      // TODO we could just specify we have FolderItem interface objects and call getFolderId, and
-      // drop this getAlbumId parameter (FolderItem was introduced for similar purposes in via
-      // MicrosoftMedia* work).
-      Function<T, String> getAlbumId,
-      int batchSize,
-      IdempotentImportExecutor executor,
-      UUID jobId,
-      TokensAndUrlAuthData authData,
-      ItemBatchImporter<T> importer)
+      ItemBatchUploader<T> importer)
       throws Exception {
     long bytes = 0L;
     if (items == null || items.size() <= 0) {
@@ -25,7 +17,7 @@
     Map<String, List<T>> itemsByAlbumId =
         items.stream()
             .filter(item -> !executor.isKeyCached(item.getIdempotentId()))
-            .collect(Collectors.groupingBy(getAlbumId));
+            .collect(Collectors.groupingBy(DownloadableFile::getFolderId));
 
     for (Entry<String, List<T>> albumEntry : itemsByAlbumId.entrySet()) {
       String originalAlbumId = albumEntry.getKey();
@@ -41,10 +33,12 @@
       }
 
       UnmodifiableIterator<List<T>> batches =
-          Iterators.partition(albumEntry.getValue().iterator(), batchSize);
+          Iterators.partition(albumEntry.getValue().iterator(),
+          BATCH_UPLOAD_SIZE);
+
       while (batches.hasNext()) {
         long batchBytes =
-            importer.importToAlbum(jobId, authData, batches.next(), executor, googleAlbumId);
+            importer.uploadToAlbum(jobId, authData, batches.next(), executor, googleAlbumId);
         bytes += batchBytes;
       }
     }
```
</details>

### diff of helper interface for said batch import func

<details>
<summary>diff of `GoogleMediaImporter.ItemBatchImporter#importToAlbum` being renamed to `GPhotosUpload.ItemBatchUploader#uploadToAlbum`</summary>

Below is the `diff` output for the code `GoogleMediaImporter.ItemBatchImporter#importToAlbum` being renamed to `GPhotosUpload.ItemBatchUploader#uploadToAlbum` generated via:

```sh
$ diff -u \
    <(
        git show master:extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/media/GoogleMediaImporter.java |
        sed -n 475,498p) \
    <(
        git show GMediaPhotosDedupe:extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/common/gphotos/GPhotosUpload.java |
        sed -n 151,170p
    )
```

```diff
--- /dev/fd/63	2023-04-17 07:52:02.161197228 -0500
+++ /dev/fd/62	2023-04-17 07:52:02.161197228 -0500
@@ -1,8 +1,3 @@
-  // TODO(aksingh737,jzacsh) refactor Google{Photos,Video,Media}{Importer,Exporter} classes so they're
-  // not all drifting-forks of each other, and instead share code with the help of small interfaces.
-  // We can start by using some of the de-duplication that happened, with the interfaces below, in
-  // the creation of this particular importer
-
   // TODO(aksingh737,jzacsh) consider renaming lower-level gphotos code (ie: anything of the "google
   // photos" product but not a "photo" from "google"; examples: the GooglePhotosInterface that
   // interacts with gphotos teams' upstream SDKs, interfaces like this one below, PhotoResult,
@@ -10,15 +5,16 @@
   // that are wrapping the gphotos SDKs (the examples already mentioned) and make that package
   // importable by the other google adapters.
   @FunctionalInterface
-  private interface ItemBatchImporter<T> {
+  public interface ItemBatchUploader<T> {
     /**
      * Returns the number of uploaded bytes, as summed across all `items` that were uploaded in this
      * batch.
      */
-    public long importToAlbum(
+    public long uploadToAlbum(
         UUID jobId,
         TokensAndUrlAuthData authData,
         List<T> batch,
         IdempotentImportExecutor executor,
         String targetAlbumId) throws Exception;
   }
+}
```
</details>