### PR TITLE
Tokensurlauth partial primitive obsession fix

### DIFF
--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokensAndUrlAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokensAndUrlAuthData.java
@@ -1,14 +1,13 @@
 package org.datatransferproject.types.transfer.auth;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -41,21 +40,39 @@ public class TokensAndUrlAuthData extends AuthData {
     return tokenServerEncodedUrl;
   }
 
+  // TODO(jzacsh, hgandhi90) all of this is internal validation logic; it should really probably
+  // happen at construction time; maybe there's a jackson annotation for this?
   @JsonIgnore
   public URI getTokenServerEncodedUri() throws IllegalStateException {
     final String urlString = getTokenServerEncodedUrl();
-    // TODO(jzacsh, hgandhi90) this should probably happen at construction time; maybe there's a jackson annotation for this?
     checkState(
         !isNullOrEmpty(urlString),
-        "malformed construction TokensAndUrlAuthData getTokenServerEncodedUrl() should be non-empty, but got \"%s\"",
+        "malformed construction TokensAndUrlAuthData getTokenServerEncodedUrl() should be"
+            + " non-empty, but got \"%s\"",
         urlString);
+    final URI uri;
     try {
-      return new URI(urlString);
+      uri = new URI(urlString);
     } catch (URISyntaxException e) {
       throw new IllegalStateException(
-          String.format("TokensAndUrlAuthData built with a malformed token-refresh URI (\"%s\")", urlString),
+          String.format(
+              "TokensAndUrlAuthData built with a malformed token-refresh URI (\"%s\")", urlString),
           e);
     }
+
+    // Run java.net.URL validation; we're returning a URI for flexibility/usage with other things,
+    // but ultimately these should really be (more specificaly) web URLs.
+    try {
+      uri.toURL();
+    } catch (IllegalArgumentException | MalformedURLException e) {
+      throw new IllegalStateException(
+          String.format(
+              "TokensAndUrlAuthData built with a token-refresh URI that's not a valid URL (\"%s\")",
+              urlString),
+          e);
+    }
+
+    return uri;
   }
 
   @JsonIgnore

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokensAndUrlAuthData.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/auth/TokensAndUrlAuthData.java
@@ -1,9 +1,16 @@
 package org.datatransferproject.types.transfer.auth;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /** Token-based authentication data. */
 @JsonTypeName("org.dataportability:TokensAndUrlAuthData")
@@ -35,8 +42,30 @@ public class TokensAndUrlAuthData extends AuthData {
   }
 
   @JsonIgnore
+  public URI getTokenServerEncodedUri() throws IllegalStateException {
+    final String urlString = getTokenServerEncodedUrl();
+    // TODO(jzacsh, hgandhi90) this should probably happen at construction time; maybe there's a jackson annotation for this?
+    checkState(
+        !isNullOrEmpty(urlString),
+        "malformed construction TokensAndUrlAuthData getTokenServerEncodedUrl() should be non-empty, but got \"%s\"",
+        urlString);
+    try {
+      return new URI(urlString);
+    } catch (URISyntaxException e) {
+      throw new IllegalStateException(
+          String.format("TokensAndUrlAuthData built with a malformed token-refresh URI (\"%s\")", urlString),
+          e);
+    }
+  }
+
+  @JsonIgnore
   @Override
   public String getToken() {
     return getAccessToken();
+  }
+
+  @JsonIgnore
+  public TokensAndUrlAuthData rebuildWithRefresh(String fresherAccessToken) {
+    return new TokensAndUrlAuthData(fresherAccessToken, getRefreshToken(), getTokenServerEncodedUrl());
   }
 }

--- a/portability-types-transfer/src/test/java/org/datatransferproject/types/transfer/auth/AuthDataSerializationTest.java
+++ b/portability-types-transfer/src/test/java/org/datatransferproject/types/transfer/auth/AuthDataSerializationTest.java
@@ -115,4 +115,33 @@ public class AuthDataSerializationTest {
                 .getTokenServerEncodedUri()
                 .toURL());
   }
+
+  @Test
+  public void verifyRebuildWithRefresh() throws IOException {
+    //
+    // Arrange
+    //
+    final String accessToken = "my_access_token";
+    final String refreshToken = "my_refresh_token";
+    final String authUrl = "https://www.example.com/auth";
+
+    final TokensAndUrlAuthData original =
+        new TokensAndUrlAuthData(accessToken, refreshToken, authUrl);
+    final String someOtherFakeToken = "foo-bar-baz";
+
+    //
+    // Act
+    //
+    final TokensAndUrlAuthData rebuilt = original.rebuildWithRefresh(someOtherFakeToken);
+
+    //
+    // Assert
+    //
+
+    // identical:
+    assertEquals(rebuilt.getRefreshToken(), original.getRefreshToken());
+    assertEquals(rebuilt.getTokenServerEncodedUrl(), original.getTokenServerEncodedUrl());
+    // accept for this variation:
+    assertEquals(rebuilt.getAccessToken(), someOtherFakeToken);
+  }
 }

--- a/portability-types-transfer/src/test/java/org/datatransferproject/types/transfer/auth/AuthDataSerializationTest.java
+++ b/portability-types-transfer/src/test/java/org/datatransferproject/types/transfer/auth/AuthDataSerializationTest.java
@@ -1,6 +1,7 @@
 package org.datatransferproject.types.transfer.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -87,5 +88,31 @@ public class AuthDataSerializationTest {
     final TokenSecretAuthData readAuthData = (TokenSecretAuthData) readValue;
     assertEquals(token, readAuthData.getToken(), "Expect token to be the same");
     assertEquals(secret, readAuthData.getSecret(), "Expect secret to be the same");
+  }
+
+  @Test
+  public void verifyGetTokenServerEncodedUri() throws IOException {
+    final String accessToken = "my_access_token";
+    final String refreshToken = "my_refresh_token";
+
+    final String fakeAuthUrl = "https://www.example.com/auth";
+    assertEquals(
+        new TokensAndUrlAuthData(accessToken, refreshToken, fakeAuthUrl)
+            .getTokenServerEncodedUri()
+            .toString(),
+        fakeAuthUrl);
+  }
+
+  @Test
+  public void verifyGetTokenServerEncodedUriDisallowsIlegalUrls() throws IOException {
+    final String accessToken = "my_access_token";
+    final String refreshToken = "my_refresh_token";
+    final String fakeMalformedAuthUrl = "https//www.example.com/auth"; // missing ":"
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            new TokensAndUrlAuthData(accessToken, refreshToken, fakeMalformedAuthUrl)
+                .getTokenServerEncodedUri()
+                .toURL());
   }
 }


### PR DESCRIPTION
open the door to let us start moving away from "primitive obsession"
(strings, all strings), which _in turn_ lets us start handling errors
more concisely and int he right places.

this is a prefactor for an upcoming apple-music PR (#1339) that relies
on this class for oauth token refresh.