### PR TITLE
fix(synology): replace readNBytes with Guava ByteStreams.read

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-synology/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-synology/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile project(':portability-spi-cloud')
     compile project(':portability-transfer')
     compile "com.squareup.okhttp3:okhttp:${okHttpVersion}"
+    compile "com.google.guava:guava:${guavaVersion}"
 }
 
 configurePublication(project)

--- a/extensions/data-transfer/portability-data-transfer-synology/src/main/java/org/datatransferproject/datatransfer/synology/service/SynologyDTPService.java
+++ b/extensions/data-transfer/portability-data-transfer-synology/src/main/java/org/datatransferproject/datatransfer/synology/service/SynologyDTPService.java
@@ -20,6 +20,7 @@ package org.datatransferproject.datatransfer.synology.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -276,7 +277,7 @@ public class SynologyDTPService {
     // since we are uploading in sequential, there is no concurrency issue
     byte[] chunkData = new byte[CHUNK_SIZE];
     while (true) {
-      int bytesRead = inputStream.readNBytes(chunkData, 0, CHUNK_SIZE);
+      int bytesRead = ByteStreams.read(inputStream, chunkData, 0, CHUNK_SIZE);
       if (bytesRead == 0) {
         break;
       }


### PR DESCRIPTION
## Goal
The goal of this change is to improve compatibility of chunked reading in
 by replacing the Java 9+  method with Guava's
, ensuring the code works correctly in older Java environments.

## Changes
- **Dependency Update:** Added `com.google.guava:guava` to the Synology extension's `build.gradle`.
- **Code Refactor:** Updated `SynologyDTPService` to use `ByteStreams.read` when reading video chunks.