### PR TITLE
resolve TODO: match full stacktrace retry strategy

### DIFF
--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryMapping.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryMapping.java
@@ -16,53 +16,133 @@
 
 package org.datatransferproject.types.transfer.retry;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Class that determines whether a given {@link Throwable} is a match for its {@link RetryStrategy}.
  * At the moment, this class only examines the string of the Throwable and determines whether it
  * matches any of its string regular expressions.
  *
- * NOTE: Our core library only supports reading RetryMappings from JSON or YAML format.
+ * <p>NOTE: Our core library only supports reading RetryMappings from JSON or YAML format.
  */
 public class RetryMapping {
 
   @JsonProperty("regexes")
   private String[] regexes;
-  @JsonProperty("strategy")
+
+  @JsonProperty("stacktraceRegexes")
+  private String[] stacktraceRegexes;
+
+  @JsonProperty(value = "strategy", required = true)
   private RetryStrategy strategy;
 
-  public RetryMapping(@JsonProperty("regexes") String[] regexes,
+  public RetryMapping(
+      @JsonProperty("regexes") String[] regexes,
+      @JsonProperty("stacktraceRegexes") String[] stacktraceRegexes,
       @JsonProperty("strategy") RetryStrategy strategy) {
     this.regexes = regexes;
+    this.stacktraceRegexes = stacktraceRegexes;
     this.strategy = strategy;
+    checkArgument(
+        this.regexes != null || this.stacktraceRegexes != null,
+        "either regexes or stacktraceRegexes must be set for a valid RetryMapping");
   }
 
   public String[] getRegexes() {
     return regexes;
   }
 
+  public String[] getStacktraceRegexes() {
+    return stacktraceRegexes;
+  }
+
   public RetryStrategy getStrategy() {
     return strategy;
   }
 
+  /**
+   * Deprecated method to determine if throwable is matched by the config this class was constructed
+   * with.
+   *
+   * <ul>
+   *   Deprecated in favor of {@link matchesThrowableTop} for old behavior, or more precisely:
+   *   please use...
+   *   <li>{@link matches} to handle either older style matching or new style matching, whichever
+   *       the YAML dictates. This is the most likely correct choice.
+   *   <li>{@link matchesThrowableTop} to handle either older style matching only.
+   *   <li>{@link matchesThrowableStack} to handle only newer style matching (full stack trace).
+   * </ul>
+   */
   public boolean matchesThrowable(Throwable throwable) {
-    // TODO: examine entire throwable, not just toString
-    String input = throwable.toString();
-    for (String regex : regexes) {
-      if (input.matches(regex)) {
+    return matchesThrowableTop(throwable);
+  }
+
+  /** Whether throwable is matched by any of the current or future capabilities of this class. */
+  public boolean matches(Throwable throwable) {
+    // nit: we're purposely trying to short-circuit here on an early match with a much smaller
+    // haystack (the top-level message).
+    return matchesThrowableTop(throwable) || matchesThrowableStack(throwable);
+  }
+
+  /**
+   * Whether throwable matches the top-level (ie: most recent, or high-stack-level propogator) of
+   * this stack trace.
+   */
+  public boolean matchesThrowableTop(Throwable throwable) {
+    if (regexes == null) {
+      return false;
+    }
+
+    return throwableMatchesExpressions(throwable.toString(), regexes);
+  }
+
+  /**
+   * More lenient version of {@link matchesThrowableTop} that checks not just for matches against
+   * the top-level message in the stack that Throwable comprises, but for a match _anywhere_ in the
+   * full stack trace.
+   */
+  public boolean matchesThrowableStack(Throwable throwable) {
+    if (stacktraceRegexes == null) {
+      return false;
+    }
+
+    return throwableMatchesExpressions(getStackTraceAsString(throwable), stacktraceRegexes);
+  }
+
+  private static boolean throwableMatchesExpressions(
+      String throwableHaystack, String[] expressions) {
+    for (String regex : expressions) {
+      if (isMultilineMatch(regex, throwableHaystack)) {
         return true;
       }
     }
     return false;
   }
 
+  /** Whether hayStack contains the regex, even if '.' operator needs to match linebreaks. */
+  private static boolean isMultilineMatch(String regex, String hayStack) {
+    // Identical to {@link String#matches} but utilizes {@link Pattern.DOTALL} for regex
+    // compilation.
+    Pattern p = Pattern.compile(regex, Pattern.DOTALL);
+    Matcher m = p.matcher(hayStack);
+    return m.matches();
+  }
+
   @Override
   public String toString() {
-    return "RetryMapping{" +
-        "regexes=" + Arrays.toString(regexes) +
-        ", strategy=" + strategy +
-        '}';
+    return "RetryMapping{"
+        + "regexes="
+        + Arrays.toString(regexes)
+        + ", stacktraceRegexes="
+        + Arrays.toString(stacktraceRegexes)
+        + ", strategy="
+        + strategy
+        + '}';
   }
 }

--- a/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryStrategyLibrary.java
+++ b/portability-types-transfer/src/main/java/org/datatransferproject/types/transfer/retry/RetryStrategyLibrary.java
@@ -38,7 +38,8 @@ public class RetryStrategyLibrary {
 
   @JsonProperty("strategyMappings")
   private final List<RetryMapping> retryMappings;
-  @JsonProperty("defaultRetryStrategy")
+
+  @JsonProperty(value = "defaultRetryStrategy", required = true)
   private final RetryStrategy defaultRetryStrategy;
 
   public RetryStrategyLibrary(@JsonProperty("strategyMappings") List<RetryMapping> retryMappings,
@@ -49,16 +50,15 @@ public class RetryStrategyLibrary {
   }
 
   /**
-   * Returns the best {@link RetryStrategy} for a given Throwable.  If there are no matches, returns
+   * Returns the best {@link RetryStrategy} for a given Throwable. If there are no matches, returns
    * the default RetryStrategy.
    *
    * Right now it just looks at the message in the Throwable and tries to find a matching regex in
    * its internal library.  Later on it will use more and more of the Throwable to make a decision.
    */
   public RetryStrategy checkoutRetryStrategy(Throwable throwable) {
-    // TODO: determine retry strategy based on full information in Throwable
     for (RetryMapping mapping : retryMappings) {
-      if (mapping.matchesThrowable(throwable)) {
+      if (mapping.matches(throwable)) {
         return mapping.getStrategy();
       }
     }


### PR DESCRIPTION
this is a new feature that should have no impact on existing RetryStrategy yaml/json users: there's simply a new `stacktraceRegexes` key in the config that acts as an alternative to the older `regexes`. It's only difference from the original is that its regexes match across the long, multi-line strings that are **full** stacktraces.

motivation: matching more of the Throwable is a TODO that's come up multiple times and now actually caused a surprise last-minute bug for us, so this patch resolves the feature gap and unblocks google's and apple's work.

testing: for now we're leaving backfilling (a new unit test for this file) as a fast-follow, since Google has intern integration~esque unit-test coverage of this file against our real-world YAML config. Not ideal, but need time to come back and opensource the test.