### PR TITLE
Change retrying executor to singleton

### DIFF
--- a/extensions/copier/portability-stack-copier/src/main/java/org/datatransferproject/copier/stack/PortabilityStackInMemoryDataCopier.java
+++ b/extensions/copier/portability-stack-copier/src/main/java/org/datatransferproject/copier/stack/PortabilityStackInMemoryDataCopier.java
@@ -32,6 +32,7 @@ import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.spi.transfer.types.ContinuationData;
 import org.datatransferproject.spi.transfer.types.CopyException;
+import org.datatransferproject.transfer.Annotations;
 import org.datatransferproject.transfer.copier.InMemoryDataCopier;
 import org.datatransferproject.transfer.copier.PortabilityAbstractInMemoryDataCopier;
 import org.datatransferproject.types.common.ExportInformation;
@@ -53,6 +54,7 @@ public class PortabilityStackInMemoryDataCopier extends PortabilityAbstractInMem
       Provider<RetryStrategyLibrary> retryStrategyLibraryProvider,
       Monitor monitor,
       IdempotentImportExecutor idempotentImportExecutor,
+      @Annotations.RetryingExecutor IdempotentImportExecutor retryingIdempotentImportExecutor,
       DtpInternalMetricRecorder dtpInternalMetricRecorder,
       JobStore jobStore) {
     super(
@@ -61,6 +63,7 @@ public class PortabilityStackInMemoryDataCopier extends PortabilityAbstractInMem
         retryStrategyLibraryProvider,
         monitor,
         idempotentImportExecutor,
+        retryingIdempotentImportExecutor,
         dtpInternalMetricRecorder,
         jobStore);
   }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutorExtension.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutorExtension.java
@@ -11,7 +11,7 @@ public class InMemoryIdempotentImportExecutorExtension
   IdempotentImportExecutor idempotentImportExecutor;
   IdempotentImportExecutor retryingIdempotentImportExecutor;
   @Override
-  public IdempotentImportExecutor getIdempotentImportExecutor(ExtensionContext extensionContext) {
+  public synchronized IdempotentImportExecutor getIdempotentImportExecutor(ExtensionContext extensionContext) {
     if (idempotentImportExecutor == null) {
       idempotentImportExecutor = new InMemoryIdempotentImportExecutor(extensionContext.getMonitor());
     }
@@ -19,7 +19,7 @@ public class InMemoryIdempotentImportExecutorExtension
   }
 
   @Override
-  public IdempotentImportExecutor getRetryingIdempotentImportExecutor(ExtensionContext extensionContext){
+  public synchronized IdempotentImportExecutor getRetryingIdempotentImportExecutor(ExtensionContext extensionContext){
     if(retryingIdempotentImportExecutor == null) {
       retryingIdempotentImportExecutor = new RetryingInMemoryIdempotentImportExecutor(extensionContext.getMonitor(), extensionContext.getSetting("retryLibrary", null));
     }

--- a/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutorExtension.java
+++ b/portability-spi-transfer/src/main/java/org/datatransferproject/spi/transfer/idempotentexecutor/InMemoryIdempotentImportExecutorExtension.java
@@ -8,14 +8,22 @@ import org.datatransferproject.api.launcher.ExtensionContext;
 public class InMemoryIdempotentImportExecutorExtension
     implements IdempotentImportExecutorExtension {
 
+  IdempotentImportExecutor idempotentImportExecutor;
+  IdempotentImportExecutor retryingIdempotentImportExecutor;
   @Override
   public IdempotentImportExecutor getIdempotentImportExecutor(ExtensionContext extensionContext) {
-    return new InMemoryIdempotentImportExecutor(extensionContext.getMonitor());
+    if (idempotentImportExecutor == null) {
+      idempotentImportExecutor = new InMemoryIdempotentImportExecutor(extensionContext.getMonitor());
+    }
+    return idempotentImportExecutor;
   }
 
   @Override
   public IdempotentImportExecutor getRetryingIdempotentImportExecutor(ExtensionContext extensionContext){
-    return new RetryingInMemoryIdempotentImportExecutor(extensionContext.getMonitor(), extensionContext.getSetting("retryLibrary", null));
+    if(retryingIdempotentImportExecutor == null) {
+      retryingIdempotentImportExecutor = new RetryingInMemoryIdempotentImportExecutor(extensionContext.getMonitor(), extensionContext.getSetting("retryLibrary", null));
+    }
+    return retryingIdempotentImportExecutor;
   }
 
   @Override

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/Annotations.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/Annotations.java
@@ -15,16 +15,20 @@
  */
 package org.datatransferproject.transfer;
 
-import javax.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import javax.inject.Qualifier;
 
-/** Package private Guice annotations. **/
-final class Annotations {
+/** Package private Guice annotations. * */
+public final class Annotations {
   /** A scheduler for for checking if a job has been canceled. */
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)
   @interface CancelScheduler {}
 
-  private Annotations() {}
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface RetryingExecutor {}
+
+  public Annotations() {}
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerMain.java
@@ -43,7 +43,6 @@ import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
 import org.datatransferproject.spi.service.extension.ServiceExtension;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.hooks.JobHooks;
-import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorExtension;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorLoader;
 import org.datatransferproject.spi.transfer.provider.TransferCompatibilityProvider;
@@ -127,7 +126,7 @@ public class WorkerMain {
                   cloudExtension,
                   transferExtensions,
                   securityExtension,
-                  idempotentImportExecutorExtension.getIdempotentImportExecutor(extensionContext),
+                  idempotentImportExecutorExtension,
                   symmetricKeyGenerator,
                   jobHooks,
                   new TransferCompatibilityProvider()));

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/WorkerModule.java
@@ -45,6 +45,7 @@ import org.datatransferproject.spi.cloud.storage.JobStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
 import org.datatransferproject.spi.transfer.hooks.JobHooks;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.spi.transfer.provider.TransferCompatibilityProvider;
@@ -63,7 +64,7 @@ final class WorkerModule extends FlagBindingModule {
   private final ExtensionContext context;
   private final List<TransferExtension> transferExtensions;
   private final SecurityExtension securityExtension;
-  private final IdempotentImportExecutor idempotentImportExecutor;
+  private final IdempotentImportExecutorExtension idempotentImportExecutorExtension;
   private final SymmetricKeyGenerator symmetricKeyGenerator;
   private final JobHooks jobHooks;
   private final TransferCompatibilityProvider compatibilityProvider;
@@ -73,7 +74,7 @@ final class WorkerModule extends FlagBindingModule {
       CloudExtension cloudExtension,
       List<TransferExtension> transferExtensions,
       SecurityExtension securityExtension,
-      IdempotentImportExecutor idempotentImportExecutor,
+      IdempotentImportExecutorExtension idempotentImportExecutorExtension,
       SymmetricKeyGenerator symmetricKeyGenerator,
       JobHooks jobHooks,
       TransferCompatibilityProvider transferCompatibilityProvider) {
@@ -81,7 +82,7 @@ final class WorkerModule extends FlagBindingModule {
     this.context = context;
     this.transferExtensions = transferExtensions;
     this.securityExtension = securityExtension;
-    this.idempotentImportExecutor = idempotentImportExecutor;
+    this.idempotentImportExecutorExtension = idempotentImportExecutorExtension;
     this.symmetricKeyGenerator = symmetricKeyGenerator;
     this.jobHooks = jobHooks;
     this.compatibilityProvider = transferCompatibilityProvider;
@@ -261,6 +262,13 @@ final class WorkerModule extends FlagBindingModule {
   @Provides
   @Singleton
   public IdempotentImportExecutor getIdempotentImportExecutor() {
-    return idempotentImportExecutor;
+    return idempotentImportExecutorExtension.getIdempotentImportExecutor(context);
+  }
+
+  @Provides
+  @Singleton
+  @Annotations.RetryingExecutor
+  public IdempotentImportExecutor getRetryingIdempotentImportExecutor() {
+    return idempotentImportExecutorExtension.getRetryingIdempotentImportExecutor(context);
   }
 }

--- a/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityAbstractInMemoryDataCopier.java
+++ b/portability-transfer/src/main/java/org/datatransferproject/transfer/copier/PortabilityAbstractInMemoryDataCopier.java
@@ -39,6 +39,7 @@ import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.spi.transfer.types.CopyException;
 import org.datatransferproject.spi.transfer.types.CopyExceptionWithFailureReason;
+import org.datatransferproject.transfer.Annotations;
 import org.datatransferproject.transfer.CallableExporter;
 import org.datatransferproject.transfer.CallableImporter;
 import org.datatransferproject.transfer.CallableSizeCalculator;
@@ -64,6 +65,7 @@ public abstract class PortabilityAbstractInMemoryDataCopier implements InMemoryD
 
   protected final Provider<Importer> importerProvider;
   protected final IdempotentImportExecutor idempotentImportExecutor;
+  protected final IdempotentImportExecutor retryingIdempotentImportExecutor;
   protected final Provider<RetryStrategyLibrary> retryStrategyLibraryProvider;
   protected final Monitor monitor;
   protected final DtpInternalMetricRecorder metricRecorder;
@@ -75,6 +77,7 @@ public abstract class PortabilityAbstractInMemoryDataCopier implements InMemoryD
       Provider<RetryStrategyLibrary> retryStrategyLibraryProvider,
       Monitor monitor,
       IdempotentImportExecutor idempotentImportExecutor,
+      @Annotations.RetryingExecutor IdempotentImportExecutor retryingIdempotentImportExecutor,
       DtpInternalMetricRecorder dtpInternalMetricRecorder,
       JobStore jobStore) {
     this.exporterProvider = exporterProvider;
@@ -82,6 +85,7 @@ public abstract class PortabilityAbstractInMemoryDataCopier implements InMemoryD
     this.retryStrategyLibraryProvider = retryStrategyLibraryProvider;
     this.monitor = monitor;
     this.idempotentImportExecutor = idempotentImportExecutor;
+    this.retryingIdempotentImportExecutor = retryingIdempotentImportExecutor;
     this.metricRecorder = dtpInternalMetricRecorder;
     this.jobStore = jobStore;
   }
@@ -100,6 +104,7 @@ public abstract class PortabilityAbstractInMemoryDataCopier implements InMemoryD
   @Override
   public Collection<ErrorDetail> getErrors(UUID jobId) {
     idempotentImportExecutor.setJobId(jobId);
+    retryingIdempotentImportExecutor.setJobId(jobId);
     return idempotentImportExecutor.getErrors();
   }
 

--- a/portability-transfer/src/test/java/org/datatransferproject/transfer/copier/PortabilityInMemoryDataCopierTest.java
+++ b/portability-transfer/src/test/java/org/datatransferproject/transfer/copier/PortabilityInMemoryDataCopierTest.java
@@ -60,6 +60,7 @@ public class PortabilityInMemoryDataCopierTest {
           null,
           Mockito.mock(Monitor.class),
           new FakeIdempotentImportExecutor(),
+          new FakeIdempotentImportExecutor(),
           null,
           null);
     }
@@ -85,6 +86,7 @@ public class PortabilityInMemoryDataCopierTest {
           null,
           null,
           Mockito.mock(Monitor.class),
+          new FakeIdempotentImportExecutor(),
           new FakeIdempotentImportExecutor(),
           null,
           (Mockito.mock(JobStore.class)));


### PR DESCRIPTION
Change executor to be singleton so that worker and importers/exporters use the same executor. Previously executor used in importers were not getting job id from worker, along with other job info and failed files