### PR TITLE
Made GoogleAlbum serializable; added test to check serializability

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleAlbum.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleAlbum.java
@@ -17,11 +17,12 @@
 package org.datatransferproject.datatransfer.google.mediaModels;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 
 /**
  * Class representing an album as returned by the Google Photos API.
  */
-public class GoogleAlbum {
+public class GoogleAlbum implements Serializable {
   @JsonProperty("id")
   private String id;
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleAlbumTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleAlbumTest.java
@@ -1,0 +1,40 @@
+package org.datatransferproject.datatransfer.google.mediaModels;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.Date;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.junit.Test;
+public class GoogleAlbumTest {
+  private static final ObjectMapper mapper = new ObjectMapper()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @Test
+  public void googleAlbum_isSerializable() {
+    String googleAlbumStringJSON = "{\"id\":\"test_id\", \"title\":\"test_title\", \"isWriteable\":true, \"mediaItemsCount\":10}";
+    boolean serializable = true;
+    // Turning an object into a byte array can only be done if the class is serializable.
+    try {
+      GoogleAlbum googleAlbum = mapper.readValue(googleAlbumStringJSON, GoogleAlbum.class);
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      ObjectOutputStream oos = new ObjectOutputStream(bos);
+      oos.writeObject(googleAlbum);
+      oos.flush();
+      byte [] data = bos.toByteArray();
+    } catch (Exception e ) {
+      serializable = false;
+    }
+    assertTrue(serializable);
+  }
+
+}


### PR DESCRIPTION
Necessary for wrapping our GooglePhotosInterface responses with the RetryingIdempotentExecutor