### PR TITLE
add Apple DTP import operation group

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/AppleConstants.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/AppleConstants.java
@@ -26,4 +26,6 @@ public class AppleConstants {
   public static final String DTP_SERVICE_ID = "Apple";
   public static final String APPLE_KEY = "APPLE_KEY";
   public static final String APPLE_SECRET = "APPLE_SECRET";
+
+  public static final String DTP_IMPORT_OPERATION_GROUP = "DTP%20Import";
 }

--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/Headers.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/Headers.java
@@ -25,7 +25,8 @@ import org.jetbrains.annotations.Nullable;
 public enum Headers {
   AUTHORIZATION("Authorization"),
   CORRELATION_ID("X-Apple-Request-UUID"),
-  CONTENT_TYPE("Content-Type");
+  CONTENT_TYPE("Content-Type"),
+  OPERATION_GROUP("x-apple-operation-group-name");
 
 
   private final String value;

--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/photos/streaming/StreamingContentClient.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/photos/streaming/StreamingContentClient.java
@@ -27,7 +27,9 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.datatransfer.apple.constants.AppleConstants;
 import org.datatransferproject.datatransfer.apple.constants.ApplePhotosConstants;
+import org.datatransferproject.datatransfer.apple.constants.Headers;
 import org.datatransferproject.datatransfer.apple.exceptions.AppleContentException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -66,6 +68,7 @@ public class StreamingContentClient {
       connection.setDoInput(true);
       connection.setChunkedStreamingMode(ApplePhotosConstants.contentRequestLength);
       connection.setRequestMethod("POST");
+      connection.setRequestProperty(Headers.OPERATION_GROUP.getValue(), AppleConstants.DTP_IMPORT_OPERATION_GROUP);
       outputStream = new DataOutputStream(connection.getOutputStream());
     } else {
       connection.setRequestMethod("GET");


### PR DESCRIPTION
Add operation group in the content upload request so that Apple can analyze the capacity of DTP Import usage.