### PR TITLE
Make track limitation in YouTube Music as skippable failure

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-google/src/main/java/org/datatransferproject/datatransfer/google/music/GoogleMusicImporter.java
@@ -230,7 +230,8 @@ public class GoogleMusicImporter implements Importer<TokensAndUrlAuthData, Music
         // TODO(critical WIP-feature step): Add permanent failures.
         throw new CopyException("Permanent Failure:", e);
       } else if (StringUtils.contains(e.getMessage(), "Fail to find track matching")
-          || StringUtils.contains(e.getMessage(), "Missing ISRC in playlist item")) {
+          || StringUtils.contains(e.getMessage(), "Missing ISRC in playlist item")
+          || StringUtils.contains(e.getMessage(), "Max videos exceeded")) {
         // Skippable Failure: we skip this batch and log some data to understand it better
         // TODO(critical WIP-feature step): Add skippable failures.
         monitor.info(() -> "Skippable Failure:", e);


### PR DESCRIPTION
YouTube music has 5000 tracks per playlist limitation. We want to make it as skippable failure for initial launch.