### PR TITLE
bugfix: use correct time; fix brittle unit test

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
@@ -11,6 +11,8 @@ import java.io.ObjectOutputStream;
 import static java.lang.String.format;
 import static org.junit.Assert.assertTrue;
 import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -154,32 +156,34 @@ public class GoogleMediaItemTest {
   }
 
   @Test
-  public void getUploadTime_videoModel() throws ParseException{
+  public void getUploadTime_videoModel() throws ParseException {
+    String fakePhotosApiTimestamp = "2023-10-02T22:33:38Z";
     GoogleMediaItem videoMediaItem = getVideoMediaItem();
     MediaMetadata metadata = new MediaMetadata();
     metadata.setVideo(new Video());
     // CreationTime in GoogleMediaItem is populated as uploadTime in our common models.
-    metadata.setCreationTime("2023-10-02T22:33:38Z");
+    metadata.setCreationTime(fakePhotosApiTimestamp);
     videoMediaItem.setMediaMetadata(metadata);
 
     VideoModel videoModel = GoogleMediaItem.convertToVideoModel(Optional.empty(), videoMediaItem);
 
-    assertEquals("Mon Oct 02 22:33:38 UTC 2023", videoModel.getUploadedTime().toString());
-
+    assertEquals(videoModel.getUploadedTime().toInstant(), Instant.parse(fakePhotosApiTimestamp));
   }
 
   @Test
-  public void getUploadTime_photoModel() throws ParseException{
+  public void getUploadTime_photoModel() throws ParseException {
+    String fakePhotosApiTimestamp = "2023-10-02T22:33:38Z";
+
     GoogleMediaItem photoMediaItem = getPhotoMediaItem();
     MediaMetadata metadata = new MediaMetadata();
     metadata.setPhoto(new Photo());
     // CreationTime in GoogleMediaItem is populated as uploadTime in our common models.
-    metadata.setCreationTime("2023-10-02T22:33:38Z");
+    metadata.setCreationTime(fakePhotosApiTimestamp);
     photoMediaItem.setMediaMetadata(metadata);
 
     PhotoModel photoModel = GoogleMediaItem.convertToPhotoModel(Optional.empty(), photoMediaItem);
 
-    assertEquals("Mon Oct 02 22:33:38 UTC 2023", photoModel.getUploadedTime().toString());
+    assertEquals(photoModel.getUploadedTime().toInstant(), Instant.parse(fakePhotosApiTimestamp));
   }
 
   public static GoogleMediaItem getPhotoMediaItem() {


### PR DESCRIPTION
this is fixing a single time-mishandling issue that uncovered two orthogonal problems:

- 1. "correct time" issue: json parsing dropped timezone/offset specifiers as we were using a hand-crafted formatter string. Switching us to a standard library one that accepts both `Z` alias (for greenwhich) and offsets (like `+00:00`). Gphotos api docs[a] (inlined into the code) shows we use the former, which is what the unit test uses as well.
  - this probably meant time metadata for content transferred was off by some number of due to timezone being dropped
- 2. "brittle unit test": unit test was relying on machine-specific `gradle test` behavior, so an out of the box `git checkout master` had two failing tests for me[b] but not for our github ci/cd.
   - this was due to use of `toString()` (in our assertEquals) which relies on your locale
   - fixed now as we use `java.time.Instant#equals` instead.

[a]: https://developers.google.com/photos/library/reference/rest/v1/mediaItems#mediametadata lists `creationTime` as:
> string (Timestamp format)
>
> Time when the media item was first created (not when it was uploaded
> to Google Photos).
>
> A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution
> and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and
> "2014-10-02T15:01:23.045123456Z".

[b]: local unit test failure looked like this for me (I'm in midwest US):
```
org.opentest4j.AssertionFailedError:
    expected: <Mon Oct 02 22:33:38 UTC 2023>
    but was: <Mon Oct 02 22:33:38 CDT 2023>
```