### PR TITLE
Decrease Google Music Post Request read timeout

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicHttpApi.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicHttpApi.java
@@ -192,7 +192,7 @@ public class GoogleMusicHttpApi {
     HttpRequest postRequest =
         requestFactory.buildPostRequest(
             new GenericUrl(baseUrl + "?" + generateParamsString(parameters)), httpContent);
-    postRequest.setReadTimeout(2 * 60000); // 2 minutes read timeout
+    postRequest.setReadTimeout(6000); // 6 seconds read timeout
     HttpResponse response;
 
     try {


### PR DESCRIPTION
Apple Music -> YouTube Music flow has long latency when importing playlists. Each importing iteration takes around 100-125sec. YouTube Music Importing APIs' latency is around 5s. Reducing blocking read time out should help reduce the time per playlist.