### PR TITLE
fix(synology): await producer thread shutdown before returning from uploadVideoChunks

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-synology/src/main/java/org/datatransferproject/datatransfer/synology/service/SynologyDTPService.java
+++ b/extensions/data-transfer/portability-data-transfer-synology/src/main/java/org/datatransferproject/datatransfer/synology/service/SynologyDTPService.java
@@ -307,6 +307,11 @@ public class SynologyDTPService {
     } finally {
       consumerAborted.set(true);
       producerFuture.cancel(true);
+      try {
+        producerFuture.get(5, TimeUnit.SECONDS);
+      } catch (Exception ignored) {
+        // Expected: CancellationException if cancelled, or timeout -- producer is stopping
+      }
     }
   }
 


### PR DESCRIPTION
`producerFuture.cancel(true)` requests interruption but returns immediately, leaving the producer thread alive after `createVideo` returns. On resource-constrained CI runners, this races with Mockito's post-test stub validation, causing `CreateMedia` VideoModel tests to flake as SKIPPED.

Added `producerFuture.get(5, TimeUnit.SECONDS)` after the cancel so the method only returns once the producer has actually stopped. `CancellationException` and timeout are swallowed -- both mean the producer is done or on its way out.

Fixes the flaky test (see [Gradle CI attempts on current master branch](https://github.com/dtinit/data-transfer-project/actions/runs/26077383377/attempts/4))