### PR TITLE
add Retry and skip logic in AppleMediaImporter

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/AppleTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/AppleTransferExtension.java
@@ -33,6 +33,8 @@ import org.datatransferproject.datatransfer.apple.photos.ApplePhotosImporter;
 import org.datatransferproject.datatransfer.apple.photos.AppleVideosImporter;
 import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
 import org.datatransferproject.spi.transfer.extension.TransferExtension;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutorExtension;
 import org.datatransferproject.spi.transfer.provider.Exporter;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.types.common.models.DataVertical;
@@ -86,11 +88,15 @@ public class AppleTransferExtension implements TransferExtension {
       return;
     }
 
+    IdempotentImportExecutor idempotentImportExecutor = context.getService(
+            IdempotentImportExecutorExtension.class).getRetryingIdempotentImportExecutor(context);
+    boolean enableRetrying = context.getSetting("enableRetrying", false);
+
     importerMap =
         ImmutableMap.<DataVertical, Importer>builder()
             .put(PHOTOS, new ApplePhotosImporter(appCredentials, monitor))
             .put(VIDEOS, new AppleVideosImporter(appCredentials, monitor))
-            .put(MEDIA, new AppleMediaImporter(appCredentials, monitor))
+            .put(MEDIA, new AppleMediaImporter(appCredentials, monitor, idempotentImportExecutor, enableRetrying))
             .build();
 
     exporterMap = ImmutableMap.<DataVertical, Exporter>builder().build();

--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/ApplePhotosConstants.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/ApplePhotosConstants.java
@@ -30,4 +30,5 @@ public class ApplePhotosConstants {
   public static final Long maxMediaTransferByteSize = 50_000_000_000L;
   public static final String BYTES_KEY = "bytes";
   public static final String COUNT_KEY = "count";
+  public static final String APPLE_PHOTOS_IMPORT_ERROR_PREFIX = "APPLE PHOTOS IMPORT:";
 }

--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/AuditKeys.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/constants/AuditKeys.java
@@ -65,6 +65,7 @@ public enum AuditKeys {
   transactionId,
   updatedTimeInMs,
   uri,
+  uploadUrl,
   value,
   error,
 }

--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/photos/AppleMediaImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/photos/AppleMediaImporter.java
@@ -18,12 +18,18 @@ package org.datatransferproject.datatransfer.apple.photos;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.datatransferproject.api.launcher.Monitor;
 import org.datatransferproject.datatransfer.apple.AppleInterfaceFactory;
 import org.datatransferproject.datatransfer.apple.constants.ApplePhotosConstants;
 import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.idempotentexecutor.RetryingInMemoryIdempotentImportExecutor;
 import org.datatransferproject.spi.transfer.provider.ImportResult;
 import org.datatransferproject.spi.transfer.provider.Importer;
 import org.datatransferproject.transfer.JobMetadata;
@@ -31,7 +37,12 @@ import org.datatransferproject.types.common.models.DataVertical;
 import org.datatransferproject.types.common.models.media.MediaContainerResource;
 import org.datatransferproject.types.transfer.auth.AppCredentials;
 import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.datatransferproject.types.transfer.errors.ErrorDetail;
 import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+import static java.lang.String.format;
 
 /**
  * An Apple importer to import the Photos and Videos into Apple iCloud-photos.
@@ -41,20 +52,26 @@ public class AppleMediaImporter implements Importer<TokensAndUrlAuthData, MediaC
   private final String exportingService;
   private final Monitor monitor;
   private final AppleInterfaceFactory factory;
+  private IdempotentImportExecutor retryingIdempotentExecutor;
+  private Boolean enableRetrying;
 
   public AppleMediaImporter(
-      @NotNull final AppCredentials appCredentials, @NotNull final Monitor monitor) {
-    this(appCredentials, JobMetadata.getExportService(), monitor, new AppleInterfaceFactory());
+      @NotNull final AppCredentials appCredentials, @NotNull final Monitor monitor, @Nullable IdempotentImportExecutor retryingIdempotentExecutor, boolean enableRetrying) {
+    this(appCredentials, JobMetadata.getExportService(), monitor, new AppleInterfaceFactory(), retryingIdempotentExecutor, enableRetrying);
   }
 
   @VisibleForTesting
   AppleMediaImporter(
     @NotNull final AppCredentials appCredentials, @NotNull  String exportingService,
-    @NotNull final Monitor monitor, @NotNull  AppleInterfaceFactory factory) {
+    @NotNull final Monitor monitor, @NotNull  AppleInterfaceFactory factory,
+    @Nullable IdempotentImportExecutor retryingIdempotentExecutor,
+    boolean enableRetrying) {
     this.appCredentials = appCredentials;
     this.exportingService = exportingService;
     this.monitor = monitor;
     this.factory = factory;
+    this.retryingIdempotentExecutor = retryingIdempotentExecutor;
+    this.enableRetrying = enableRetrying;
   }
   @Override
   public ImportResult importItem(
@@ -67,38 +84,77 @@ public class AppleMediaImporter implements Importer<TokensAndUrlAuthData, MediaC
       return ImportResult.OK;
     }
 
+    IdempotentImportExecutor executor =
+            (retryingIdempotentExecutor != null && enableRetrying) ? retryingIdempotentExecutor : idempotentExecutor;
+
     AppleMediaInterface mediaInterface = factory
       .getOrCreateMediaInterface(jobId, authData, appCredentials, exportingService, monitor);
 
-    final int albumCount =
-        mediaInterface.importAlbums(
-            jobId,
-            idempotentExecutor,
-            data.getAlbums(),
-          DataVertical.MEDIA.getDataType());
-    final Map<String, Long> importPhotosMap =
-        mediaInterface.importAllMedia(
-            jobId,
-            idempotentExecutor,
-            data.getPhotos(),
-          DataVertical.MEDIA.getDataType());
-    final Map<String, Long> importVideosResult =
-        mediaInterface.importAllMedia(
-            jobId,
-            idempotentExecutor,
-            data.getVideos(),
-          DataVertical.MEDIA.getDataType());
+    final String retryId = format("AppleMediaImporter_%s_%s", jobId, UUID.randomUUID());
 
-    final Map<String, Integer> counts =
-        new ImmutableMap.Builder<String, Integer>()
-            .put(MediaContainerResource.ALBUMS_COUNT_DATA_NAME, albumCount)
-            .put(
-                MediaContainerResource.PHOTOS_COUNT_DATA_NAME,
-                importPhotosMap.getOrDefault(ApplePhotosConstants.COUNT_KEY, 0L).intValue())
-            .put(
-                MediaContainerResource.VIDEOS_COUNT_DATA_NAME,
-                importVideosResult.getOrDefault(ApplePhotosConstants.COUNT_KEY, 0L).intValue())
-            .build();
+    final Map<String, Long> importPhotosMap = new HashMap<>();
+    final Map<String, Long> importVideosResult = new HashMap<>();
+    final Map<String, Integer> counts = new HashMap<>();
+
+    // lower stack retry logic in data copier will not handle the skippable error case, that's why we want to build retry logic in importer itself.
+
+    // executor can either be a RetryingInMemoryIdempotentImportExecutor or an InMemoryIdempotentImportExecutor
+    // RetryingInMemoryIdempotentImportExecutor will return null for skippable error, throw for the others
+    // InMemoryIdempotentImportExecutor will throw every error (the callableImporter will throw it as well if we don't throw it here)
+
+    // if executor is a RetryingInMemoryIdempotentImportExecutor, then it will be different from the idempotentExecutor in the param, which will check for recent errors in lower stack (CallableImporter),
+    // So if the error in executor is skippable, we need to clean the errors in idempotentExecutor to make sure they will not be thrown in the lower stack.
+
+    executor.executeOrThrowException(retryId, retryId, () -> {
+      importPhotosMap.clear();
+      importVideosResult.clear();
+      counts.clear();
+      idempotentExecutor.resetRecentErrors();
+
+      final int albumCount =
+              mediaInterface.importAlbums(
+                      jobId,
+                      idempotentExecutor,
+                      data.getAlbums(),
+                      DataVertical.MEDIA.getDataType());
+      importPhotosMap.putAll(
+              mediaInterface.importAllMedia(
+                      jobId,
+                      idempotentExecutor,
+                      data.getPhotos(),
+                      DataVertical.MEDIA.getDataType()));
+      importVideosResult.putAll(
+              mediaInterface.importAllMedia(
+                      jobId,
+                      idempotentExecutor,
+                      data.getVideos(),
+                      DataVertical.MEDIA.getDataType()));
+      counts.putAll(
+              new ImmutableMap.Builder<String, Integer>()
+                      .put(MediaContainerResource.ALBUMS_COUNT_DATA_NAME, albumCount)
+                      .put(
+                              MediaContainerResource.PHOTOS_COUNT_DATA_NAME,
+                              importPhotosMap.getOrDefault(ApplePhotosConstants.COUNT_KEY, 0L).intValue())
+                      .put(
+                              MediaContainerResource.VIDEOS_COUNT_DATA_NAME,
+                              importVideosResult.getOrDefault(ApplePhotosConstants.COUNT_KEY, 0L).intValue())
+                      .build());
+
+      Collection<ErrorDetail> errors = idempotentExecutor.getRecentErrors();
+      if (!errors.isEmpty() && executor instanceof RetryingInMemoryIdempotentImportExecutor) { // throw the error for retryExecutor to retry, only include the actual error message, but not the stack traces
+        throw new IOException(errors.iterator().hasNext() ? errors.iterator().next().exception().lines().findFirst().get() : ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX + " Unknown Error");
+      }
+      return true;
+    });
+
+    // if retryingExecutor thinks the errors are skippable, we need to clean the errors in idempotentExecutor to make sure they will not be thrown in the lower stack.
+    // (Notice that lower stack CallableImporter does not have skip logic)
+    if(executor instanceof RetryingInMemoryIdempotentImportExecutor) {
+      Collection<ErrorDetail> recentErrorsFromRetryingExecutor = executor.getRecentErrors();
+      if (!recentErrorsFromRetryingExecutor.isEmpty() && recentErrorsFromRetryingExecutor.iterator().hasNext() && recentErrorsFromRetryingExecutor.stream().allMatch(errorDetail -> errorDetail.canSkip())) {
+        idempotentExecutor.resetRecentErrors();
+      }
+    }
 
     return ImportResult.OK
         .copyWithBytes(

--- a/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/photos/AppleMediaInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/main/java/org/datatransferproject/datatransfer/apple/photos/AppleMediaInterface.java
@@ -192,13 +192,11 @@ public class AppleMediaInterface implements AppleBaseInterface {
           totalSize += data.length;
 
           if (totalSize > ApplePhotosConstants.maxMediaTransferByteSize) {
-            monitor.severe(
-              () -> "file too large to import to Apple: ",
-              AuditKeys.dataId, dataId,
-              AuditKeys.downloadURL, downloadURL,
-              authorizeUploadResponse.getUploadUrl());
             uploadClient.completeUpload();
-            throw new AppleContentException("file too large to import to Apple");
+            throw new AppleContentException(getApplePhotosImportThrowingMessage("file too large to import to Apple", ImmutableMap.of(
+                    AuditKeys.dataId, dataId,
+                    AuditKeys.downloadURL, downloadURL,
+                    AuditKeys.uploadUrl, authorizeUploadResponse.getUploadUrl())));
           }
 
           uploadClient.uploadBytes(data);
@@ -283,19 +281,19 @@ public class AppleMediaInterface implements AppleBaseInterface {
 
     switch (con.getResponseCode()) {
       case SC_UNAUTHORIZED:
-        throw new UnconfirmedUserException("Unauthorized iCloud User", e);
+        throw new UnconfirmedUserException(getApplePhotosImportThrowingMessage("Unauthorized iCloud User"), e);
       case SC_PRECONDITION_FAILED:
-        throw new PermissionDeniedException("Permission Denied", e);
+        throw new PermissionDeniedException(getApplePhotosImportThrowingMessage("Permission Denied"), e);
       case SC_NOT_FOUND:
-        throw new DestinationNotFoundException("iCloud Photos Library not found", e);
+        throw new DestinationNotFoundException(getApplePhotosImportThrowingMessage("iCloud Photos Library not found"), e);
       case SC_INSUFFICIENT_STORAGE:
-        throw new DestinationMemoryFullException("iCloud Storage is full", e);
+        throw new DestinationMemoryFullException(getApplePhotosImportThrowingMessage("iCloud Storage is full"), e);
       case SC_SERVICE_UNAVAILABLE:
-        throw new IOException("DTP import service unavailable", e);
+        throw new IOException(getApplePhotosImportThrowingMessage("DTP import service unavailable"), e);
       case SC_BAD_REQUEST:
-        throw new IOException("Bad request sent to iCloud Photos import api", e);
+        throw new IOException(getApplePhotosImportThrowingMessage("Bad request sent to iCloud Photos import api"), e);
       case SC_INTERNAL_SERVER_ERROR:
-        throw new IOException("Internal server error in iCloud Photos service", e);
+        throw new IOException(getApplePhotosImportThrowingMessage("Internal server error in iCloud Photos service"), e);
       case SC_OK:
         break;
       default:
@@ -323,7 +321,7 @@ public class AppleMediaInterface implements AppleBaseInterface {
     return responseData;
   }
 
-  private void refreshTokens() throws IOException, InvalidTokenException {
+  private void refreshTokens() throws InvalidTokenException {
     final String refreshToken = authData.getRefreshToken();
     final String refreshUrlString = authData.getTokenServerEncodedUrl();
     final String clientId = appCredentials.getKey();
@@ -351,9 +349,7 @@ public class AppleMediaInterface implements AppleBaseInterface {
 
     } catch (ParseException | IOException | CopyExceptionWithFailureReason e) {
 
-      monitor.debug(() -> "Failed to refresh token", e);
-
-      throw new InvalidTokenException("Unable to refresh token", e);
+      throw new InvalidTokenException(getApplePhotosImportThrowingMessage("Unable to refresh token"), e);
     }
   }
 
@@ -442,16 +438,11 @@ public class AppleMediaInterface implements AppleBaseInterface {
             mediaAlbum.getId(),
             mediaAlbum.getName(),
             () -> {
-              monitor.severe(
-                () -> "Error importing album: ",
-                AuditKeys.jobId, jobId,
-                AuditKeys.albumId, mediaAlbum.getId(),
-                AuditKeys.errorCode, newPhotoAlbumResponse.getStatus().getCode());
-
-              throw new IOException(
-                String.format(
-                  "Failed to create album, error code: %d",
-                  newPhotoAlbumResponse.getStatus().getCode()));
+              throw new IOException(getApplePhotosImportThrowingMessage("Fail to create album",
+                      ImmutableMap.of(
+                              AuditKeys.errorCode, String.valueOf(newPhotoAlbumResponse.getStatus().getCode()),
+                              AuditKeys.jobId, jobId.toString(),
+                              AuditKeys.albumId, mediaAlbum.getId())));
             });
         }
       }
@@ -530,16 +521,13 @@ public class AppleMediaInterface implements AppleBaseInterface {
           downloadableFile.getIdempotentId(),
           downloadableFile.getName(),
           () -> {
-            monitor.severe(
-              () -> "Fail to get upload url: ",
-              AuditKeys.jobId, jobId,
-              AuditKeys.dataId, getDataId(downloadableFile),
-              AuditKeys.albumId, downloadableFile.getFolderId(),
-              AuditKeys.statusCode, authorizeUploadResponse.getStatus().getCode());
             throw new IOException(
-              String.format(
-                "Fail to get upload url, error code: %d",
-                authorizeUploadResponse.getStatus().getCode()));
+                    getApplePhotosImportThrowingMessage(
+                            "Fail to get upload url", ImmutableMap.of(
+                                    AuditKeys.errorCode, String.valueOf(authorizeUploadResponse.getStatus().getCode()),
+                                    AuditKeys.jobId, jobId.toString(),
+                                    AuditKeys.dataId, getDataId(downloadableFile),
+                                    AuditKeys.albumId, downloadableFile.getFolderId())));
           });
       }
     }
@@ -564,12 +552,11 @@ public class AppleMediaInterface implements AppleBaseInterface {
           downloadableFile.getIdempotentId(),
           downloadableFile.getName(),
           () -> {
-            monitor.severe(
-              () -> "Fail to upload content: ",
-              AuditKeys.jobId, jobId,
-              AuditKeys.dataId, getDataId(downloadableFile),
-              AuditKeys.albumId, downloadableFile.getFolderId());
-            throw new IOException("Fail to upload content");
+            throw new IOException(getApplePhotosImportThrowingMessage("Fail to upload content", ImmutableMap.of(
+                    AuditKeys.jobId, jobId.toString(),
+                    AuditKeys.dataId, getDataId(downloadableFile),
+                    AuditKeys.albumId, downloadableFile.getFolderId()
+            )));
           });
       }
     }
@@ -641,16 +628,13 @@ public class AppleMediaInterface implements AppleBaseInterface {
           downloadableFile.getIdempotentId(),
           downloadableFile.getName(),
           () -> {
-            monitor.severe(
-              () -> "Fail to create media: ",
-              AuditKeys.jobId, jobId,
-              AuditKeys.dataId, getDataId(downloadableFile),
-              AuditKeys.albumId, downloadableFile.getFolderId(),
-              AuditKeys.statusCode, newMediaResponse.getStatus().getCode());
             throw new IOException(
-              String.format(
-                "Fail to create media, error code: %d",
-                newMediaResponse.getStatus().getCode()));
+                    getApplePhotosImportThrowingMessage(
+                "Fail to create media", ImmutableMap.of(
+                            AuditKeys.errorCode, String.valueOf(newMediaResponse.getStatus().getCode()),
+                            AuditKeys.jobId, jobId.toString(),
+                            AuditKeys.dataId, getDataId(downloadableFile),
+                            AuditKeys.albumId, downloadableFile.getFolderId())));
           });
       }
     }
@@ -695,5 +679,17 @@ public class AppleMediaInterface implements AppleBaseInterface {
       return ((VideoModel) downloadableFile).getDescription();
     }
     return null;
+  }
+
+  public static String getApplePhotosImportThrowingMessage(final String cause) {
+    return getApplePhotosImportThrowingMessage(cause, ImmutableMap.of());
+  }
+
+  public static String getApplePhotosImportThrowingMessage(final String cause, final ImmutableMap<AuditKeys, String> keyValuePairs) {
+    String finalLogMessage = String.format("%s " + cause, ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX);
+    for (AuditKeys key: keyValuePairs.keySet()){
+      finalLogMessage = String.format("%s, %s:%s", finalLogMessage, key.name(), keyValuePairs.get(key));
+    }
+    return finalLogMessage;
   }
 }

--- a/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/photos/AppleImporterTestBase.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/photos/AppleImporterTestBase.java
@@ -161,7 +161,7 @@ public class AppleImporterTestBase {
                 });
   }
 
-  protected void setUpCreateMediaResponse(@NotNull final Map<String, Integer> datatIdToStatus)
+  protected void setUpCreateMediaResponse(@NotNull final Map<String, Integer> dataIdToStatus)
       throws IOException, CopyExceptionWithFailureReason {
     when(mediaInterface.createMedia(any(String.class), any(String.class), any(List.class)))
         .thenAnswer(
@@ -185,7 +185,7 @@ public class AppleImporterTestBase {
                                       .setStatus(
                                           PhotosProtocol.Status.newBuilder()
                                               .setCode(
-                                                  datatIdToStatus.get(newMediaRequest.getDataId()))
+                                                  dataIdToStatus.get(newMediaRequest.getDataId()))
                                               .build())
                                       .build())
                           .collect(Collectors.toList());
@@ -220,7 +220,7 @@ public class AppleImporterTestBase {
     final Map<String, ErrorDetail> actualIdToErrorDetail =
         executor.getErrors().stream()
             .collect(Collectors.toMap(ErrorDetail::id, errorDetail -> errorDetail));
-    assertThat(actualIdToErrorDetail.size() == expected.size());
+    assertThat(actualIdToErrorDetail.size() == expected.size()).isTrue();
     for (ErrorDetail expectedErrorDetail : expected) {
       validateError(expectedErrorDetail, actualIdToErrorDetail.get(expectedErrorDetail.id()));
     }
@@ -230,7 +230,7 @@ public class AppleImporterTestBase {
     final Map<String, ErrorDetail> actualIdToErrorDetail =
         executor.getRecentErrors().stream()
             .collect(Collectors.toMap(ErrorDetail::id, errorDetail -> errorDetail));
-    assertThat(actualIdToErrorDetail.size() == expected.size());
+    assertThat(actualIdToErrorDetail.size() == expected.size()).isTrue();
     for (ErrorDetail expectedErrorDetail : expected) {
       validateError(expectedErrorDetail, actualIdToErrorDetail.get(expectedErrorDetail.id()));
     }
@@ -240,7 +240,7 @@ public class AppleImporterTestBase {
       @NotNull final ErrorDetail expected, @NotNull final ErrorDetail actual) {
     assertThat(actual.id()).isEqualTo(expected.id());
     assertThat(actual.title()).isEqualTo(expected.title());
-    assertThat(actual.exception()).startsWith(expected.exception()); // the error message is a long stack trace, we just want to make sure
+    assertThat(actual.exception()).contains(expected.exception()); // the error message is a long stack trace, we just want to make sure
     // we have the right error code and error message
   }
 

--- a/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/photos/ApplePhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/photos/ApplePhotosImporterTest.java
@@ -264,7 +264,8 @@ public class ApplePhotosImporterTest extends AppleImporterTestBase {
               .setTitle(ALBUM_NAME_BASE + i)
               .setException(
                   String.format(
-                      "java.io.IOException: Failed to create album, error code: %d",
+                      "java.io.IOException: %s Fail to create album, errorCode:%d",
+                      ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX,
                       SC_INTERNAL_SERVER_ERROR))
               .build();
       expectedErrors.add(errorDetail);
@@ -459,19 +460,22 @@ public class ApplePhotosImporterTest extends AppleImporterTestBase {
               .setTitle(photoModel.getTitle())
               .setException(
                   String.format(
-                      "java.io.IOException: Fail to get upload url, error code: %d",
+                      "java.io.IOException: %s Fail to get upload url, errorCode:%d",
+                      ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX,
                       SC_INTERNAL_SERVER_ERROR));
       if (i < errorCountGetUploadURL) {
         errorDetailBuilder.setException(
             String.format(
-                "java.io.IOException: Fail to get upload url, error code: %d",
+                "java.io.IOException: %s Fail to get upload url, errorCode:%d",
+                ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX,
                 SC_INTERNAL_SERVER_ERROR));
       } else if (i < errorCountGetUploadURL + errorCountGetUploadURL) {
-        errorDetailBuilder.setException("java.io.IOException: Fail to upload content");
+        errorDetailBuilder.setException(String.format("java.io.IOException: %s Fail to upload content", ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX));
       } else {
         errorDetailBuilder.setException(
             String.format(
-                "java.io.IOException: Fail to create media, error code: %d",
+                "java.io.IOException: %s Fail to create media, errorCode:%d",
+                ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX,
                 SC_INTERNAL_SERVER_ERROR));
       }
       expectedErrors.add(errorDetailBuilder.build());

--- a/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/photos/AppleVideosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/photos/AppleVideosImporterTest.java
@@ -205,20 +205,25 @@ public class AppleVideosImporterTest extends AppleImporterTestBase {
               .setTitle(video.getName())
               .setException(
                   String.format(
-                      "java.io.IOException: Fail to get upload url, error code: %d",
+                      "java.io.IOException: %s Fail to get upload url, errorCode:%d",
+                      ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX,
                       SC_INTERNAL_SERVER_ERROR));
       if (i < errorCountGetUploadURL) {
         errorDetailBuilder.setException(
             String.format(
-                "java.io.IOException: Fail to get upload url, error code: %d",
+                "java.io.IOException: %s Fail to get upload url, errorCode:%d",
+                ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX,
                 SC_INTERNAL_SERVER_ERROR));
       } else if (i < errorCountGetUploadURL + errorCountGetUploadURL) {
-        errorDetailBuilder.setException("java.io.IOException: Fail to upload content");
+        errorDetailBuilder.setException(String.format(
+                "java.io.IOException: %s Fail to upload content",
+                ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX));
       } else {
         errorDetailBuilder.setException(
             String.format(
-                "java.io.IOException: Fail to create media, error code: %d",
-                SC_INTERNAL_SERVER_ERROR));
+                "java.io.IOException: %s Fail to create media, errorCode:%d",
+                    ApplePhotosConstants.APPLE_PHOTOS_IMPORT_ERROR_PREFIX,
+                    SC_INTERNAL_SERVER_ERROR));
       }
       expectedErrors.add(errorDetailBuilder.build());
     }

--- a/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/photos/TestConstants.java
+++ b/extensions/data-transfer/portability-data-transfer-apple/src/test/java/org/datatransferproject/datatransfer/apple/photos/TestConstants.java
@@ -22,6 +22,8 @@ public class TestConstants {
   public static final String IMPORT_FOLDER_NAME_BASE = "Imported From ";
 
   public static final String IMPORT_ZONE_PREFIX = "IMPORT:";
+  public static final int RETRY_MAX_ATTEMPTS = 1;
+  public static final long RETRY_INTERVAL_MILLIS = 100L;
 
   public static String getImportZoneName(@NotNull String importId) {
     return IMPORT_ZONE_PREFIX + importId;


### PR DESCRIPTION
The major difficulty I met is that the IdempotentExecutor used by CallableImporter cannot be a retryable executor, so I have to use a different retryable executor in AppleMediaImporter itself.

- Use retryable executor in AppleMediaImporter
- Add Apple Photos error prefix to all errors thrown by AppleMediaInterface
- Please help add the following Apple retry strategy to the yaml config:
    - Skippable:  ".\*APPLE PHOTOS IMPORT: Fail to upload content.\*" , ".\*APPLE PHOTOS IMPORT: Fail to create album.\*", ".\*APPLE PHOTOS IMPORT: Fail to create media.\*", ".\*APPLE PHOTOS IMPORT: Fail to get upload url.\*"
    - Non-Retryable:  ".\*APPLE PHOTOS IMPORT: iCloud Photos Library not found.\*", ".\*APPLE PHOTOS IMPORT: iCloud Storage is full.\*"

