### PR TITLE
test(synology): raise test JVM heap to 1g to avoid OOM

### DIFF
--- a/extensions/data-transfer/portability-data-transfer-synology/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-synology/build.gradle
@@ -28,4 +28,11 @@ dependencies {
     compile "com.google.guava:guava:${guavaVersion}"
 }
 
+test {
+    // uploadVideoChunks pre-allocates two 50MB buffers per call; the large-video test
+    // uses ~150MB total (content + pool), and the following test allocates another 100MB
+    // pool before GC clears the previous one -- OOM on the default heap.
+    maxHeapSize = "1g"
+}
+
 configurePublication(project)


### PR DESCRIPTION
## Problem

The Synology test suite OOMs in CI on `shouldThrowExceptionIfSendPostRequestFailed [2] VideoModel` -- which was identified after investigation in #1495. This blocks the CI.

`uploadVideoChunks` pre-allocates two 50MB byte arrays into a buffer pool on every call. `shouldSendMultipleChunksForLargeVideo` leaves ~150MB live (50MB content + 100MB pool). 

The next test immediately allocates another 100MB pool before GC has a chance to clear the previous one -- exceeding the default test JVM heap.

The `maxHeapSize` setting only affects the test JVM, not Gradle itself or production runtime.

## What's not fixed

The root cause -- `uploadVideoChunks` pre-allocating 100MB regardless of file size -- is a production-code issue. Lazy buffer allocation (allocate on demand, release after consumer finishes) would fix both the test OOM and the memory waste on small files.

That's a more invasive change left for a follow-up.

cc @simonxander or @mengyushen -- let's discuss the 100MB buffer after the CI is unblocked.