### PR TITLE
Update Google music models and  Import/Export adapters

### DIFF
--- a/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleOAuthConfig.java
+++ b/extensions/auth/portability-auth-google/src/main/java/org/datatransferproject/auth/google/GoogleOAuthConfig.java
@@ -20,6 +20,7 @@ import static org.datatransferproject.types.common.models.DataVertical.BLOBS;
 import static org.datatransferproject.types.common.models.DataVertical.CALENDAR;
 import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
 import static org.datatransferproject.types.common.models.DataVertical.MAIL;
+import static org.datatransferproject.types.common.models.DataVertical.MUSIC;
 import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
 import static org.datatransferproject.types.common.models.DataVertical.TASKS;
@@ -69,7 +70,8 @@ public class GoogleOAuthConfig implements OAuth2Config {
         .put(SOCIAL_POSTS, ImmutableSet.of("https://www.googleapis.com/auth/plus.login"))
         .put(TASKS, ImmutableSet.of("https://www.googleapis.com/auth/tasks.readonly"))
         .put(VIDEOS, ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.readonly"))
-        .build();
+        .put(MUSIC, ImmutableSet.of("https://www.googleapis.com/auth/music"))
+	.build();
   }
 
   // See https://developers.google.com/identity/protocols/googlescopes
@@ -83,7 +85,8 @@ public class GoogleOAuthConfig implements OAuth2Config {
         .put(PHOTOS, ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary.appendonly"))
         .put(TASKS, ImmutableSet.of("https://www.googleapis.com/auth/tasks"))
         .put(VIDEOS, ImmutableSet.of("https://www.googleapis.com/auth/photoslibrary"))
-        .build();
+        .put(MUSIC, ImmutableSet.of("https://www.googleapis.com/auth/music"))
+	.build();
   }
 
   @Override

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/GoogleTransferExtension.java
@@ -5,6 +5,7 @@ import static org.datatransferproject.types.common.models.DataVertical.CALENDAR;
 import static org.datatransferproject.types.common.models.DataVertical.CONTACTS;
 import static org.datatransferproject.types.common.models.DataVertical.MAIL;
 import static org.datatransferproject.types.common.models.DataVertical.MEDIA;
+import static org.datatransferproject.types.common.models.DataVertical.MUSIC;
 import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
 import static org.datatransferproject.types.common.models.DataVertical.SOCIAL_POSTS;
 import static org.datatransferproject.types.common.models.DataVertical.TASKS;
@@ -29,6 +30,8 @@ import org.datatransferproject.datatransfer.google.gplus.GooglePlusExporter;
 import org.datatransferproject.datatransfer.google.mail.GoogleMailExporter;
 import org.datatransferproject.datatransfer.google.mail.GoogleMailImporter;
 import org.datatransferproject.datatransfer.google.media.GoogleMediaExporter;
+import org.datatransferproject.datatransfer.google.music.GoogleMusicExporter;
+import org.datatransferproject.datatransfer.google.music.GoogleMusicImporter;
 import org.datatransferproject.datatransfer.google.photos.GooglePhotosExporter;
 import org.datatransferproject.datatransfer.google.photos.GooglePhotosImporter;
 import org.datatransferproject.datatransfer.google.tasks.GoogleTasksExporter;
@@ -50,11 +53,12 @@ import org.datatransferproject.types.transfer.auth.AppCredentials;
  * to be retrieved.
  */
 public class GoogleTransferExtension implements TransferExtension {
+
   public static final String SERVICE_ID = "google";
   // TODO: centralized place, or enum type for these
   private static final ImmutableList<DataVertical> SUPPORTED_SERVICES =
       ImmutableList.of(
-          BLOBS, CALENDAR, CONTACTS, MAIL, PHOTOS, SOCIAL_POSTS, TASKS, VIDEOS, MEDIA);
+          BLOBS, CALENDAR, CONTACTS, MAIL, PHOTOS, SOCIAL_POSTS, TASKS, VIDEOS, MEDIA, MUSIC);
   private ImmutableMap<DataVertical, Importer> importerMap;
   private ImmutableMap<DataVertical, Exporter> exporterMap;
   private boolean initialized = false;
@@ -83,7 +87,9 @@ public class GoogleTransferExtension implements TransferExtension {
     // Note: initialize could be called twice in an account migration scenario where we import and
     // export to the same service provider. So just return rather than throwing if called multiple
     // times.
-    if (initialized) return;
+    if (initialized) {
+      return;
+    }
 
     JobStore jobStore = context.getService(JobStore.class);
     HttpTransport httpTransport = context.getService(HttpTransport.class);
@@ -130,6 +136,8 @@ public class GoogleTransferExtension implements TransferExtension {
             idempotentImportExecutor,
             enableRetrying));
     importerBuilder.put(VIDEOS, new GoogleVideosImporter(appCredentials, jobStore, monitor));
+    importerBuilder.put(MUSIC, new GoogleMusicImporter(credentialFactory, jsonFactory, monitor,
+        context.getSetting("googleWritesPerSecond", 1.0)));
     importerMap = importerBuilder.build();
 
     ImmutableMap.Builder<DataVertical, Exporter> exporterBuilder = ImmutableMap.builder();
@@ -144,6 +152,7 @@ public class GoogleTransferExtension implements TransferExtension {
     exporterBuilder.put(VIDEOS, new GoogleVideosExporter(credentialFactory, jsonFactory));
     exporterBuilder.put(
         MEDIA, new GoogleMediaExporter(credentialFactory, jobStore, jsonFactory, monitor));
+    exporterBuilder.put(MUSIC, new GoogleMusicExporter(credentialFactory, jsonFactory, monitor));
 
     exporterMap = exporterBuilder.build();
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicExporter.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.google.common.GoogleCredentialFactory;
+import org.datatransferproject.datatransfer.google.musicModels.GoogleArtist;
 import org.datatransferproject.datatransfer.google.musicModels.GooglePlaylist;
 import org.datatransferproject.datatransfer.google.musicModels.GooglePlaylistItem;
 import org.datatransferproject.datatransfer.google.musicModels.GoogleRelease;
@@ -55,6 +56,7 @@ import org.datatransferproject.types.common.models.music.MusicRelease;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
 
 public class GoogleMusicExporter implements Exporter<TokensAndUrlAuthData, MusicContainerResource> {
+
   static final String PLAYLIST_TRACK_RELEASE_TOKEN_PREFIX = "playlist:track:release:";
   static final String PLAYLIST_TRACK_TOKEN_PREFIX = "playlist:track:";
   static final String PLAYLIST_RELEASE_TOKEN_PREFIX = "playlist:release:";
@@ -236,13 +238,13 @@ public class GoogleMusicExporter implements Exporter<TokensAndUrlAuthData, Music
     return 0;
   }
 
-  private List<MusicGroup> createMusicGroups(String[] artistTitles) {
-    if (artistTitles == null) {
+  private List<MusicGroup> createMusicGroups(GoogleArtist[] artists) {
+    if (artists == null) {
       return null;
     }
     List<MusicGroup> musicGroups = new ArrayList<>();
-    for (String artistTitle : artistTitles) {
-      musicGroups.add(new MusicGroup(artistTitle));
+    for (GoogleArtist artist : artists) {
+      musicGroups.add(new MusicGroup(artist.getTitle()));
     }
     return musicGroups;
   }
@@ -254,13 +256,13 @@ public class GoogleMusicExporter implements Exporter<TokensAndUrlAuthData, Music
     return new MusicPlaylistItem(
         new MusicRecording(
             track.getIsrc(),
-            track.getTrackTitle(),
+            track.getTitle(),
             track.getDurationMillis(),
             new MusicRelease(
                 release.getIcpn(),
-                release.getReleaseTitle(),
-                createMusicGroups(release.getArtistTitles())),
-            createMusicGroups(track.getArtistTitles())),
+                release.getTitle(),
+                createMusicGroups(release.getArtists())),
+            createMusicGroups(track.getArtists())),
         playlistId,
         googlePlaylistItem.getOrder());
   }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicExporter.java
@@ -96,14 +96,14 @@ public class GoogleMusicExporter implements Exporter<TokensAndUrlAuthData, Music
   public ExportResult<MusicContainerResource> export(
       UUID jobId, TokensAndUrlAuthData authData, Optional<ExportInformation> exportInformation)
       throws IOException, InvalidTokenException, PermissionDeniedException {
+    // TODO: Remove the logic when testing is finished.
     // Local demo-server test usage. Start transfer job without ExportInformation.
     // if (!exportInformation.isPresent()) {
     //   StringPaginationToken paginationToken = new StringPaginationToken(PLAYLIST_TOKEN_PREFIX);
     //   return exportPlaylists(authData, Optional.of(paginationToken), jobId);
     // }
 
-    if (exportInformation.get()
-        .getContainerResource() instanceof IdOnlyContainerResource) {
+    if (exportInformation.get().getContainerResource() instanceof IdOnlyContainerResource) {
       // if ExportInformation is an id only container, this is a request to export playlist items.
       return exportPlaylistItems(
           authData,

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicExporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicExporter.java
@@ -96,8 +96,14 @@ public class GoogleMusicExporter implements Exporter<TokensAndUrlAuthData, Music
   public ExportResult<MusicContainerResource> export(
       UUID jobId, TokensAndUrlAuthData authData, Optional<ExportInformation> exportInformation)
       throws IOException, InvalidTokenException, PermissionDeniedException {
+    // Local demo-server test usage. Start transfer job without ExportInformation.
+    // if (!exportInformation.isPresent()) {
+    //   StringPaginationToken paginationToken = new StringPaginationToken(PLAYLIST_TOKEN_PREFIX);
+    //   return exportPlaylists(authData, Optional.of(paginationToken), jobId);
+    // }
 
-    if (exportInformation.get().getContainerResource() instanceof IdOnlyContainerResource) {
+    if (exportInformation.get()
+        .getContainerResource() instanceof IdOnlyContainerResource) {
       // if ExportInformation is an id only container, this is a request to export playlist items.
       return exportPlaylistItems(
           authData,

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicHttpApi.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicHttpApi.java
@@ -59,22 +59,21 @@ import org.datatransferproject.spi.transfer.types.PermissionDeniedException;
 
 /**
  * GoogleMusicHttpApi makes HTTP requests to read and write to the public Google Music's "Music
- * Library" APIs, following its documentation at https://musiclibrary.googleapis.com/DO NOT
- * SUBMIT/TODO(critical WIP-feature step): update the URL when available.
+ * Library" APIs, following its documentation at https://developers.google.com/youtube/mediaconnect.
  *
  * <p>Note that this is the lowest level of Google Music interaction - that is, you probably don't
  * want to use this class and are better off using something like a bit higher level like the Google
  * Music DTP Exporter and Importer instead.
  */
 public class GoogleMusicHttpApi {
-  // TODO(critical WIP-feature step): Update endpoint when available
-  private static final String BASE_URL = "https://musiclibrary.googleapis.com/v1/";
+  private static final String BASE_URL =
+      "https://youtubemediaconnect.googleapis.com/v1/users/me/musicLibrary/";
   private static final int PLAYLIST_PAGE_SIZE = 20;
   private static final int PLAYLIST_ITEM_PAGE_SIZE = 50;
 
   private static final String PAGE_SIZE_KEY = "pageSize";
   private static final String TOKEN_KEY = "pageToken";
-  private static final String PLAYLIST_ID_KEY = "playlistId";
+  private static final String PARENT_KEY = "parent";
   private static final String ORIGINAL_PLAYLIST_ID_KEY = "originalPlaylistId";
   private static final String ACCESS_TOKEN_KEY = "access_token";
 
@@ -114,7 +113,7 @@ public class GoogleMusicHttpApi {
       throws IOException, InvalidTokenException, PermissionDeniedException {
     Map<String, String> params = new LinkedHashMap<>();
     params.put(PAGE_SIZE_KEY, String.valueOf(PLAYLIST_ITEM_PAGE_SIZE));
-    params.put(PLAYLIST_ID_KEY, playlistId);
+    params.put(PARENT_KEY, "playlists/" + playlistId);
     if (pageToken.isPresent()) {
       params.put(TOKEN_KEY, pageToken.get());
     }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/BatchPlaylistItemRequest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/BatchPlaylistItemRequest.java
@@ -23,38 +23,29 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Class containing all the information necessary to create new {@link GooglePlaylistItem}s in the
- * Google Music API.
+ * Class containing all the information necessary to create new {@link CreatePlaylistItemRequest}s
+ * in the Google Music API.
  */
 @JsonInclude(Include.NON_NULL)
 public class BatchPlaylistItemRequest {
 
-  @JsonProperty("playlistItems")
-  private List<GooglePlaylistItem> playlistItems;
+  @JsonProperty("requests")
+  private List<CreatePlaylistItemRequest> requests;
 
-  @JsonProperty("originalPlaylistId")
-  private String originalPlaylistId;
+  @JsonProperty("parent")
+  private String parent;
 
-  @JsonProperty("playlistToken")
-  private String playlistToken;
-
-  public BatchPlaylistItemRequest(
-      List<GooglePlaylistItem> playlistItems, String originalPlaylistId, String playlistToken) {
-    this.playlistItems = playlistItems;
-    this.originalPlaylistId = originalPlaylistId;
-    this.playlistToken = playlistToken;
+  public BatchPlaylistItemRequest(List<CreatePlaylistItemRequest> requests, String parent) {
+    this.requests = requests;
+    this.parent = parent;
   }
 
-  public List<GooglePlaylistItem> getPlaylistItems() {
-    return playlistItems;
+  public List<CreatePlaylistItemRequest> getRequests() {
+    return requests;
   }
 
-  public String getOriginalPlaylistId() {
-    return originalPlaylistId;
-  }
-
-  public String getPlaylistToken() {
-    return playlistToken;
+  public String getParent() {
+    return parent;
   }
 
   @Override
@@ -66,13 +57,11 @@ public class BatchPlaylistItemRequest {
       return false;
     }
     BatchPlaylistItemRequest that = (BatchPlaylistItemRequest) o;
-    return Objects.equals(playlistItems, that.playlistItems)
-        && Objects.equals(originalPlaylistId, that.originalPlaylistId)
-        && Objects.equals(playlistToken, that.playlistToken);
+    return Objects.equals(requests, that.requests) && Objects.equals(parent, that.parent);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getPlaylistItems(), getOriginalPlaylistId(), getPlaylistToken());
+    return Objects.hash(getRequests(), getParent());
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/CreatePlaylistItemRequest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/CreatePlaylistItemRequest.java
@@ -1,0 +1,53 @@
+package org.datatransferproject.datatransfer.google.musicModels;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Objects;
+
+public class CreatePlaylistItemRequest {
+
+  @JsonProperty("parent")
+  private String parent;
+
+  @JsonProperty("playlistItem")
+  private GooglePlaylistItem playlistItem;
+
+  public CreatePlaylistItemRequest(String parent, GooglePlaylistItem playlistItem) {
+    this.parent = parent;
+    this.playlistItem = playlistItem;
+  }
+
+  public String getParent() {
+    return parent;
+  }
+
+  public GooglePlaylistItem getPlaylistItem() {
+    return playlistItem;
+  }
+
+  public void setParent(String parent) {
+    this.parent = parent;
+  }
+
+  public void setPlaylistItem(
+      GooglePlaylistItem playlistItem) {
+    this.playlistItem = playlistItem;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CreatePlaylistItemRequest)) {
+      return false;
+    }
+    CreatePlaylistItemRequest that = (CreatePlaylistItemRequest) o;
+    return Objects.equals(parent, that.parent) && Objects.equals(playlistItem, that.playlistItem);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getParent(), getPlaylistItem());
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/GoogleArtist.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/GoogleArtist.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.datatransfer.google.musicModels;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public class GoogleArtist {
+
+  @JsonProperty("title")
+  private String title;
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof GoogleArtist)) {
+      return false;
+    }
+    GoogleArtist that = (GoogleArtist) o;
+    return Objects.equals(title, that.title);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getTitle());
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/GooglePlaylist.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/GooglePlaylist.java
@@ -35,10 +35,6 @@ public class GooglePlaylist {
   @JsonProperty("updateTime")
   private long updateTime;
 
-  // TODO(critical WIP-feature step): Rename the playlist token after we have final decision
-  @JsonProperty("token")
-  private String token;
-
   public String getName() {
     return name;
   }
@@ -59,10 +55,6 @@ public class GooglePlaylist {
     return updateTime;
   }
 
-  public String getToken() {
-    return token;
-  }
-
   public void setName(String name) {
     this.name = name;
   }
@@ -81,9 +73,5 @@ public class GooglePlaylist {
 
   public void setUpdateTime(long updateTime) {
     this.updateTime = updateTime;
-  }
-
-  public void setToken(String token) {
-    this.token = token;
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/GoogleRelease.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/GoogleRelease.java
@@ -29,34 +29,34 @@ public class GoogleRelease {
   @JsonProperty("icpn")
   private String icpn;
 
-  @JsonProperty("releaseTitle")
-  private String releaseTitle;
+  @JsonProperty("title")
+  private String title;
 
-  @JsonProperty("artistTitles")
-  private String[] artistTitles;
+  @JsonProperty("artists")
+  private GoogleArtist[] artists;
 
   public String getIcpn() {
     return icpn;
   }
 
-  public String getReleaseTitle() {
-    return releaseTitle;
+  public String getTitle() {
+    return title;
   }
 
-  public String[] getArtistTitles() {
-    return artistTitles;
+  public GoogleArtist[] getArtists() {
+    return artists;
   }
 
   public void setIcpn(String icpn) {
     this.icpn = icpn;
   }
 
-  public void setReleaseTitle(String releaseTitle) {
-    this.releaseTitle = releaseTitle;
+  public void setReleaseTitle(String title) {
+    this.title = title;
   }
 
-  public void setArtistTitles(String[] artistTitles) {
-    this.artistTitles = artistTitles;
+  public void setArtistTitles(GoogleArtist[] artists) {
+    this.artists = artists;
   }
 
   @Override
@@ -69,12 +69,12 @@ public class GoogleRelease {
     }
     GoogleRelease that = (GoogleRelease) o;
     return Objects.equals(icpn, that.icpn)
-        && Objects.equals(releaseTitle, that.releaseTitle)
-        && Arrays.equals(artistTitles, that.artistTitles);
+        && Objects.equals(title, that.title)
+        && Arrays.equals(artists, that.artists);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getIcpn(), getReleaseTitle(), Arrays.hashCode(getArtistTitles()));
+    return Objects.hash(getIcpn(), getTitle(), Arrays.hashCode(getArtists()));
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/GoogleTrack.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/musicModels/GoogleTrack.java
@@ -29,11 +29,11 @@ public class GoogleTrack {
   @JsonProperty("release")
   private GoogleRelease release;
 
-  @JsonProperty("trackTitle")
-  private String trackTitle;
+  @JsonProperty("title")
+  private String title;
 
-  @JsonProperty("artistTitles")
-  private String[] artistTitles;
+  @JsonProperty("artists")
+  private GoogleArtist[] artists;
 
   @JsonProperty("durationMillis")
   private long durationMillis;
@@ -46,12 +46,12 @@ public class GoogleTrack {
     return release;
   }
 
-  public String getTrackTitle() {
-    return trackTitle;
+  public String getTitle() {
+    return title;
   }
 
-  public String[] getArtistTitles() {
-    return artistTitles;
+  public GoogleArtist[] getArtists() {
+    return artists;
   }
 
   public long getDurationMillis() {
@@ -66,12 +66,12 @@ public class GoogleTrack {
     this.release = release;
   }
 
-  public void setTrackTitle(String trackTitle) {
-    this.trackTitle = trackTitle;
+  public void setTitle(String trackTitle) {
+    this.title = title;
   }
 
-  public void setArtistTitles(String[] artistTitles) {
-    this.artistTitles = artistTitles;
+  public void setArtists(GoogleArtist[] artists) {
+    this.artists = artists;
   }
 
   public void setDurationMillis(long durationMillis) {
@@ -89,8 +89,8 @@ public class GoogleTrack {
     GoogleTrack that = (GoogleTrack) o;
     return Objects.equals(isrc, that.isrc)
         && Objects.equals(release, that.release)
-        && Objects.equals(trackTitle, that.trackTitle)
-        && Arrays.equals(artistTitles, that.artistTitles)
+        && Objects.equals(title, that.title)
+        && Arrays.equals(artists, that.artists)
         && durationMillis == that.durationMillis;
   }
 
@@ -99,8 +99,8 @@ public class GoogleTrack {
     return Objects.hash(
         getIsrc(),
         getRelease(),
-        getTrackTitle(),
-        Arrays.hashCode(getArtistTitles()),
+        getTitle(),
+        Arrays.hashCode(getArtists()),
         getDurationMillis());
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/music/GoogleMusicImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/music/GoogleMusicImporterTest.java
@@ -245,7 +245,7 @@ public final class GoogleMusicImporterTest {
   @Test
   public void importPlaylistItemsSkippableFauilre() throws Exception {
     importPlaylistSetUp("p1_id", "p1_title");
-    
+
     MusicPlaylistItem playlistItem1 =
         new MusicPlaylistItem(
             new MusicRecording(
@@ -291,7 +291,8 @@ public final class GoogleMusicImporterTest {
     when(googleMusicHttpApi.createPlaylist(any(GooglePlaylist.class), any(String.class)))
         .thenReturn(responsePlaylist);
 
-    ImportResult importResult = googleMusicImporter.importItem(uuid, executor, null, data);
+    ImportResult importResult = googleMusicImporter.importItem(uuid, executor, null /*authData*/,
+        data);
   }
 
   private GooglePlaylistItem buildGooglePlaylistItem(String trackIsrc, String releaseIcpn) {

--- a/portability-types-common/src/main/java/org/datatransferproject/types/common/models/DataVertical.java
+++ b/portability-types-common/src/main/java/org/datatransferproject/types/common/models/DataVertical.java
@@ -16,6 +16,7 @@ public enum DataVertical {
   CONTACTS("CONTACTS"),
   MAIL("MAIL"),
   MEDIA("MEDIA"),
+  MUSIC("MUSIC"),
   NOTES("NOTES"),
   OFFLINE_DATA("OFFLINE-DATA"),
   PHOTOS("PHOTOS"),


### PR DESCRIPTION
- With the latest change in Youtube Music Library Public API, we need to make the same change to google music models.
- We will not the insertion token for playlist anymore. Remove cache mapping in import adapter. 
- Add music to demo server.