### PR TITLE
feat: add containerized build/test environment via Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gradle
+build
+out
+generated
+target
+node_modules
+client-rest/dist

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@ env.secrets
 distributions/*/resources/
 
 #**/src/main/resources/settings/*.yaml
-# Dockerfile is generated each time we run build.sh
-Dockerfile
-
 # compiled output
 build/
 out/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Runs the Java/Gradle build and test suite with no local JDK install.
+#
+# Source is bind-mounted at `docker run` time -- this image is not rebuilt
+# per code change. Gradle 6.9.2 (pulled by the wrapper regardless of this
+# image's bundled Gradle version) can't parse Java 17 bytecode when
+# compiling build.gradle/settings.gradle, so the JDK here is pinned to 11.
+#
+# The gradle:* image's default GRADLE_USER_HOME is /home/gradle/.gradle --
+# mount a named volume there to cache resolved dependencies across runs:
+#
+#   docker build -t datatransferproject/dev .
+#   docker run --rm -v "$PWD":/workspace -v gradle-cache:/home/gradle/.gradle datatransferproject/dev
+FROM gradle:8.10.2-jdk11
+
+WORKDIR /workspace
+
+ENTRYPOINT ["./gradlew"]
+CMD ["--no-daemon", "check"]

--- a/Documentation/Developer.md
+++ b/Documentation/Developer.md
@@ -89,24 +89,18 @@ the Java test suite without installing a JDK locally. The `Dockerfile` at the re
 `gradle:8.10.2-jdk11`; the source is bind-mounted at run time rather than baked into the image, so a
 rebuild isn't needed after every code change.
 
-Build the image once:
-```bash
-docker build -t datatransferproject/dev .
-```
-
 Run the full check task against the current working tree:
 ```bash
-docker run --rm -v "$PWD":/workspace -v gradle-cache:/home/gradle/.gradle datatransferproject/dev
+docker compose run --rm test
 ```
 
-The `gradle-cache` named volume persists resolved dependencies across runs, so only the first run pays
-the full resolution cost. `/home/gradle/.gradle` is the `gradle:*` image's default `GRADLE_USER_HOME` --
-no extra configuration is needed to point the cache there.
-
-To run something other than `check`, override the default command, e.g.:
+To run a specific Gradle task or test, override the default command:
 ```bash
-docker run --rm -v "$PWD":/workspace -v gradle-cache:/home/gradle/.gradle datatransferproject/dev test --tests SomeTest
+docker compose run --rm test test --tests SomeTest
 ```
+
+The `gradle-cache` named volume (defined in `docker-compose.yml`) persists resolved dependencies across
+runs, so only the first run pays the full resolution cost.
 
 The JDK is pinned to 11 because the Gradle wrapper (6.9.2) can't parse Java 17 bytecode when compiling
 `build.gradle`/`settings.gradle` -- a `gradle:*-jdk17` image fails outright for this reason.

--- a/Documentation/Developer.md
+++ b/Documentation/Developer.md
@@ -79,6 +79,38 @@ limitations under the License.
 
 See [Running Locally](RunningLocally.md) for instructions.
 
+## Running tests in Docker without a local JDK
+
+> **Experimental.** This workflow is new and is intended to gradually become the standard way to build
+> and test the project, eventually replacing the requirement for a local JDK. Feedback welcome.
+
+This is unrelated to the demo image built by `dockerize` above -- it's a separate, additive way to run
+the Java test suite without installing a JDK locally. The `Dockerfile` at the repo root pins
+`gradle:8.10.2-jdk11`; the source is bind-mounted at run time rather than baked into the image, so a
+rebuild isn't needed after every code change.
+
+Build the image once:
+```bash
+docker build -t datatransferproject/dev .
+```
+
+Run the full check task against the current working tree:
+```bash
+docker run --rm -v "$PWD":/workspace -v gradle-cache:/home/gradle/.gradle datatransferproject/dev
+```
+
+The `gradle-cache` named volume persists resolved dependencies across runs, so only the first run pays
+the full resolution cost. `/home/gradle/.gradle` is the `gradle:*` image's default `GRADLE_USER_HOME` --
+no extra configuration is needed to point the cache there.
+
+To run something other than `check`, override the default command, e.g.:
+```bash
+docker run --rm -v "$PWD":/workspace -v gradle-cache:/home/gradle/.gradle datatransferproject/dev test --tests SomeTest
+```
+
+The JDK is pinned to 11 because the Gradle wrapper (6.9.2) can't parse Java 17 bytecode when compiling
+`build.gradle`/`settings.gradle` -- a `gradle:*-jdk17` image fails outright for this reason.
+
 ## Deploying in production
 
 A demo distribution for Google Cloud Platform is available at

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  test:
+    build: .
+    volumes:
+      - .:/workspace
+      - gradle-cache:/home/gradle/.gradle
+
+volumes:
+  gradle-cache:


### PR DESCRIPTION
Adds a `Dockerfile` pinned to `gradle:8.10.2-jdk11` and a `docker-compose.yml` so contributors can run the full test suite with no local JDK installed:

```bash
docker compose run --rm test
```

The compose file encodes the source bind-mount and a named volume for the Gradle dependency cache, so the first run resolves dependencies and subsequent runs reuse them.

## Notable decisions / tradeoffs

- **Bind-mount design:** source is bind-mounted at run time rather than `COPY`ed into the image, so the image doesn't need rebuilding on every code change. The `docker-compose.yml` hides this from contributors -- they just run `docker compose run`.
- **`.gitignore` cleanup:** removed the bare `Dockerfile` rule. The rule's comment said it was for the demo-server's generated `Dockerfile`, but that file lands in `distributions/demo-server/build/demo/Dockerfile` -- already covered by the `build/` ignore rule. The bare rule was redundant.
- **Image name `datatransferproject/dev`:** mirrors the existing `datatransferproject/demo` image produced by the `:dockerize` task, establishing a consistent namespace.
- **JDK pinned to 11:** the Gradle wrapper (6.9.2) can't parse Java 17 bytecode when compiling build scripts -- `gradle:*-jdk17` fails outright. Not a preference; a hard constraint from the wrapper version.
