### PR TITLE
nitfix: encode high-precision stamp from docs

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItem.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItem.java
@@ -20,21 +20,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Optional;
-import org.apache.tika.Tika;
 import org.datatransferproject.types.common.models.photos.PhotoModel;
 import org.datatransferproject.types.common.models.videos.VideoModel;
+import org.apache.tika.Tika;
+import com.google.common.base.Strings;
+
 
 /** Media item returned by queries to the Google Photos API. Represents what is stored by Google. */
 public class GoogleMediaItem implements Serializable {
-  public static final Tika TIKA = new Tika();
-  private static final String DEFAULT_PHOTO_MIMETYPE = "image/jpg";
-  private static final String DEFAULT_VIDEO_MIMETYPE = "video/mp4";
+  public final static Tika TIKA = new Tika();
+  private final static String DEFAULT_PHOTO_MIMETYPE = "image/jpg";
+  private final static String DEFAULT_VIDEO_MIMETYPE = "video/mp4";
   // If Tika cannot detect the mimetype, it returns the binary mimetype. This can be considered null
   private static final String DEFAULT_BINARY_MIMETYPE = "application/octet-stream";
 
@@ -83,8 +87,8 @@ public class GoogleMediaItem implements Serializable {
     }
   }
 
-  public static VideoModel convertToVideoModel(Optional<String> albumId, GoogleMediaItem mediaItem)
-      throws ParseException {
+  public static VideoModel convertToVideoModel(
+      Optional<String> albumId, GoogleMediaItem mediaItem) throws ParseException{
     Preconditions.checkArgument(mediaItem.isVideo());
 
     return new VideoModel(
@@ -98,8 +102,8 @@ public class GoogleMediaItem implements Serializable {
         getCreationTime(mediaItem));
   }
 
-  public static PhotoModel convertToPhotoModel(Optional<String> albumId, GoogleMediaItem mediaItem)
-      throws ParseException {
+  public static PhotoModel convertToPhotoModel (
+      Optional<String> albumId, GoogleMediaItem mediaItem) throws ParseException{
     Preconditions.checkArgument(mediaItem.isPhoto());
 
     return new PhotoModel(
@@ -109,8 +113,8 @@ public class GoogleMediaItem implements Serializable {
         getMimeType(mediaItem),
         mediaItem.getId(),
         albumId.orElse(null),
-        false /*inTempStore*/,
-        null /*sha1*/,
+        false  /*inTempStore*/,
+        null  /*sha1*/,
         getCreationTime(mediaItem));
   }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItem.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItem.java
@@ -17,6 +17,7 @@
 package org.datatransferproject.datatransfer.google.mediaModels;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.io.File;
@@ -112,23 +113,28 @@ public class GoogleMediaItem implements Serializable {
         getMimeType(mediaItem),
         mediaItem.getId(),
         albumId.orElse(null),
-        false  /*inTempStore*/,
-        null  /*sha1*/,
+        false /*inTempStore*/,
+        null /*sha1*/,
         getCreationTime(mediaItem));
   }
 
-  private static Date parseIso8601DateTime(String zonedIso8601DateTime) throws ParseException {
+  /**
+   * Nearly identical variant of {@link Instant#parse} that, per RFC3339, is okay with either
+   * offsets or "Z" indicator.
+   */
+  @VisibleForTesting
+  public static Date parseIso8601DateTime(String zonedIso8601DateTime) throws ParseException {
     return Date.from(
         DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(zonedIso8601DateTime, Instant::from));
   }
 
   private static Date getCreationTime(GoogleMediaItem mediaItem) throws ParseException {
-    // per https://developers.google.com/photos/library/reference/rest/v1/mediaItems#mediametadata
-    // we expect an iso 8601 date-time with a timezone/offset indicator.
     // per verified backend code, this cannot be empty or null
     final String zonedIso8601DateTime = mediaItem.getMediaMetadata().getCreationTime();
 
     try {
+      // per https://developers.google.com/photos/library/reference/rest/v1/mediaItems#mediametadata
+      // we expect an iso 8601 date-time with a timezone/offset indicator.
       return parseIso8601DateTime(zonedIso8601DateTime);
     } catch (ParseException parseException) {
       throw new ParseException(

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
@@ -168,7 +168,7 @@ public class GoogleMediaItemTest {
     VideoModel videoModel = GoogleMediaItem.convertToVideoModel(Optional.empty(), videoMediaItem);
 
     assertEquals(
-        videoModel.getUploadedTime().toInstant(),
+        videoModel.getUploadedTime(),
         GoogleMediaItem.parseIso8601DateTime(fakePhotosApiTimestamp));
   }
 
@@ -186,7 +186,7 @@ public class GoogleMediaItemTest {
     PhotoModel photoModel = GoogleMediaItem.convertToPhotoModel(Optional.empty(), photoMediaItem);
 
     assertEquals(
-        photoModel.getUploadedTime().toInstant(),
+        photoModel.getUploadedTime(),
         GoogleMediaItem.parseIso8601DateTime(fakePhotosApiTimestamp));
   }
 

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
@@ -1,14 +1,18 @@
 package org.datatransferproject.datatransfer.google.mediaModels;
 
-import static java.lang.String.format;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
+import static java.lang.String.format;
+import static org.junit.Assert.assertTrue;
 import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -17,38 +21,31 @@ import org.datatransferproject.types.common.models.videos.VideoModel;
 import org.junit.Test;
 
 public class GoogleMediaItemTest {
-  private static final ObjectMapper mapper =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+  private static final ObjectMapper mapper = new ObjectMapper()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
   @Test
   public void googleMediaItem_isSerializable() {
-    String photoStringJSON =
-        "{\"cameraMake\":\"testMake\", \"cameraModel\":\"testModel\","
-            + "\"focalLength\":\"5.0\", \"apertureFNumber\":\"2.0\", \"isoEquivalent\":\"8.0\", "
-            + "\"exposureTime\":\"testExposureTime\"}";
-    String videoStringJSON =
-        "{\"cameraMake\":\"testMake\", \"cameraModel\":\"testModel\","
-            + "\"fps\": \"30\", \"status\": \"READY\"}";
-    String mediaMetadataStringJSON =
-        format("{\"photo\": %s, \"video\": %s}", photoStringJSON, videoStringJSON);
-    String googleMediaItemStringJSON =
-        format(
-            "{\"id\":\"test_id\", \"description\":\"test description\","
-                + " \"baseUrl\":\"www.testUrl.com\", \"mimeType\":\"image/png\", \"mediaMetadata\":"
-                + " %s, \"filename\":\"filename.png\", \"productUrl\":\"www.testProductUrl.com\", "
-                + "\"uploadedTime\":\"1697153355456\"}",
-            mediaMetadataStringJSON);
+    String photoStringJSON = "{\"cameraMake\":\"testMake\", \"cameraModel\":\"testModel\","
+        + "\"focalLength\":\"5.0\", \"apertureFNumber\":\"2.0\", \"isoEquivalent\":\"8.0\", "
+        + "\"exposureTime\":\"testExposureTime\"}";
+    String videoStringJSON = "{\"cameraMake\":\"testMake\", \"cameraModel\":\"testModel\","
+        + "\"fps\": \"30\", \"status\": \"READY\"}";
+    String mediaMetadataStringJSON = format("{\"photo\": %s, \"video\": %s}", photoStringJSON, videoStringJSON);
+    String googleMediaItemStringJSON = format("{\"id\":\"test_id\", \"description\":\"test description\","
+        + " \"baseUrl\":\"www.testUrl.com\", \"mimeType\":\"image/png\", \"mediaMetadata\": %s,"
+        + " \"filename\":\"filename.png\", \"productUrl\":\"www.testProductUrl.com\", "
+        + "\"uploadedTime\":\"1697153355456\"}", mediaMetadataStringJSON);
 
     boolean serializable = true;
     // Turning an object into a byte array can only be done if the class is serializable.
     try {
-      GoogleMediaItem googleMediaItem =
-          mapper.readValue(googleMediaItemStringJSON, GoogleMediaItem.class);
+      GoogleMediaItem googleMediaItem = mapper.readValue(googleMediaItemStringJSON, GoogleMediaItem.class);
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       ObjectOutputStream oos = new ObjectOutputStream(bos);
       oos.writeObject(googleMediaItem);
       oos.flush();
-      byte[] data = bos.toByteArray();
+      byte [] data = bos.toByteArray();
     } catch (Exception e) {
       serializable = false;
     }
@@ -58,14 +55,14 @@ public class GoogleMediaItemTest {
   @Test
   public void getMimeType_photoModel_mimeTypeFromFilename() throws ParseException {
     GoogleMediaItem photoMediaItem = getPhotoMediaItem();
-    Map<String, String> filenameToMimeTypeMap =
-        Map.of(
-            "file.jpg", "image/jpeg",
-            "file.png", "image/png",
-            "file.gif", "image/gif",
-            "file.webp", "image/webp");
+    Map<String, String> filenameToMimeTypeMap = Map.of(
+        "file.jpg", "image/jpeg",
+        "file.png", "image/png",
+        "file.gif", "image/gif",
+        "file.webp", "image/webp"
+    );
 
-    for (Entry entry : filenameToMimeTypeMap.entrySet()) {
+    for (Entry entry: filenameToMimeTypeMap.entrySet()) {
       photoMediaItem.setMimeType("INVALID_MIME");
       photoMediaItem.setFilename(entry.getKey().toString());
 
@@ -76,7 +73,7 @@ public class GoogleMediaItemTest {
   }
 
   @Test
-  public void getMimeType_videoModel_mimeTypeFromFilename() throws ParseException {
+  public void getMimeType_videoModel_mimeTypeFromFilename() throws ParseException{
     GoogleMediaItem videoMediaItem = getVideoMediaItem();
     Map<String, String> filenameToMimeTypeMap =
         Map.of(
@@ -89,18 +86,19 @@ public class GoogleMediaItemTest {
             "file.wmv", "video/x-ms-wmv",
             "file.3gp", "video/3gpp");
 
-    for (Entry entry : filenameToMimeTypeMap.entrySet()) {
+    for (Entry entry: filenameToMimeTypeMap.entrySet()) {
       videoMediaItem.setMimeType("INVALID_MIME");
       videoMediaItem.setFilename(entry.getKey().toString());
 
-      VideoModel videoModel = GoogleMediaItem.convertToVideoModel(Optional.empty(), videoMediaItem);
+      VideoModel videoModel = GoogleMediaItem.convertToVideoModel(Optional.empty(),
+          videoMediaItem);
 
       assertEquals(entry.getValue(), videoModel.getMimeType());
     }
   }
 
   @Test
-  public void getMimeType_photoModel_filenameMimeTypeIsNull() throws ParseException {
+  public void getMimeType_photoModel_filenameMimeTypeIsNull() throws ParseException{
     GoogleMediaItem photoMediaItem = getPhotoMediaItem();
     photoMediaItem.setFilename("file");
     photoMediaItem.setMimeType("image/webp");
@@ -111,7 +109,7 @@ public class GoogleMediaItemTest {
   }
 
   @Test
-  public void getMimeType_videoModel_filenameMimeTypeIsNull() throws ParseException {
+  public void getMimeType_videoModel_filenameMimeTypeIsNull() throws ParseException{
     GoogleMediaItem videoMediaItem = getVideoMediaItem();
     videoMediaItem.setFilename("file");
     videoMediaItem.setMimeType("video/webm");
@@ -122,7 +120,7 @@ public class GoogleMediaItemTest {
   }
 
   @Test
-  public void getMimeType_photoModel_nullMimeTypeReturnsDefault() throws ParseException {
+  public void getMimeType_photoModel_nullMimeTypeReturnsDefault() throws ParseException{
     GoogleMediaItem photoMediaItem = getPhotoMediaItem();
     photoMediaItem.setFilename("file");
     photoMediaItem.setMimeType(null);
@@ -134,7 +132,7 @@ public class GoogleMediaItemTest {
   }
 
   @Test
-  public void getMimeType_videoModel_nullMimeTypeReturnsDefault() throws ParseException {
+  public void getMimeType_videoModel_nullMimeTypeReturnsDefault() throws ParseException{
     GoogleMediaItem videoMediaItem = getVideoMediaItem();
     videoMediaItem.setFilename("file");
     videoMediaItem.setMimeType(null);
@@ -146,7 +144,7 @@ public class GoogleMediaItemTest {
   }
 
   @Test
-  public void getMimeType_photoModel_unsupportedFileExtension() throws ParseException {
+  public void getMimeType_photoModel_unsupportedFileExtension() throws ParseException{
     GoogleMediaItem photoMediaItem = getPhotoMediaItem();
     photoMediaItem.setFilename("file.avif");
     photoMediaItem.setMimeType("image/png");

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
@@ -11,6 +11,8 @@ import java.io.ObjectOutputStream;
 import static java.lang.String.format;
 import static org.junit.Assert.assertTrue;
 import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -154,32 +156,34 @@ public class GoogleMediaItemTest {
   }
 
   @Test
-  public void getUploadTime_videoModel() throws ParseException{
+  public void getUploadTime_videoModel() throws ParseException {
+    String fakePhotosApiTimestamp = "2023-10-02T22:33:38Z";
     GoogleMediaItem videoMediaItem = getVideoMediaItem();
     MediaMetadata metadata = new MediaMetadata();
     metadata.setVideo(new Video());
     // CreationTime in GoogleMediaItem is populated as uploadTime in our common models.
-    metadata.setCreationTime("2023-10-02T22:33:38Z");
+    metadata.setCreationTime(fakePhotosApiTimestamp);
     videoMediaItem.setMediaMetadata(metadata);
 
     VideoModel videoModel = GoogleMediaItem.convertToVideoModel(Optional.empty(), videoMediaItem);
 
-    assertEquals("Mon Oct 02 22:33:38 UTC 2023", videoModel.getUploadedTime().toString());
-
+    assertEquals(videoModel.getUploadedTime().toInstant(), Instant.parse(fakePhotosApiTimestamp));
   }
 
   @Test
-  public void getUploadTime_photoModel() throws ParseException{
+  public void getUploadTime_photoModel() throws ParseException {
+    String fakePhotosApiTimestamp = "2023-10-02T22:33:38Z";
+
     GoogleMediaItem photoMediaItem = getPhotoMediaItem();
     MediaMetadata metadata = new MediaMetadata();
     metadata.setPhoto(new Photo());
     // CreationTime in GoogleMediaItem is populated as uploadTime in our common models.
-    metadata.setCreationTime("2023-10-02T22:33:38Z");
+    metadata.setCreationTime(fakePhotosApiTimestamp);
     photoMediaItem.setMediaMetadata(metadata);
 
     PhotoModel photoModel = GoogleMediaItem.convertToPhotoModel(Optional.empty(), photoMediaItem);
 
-    assertEquals("Mon Oct 02 22:33:38 UTC 2023", photoModel.getUploadedTime().toString());
+    assertEquals(photoModel.getUploadedTime().toInstant(), Instant.parse(fakePhotosApiTimestamp));
   }
 
   public static GoogleMediaItem getPhotoMediaItem() {

--- a/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/test/java/org/datatransferproject/datatransfer/google/mediaModels/GoogleMediaItemTest.java
@@ -167,12 +167,14 @@ public class GoogleMediaItemTest {
 
     VideoModel videoModel = GoogleMediaItem.convertToVideoModel(Optional.empty(), videoMediaItem);
 
-    assertEquals(videoModel.getUploadedTime().toInstant(), Instant.parse(fakePhotosApiTimestamp));
+    assertEquals(
+        videoModel.getUploadedTime().toInstant(),
+        GoogleMediaItem.parseIso8601DateTime(fakePhotosApiTimestamp));
   }
 
   @Test
   public void getUploadTime_photoModel() throws ParseException {
-    String fakePhotosApiTimestamp = "2023-10-02T22:33:38Z";
+    String fakePhotosApiTimestamp = "2014-10-02T15:01:23.045123456Z";
 
     GoogleMediaItem photoMediaItem = getPhotoMediaItem();
     MediaMetadata metadata = new MediaMetadata();
@@ -183,7 +185,9 @@ public class GoogleMediaItemTest {
 
     PhotoModel photoModel = GoogleMediaItem.convertToPhotoModel(Optional.empty(), photoMediaItem);
 
-    assertEquals(photoModel.getUploadedTime().toInstant(), Instant.parse(fakePhotosApiTimestamp));
+    assertEquals(
+        photoModel.getUploadedTime().toInstant(),
+        GoogleMediaItem.parseIso8601DateTime(fakePhotosApiTimestamp));
   }
 
   public static GoogleMediaItem getPhotoMediaItem() {


### PR DESCRIPTION
nitfix: encode high-precision stamp from docs

once encoding a high-precision stamp in the docs we see the unit test
fails because we're using a differet parsers than the unit test itself.
Document what we're using and make it visible for testing.