### PR TITLE
feat: Add Amazon Photos importer extension

### DIFF
--- a/distributions/demo-server/build.gradle
+++ b/distributions/demo-server/build.gradle
@@ -68,6 +68,8 @@ dependencies {
 
     // TODO: depend on these based on list in flag values.
 
+    compile project(':extensions:auth:portability-auth-amazon')
+    compile project(':extensions:data-transfer:portability-data-transfer-amazon')
     compile project(':extensions:auth:portability-auth-apple')
     compile project(':extensions:auth:portability-auth-daybook')
     compile project(':extensions:auth:portability-auth-deezer')

--- a/extensions/auth/portability-auth-amazon/build.gradle
+++ b/extensions/auth/portability-auth-amazon/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'maven'
+    id 'signing'
+}
+
+dependencies {
+    compile project(':portability-spi-api')
+    compile project(':portability-spi-cloud')
+    compile project(':libraries:auth')
+}
+
+configurePublication(project)

--- a/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonAuthServiceExtension.java
+++ b/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonAuthServiceExtension.java
@@ -1,0 +1,9 @@
+package org.datatransferproject.auth.amazon;
+
+import org.datatransferproject.auth.OAuth2ServiceExtension;
+
+public class AmazonAuthServiceExtension extends OAuth2ServiceExtension {
+  public AmazonAuthServiceExtension() {
+    super(new AmazonOAuthConfig());
+  }
+}

--- a/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonOAuthConfig.java
+++ b/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonOAuthConfig.java
@@ -1,0 +1,55 @@
+package org.datatransferproject.auth.amazon;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.datatransferproject.auth.OAuth2Config;
+import org.datatransferproject.types.common.models.DataVertical;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
+/**
+ * OAuth2 configuration for Amazon Photos (Login with Amazon).
+ */
+public class AmazonOAuthConfig implements OAuth2Config {
+
+  @Override
+  public String getServiceName() {
+    return "Amazon";
+  }
+
+  @Override
+  public String getAuthUrl() {
+    return "https://www.amazon.com/ap/oa";
+  }
+
+  @Override
+  public String getTokenUrl() {
+    return "https://api.amazon.com/auth/o2/token";
+  }
+
+  @Override
+  public Map<DataVertical, Set<String>> getImportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(PHOTOS, ImmutableSet.of(
+            "photos::images:create",
+            "photos::albums:create",
+            "photos::albums:update"))
+        .put(VIDEOS, ImmutableSet.of(
+            "photos::videos:create",
+            "photos::albums:create",
+            "photos::albums:update"))
+        .build();
+  }
+
+  @Override
+  public Map<DataVertical, Set<String>> getExportScopes() {
+    return ImmutableMap.<DataVertical, Set<String>>builder()
+        .put(PHOTOS, ImmutableSet.of("photos::images:read", "photos::albums:read"))
+        .put(VIDEOS, ImmutableSet.of("photos::videos:read", "photos::albums:read"))
+        .build();
+  }
+}

--- a/extensions/auth/portability-auth-amazon/src/main/resources/META-INF/services/org.datatransferproject.spi.api.auth.extension.AuthServiceExtension
+++ b/extensions/auth/portability-auth-amazon/src/main/resources/META-INF/services/org.datatransferproject.spi.api.auth.extension.AuthServiceExtension
@@ -1,0 +1,1 @@
+org.datatransferproject.auth.amazon.AmazonAuthServiceExtension

--- a/extensions/auth/portability-auth-amazon/src/test/java/org/datatransferproject/auth/amazon/AmazonOAuthConfigTest.java
+++ b/extensions/auth/portability-auth-amazon/src/test/java/org/datatransferproject/auth/amazon/AmazonOAuthConfigTest.java
@@ -1,0 +1,63 @@
+package org.datatransferproject.auth.amazon;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.datatransferproject.types.common.models.DataVertical.PHOTOS;
+import static org.datatransferproject.types.common.models.DataVertical.VIDEOS;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AmazonOAuthConfigTest {
+
+  private AmazonOAuthConfig config;
+
+  @BeforeEach
+  void setUp() {
+    config = new AmazonOAuthConfig();
+  }
+
+  @Test
+  void serviceName() {
+    assertThat(config.getServiceName()).isEqualTo("Amazon");
+  }
+
+  @Test
+  void authUrlIsLwaEndpoint() {
+    assertThat(config.getAuthUrl()).isEqualTo("https://www.amazon.com/ap/oa");
+  }
+
+  @Test
+  void tokenUrlIsLwaEndpoint() {
+    assertThat(config.getTokenUrl()).isEqualTo("https://api.amazon.com/auth/o2/token");
+  }
+
+  @Test
+  void importScopesForPhotos() {
+    assertThat(config.getImportScopes().get(PHOTOS))
+        .containsExactly(
+            "photos::images:create",
+            "photos::albums:create",
+            "photos::albums:update");
+  }
+
+  @Test
+  void importScopesForVideos() {
+    assertThat(config.getImportScopes().get(VIDEOS))
+        .containsExactly(
+            "photos::videos:create",
+            "photos::albums:create",
+            "photos::albums:update");
+  }
+
+  @Test
+  void exportScopesForPhotos() {
+    assertThat(config.getExportScopes().get(PHOTOS))
+        .containsExactly("photos::images:read", "photos::albums:read");
+  }
+
+  @Test
+  void exportScopesForVideos() {
+    assertThat(config.getExportScopes().get(VIDEOS))
+        .containsExactly("photos::videos:read", "photos::albums:read");
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/build.gradle
+++ b/extensions/data-transfer/portability-data-transfer-amazon/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java'
+}
+
+dependencies {
+    implementation project(':portability-spi-cloud')
+    implementation project(':portability-spi-transfer')
+    implementation project(':portability-transfer')
+    implementation project(':portability-spi-api')
+    implementation project(':portability-types-common')
+    implementation project(':portability-types-transfer')
+    implementation project(':portability-api-launcher')
+
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "com.google.guava:guava:${guavaVersion}"
+    implementation "com.squareup.okhttp3:okhttp:4.9.0"
+
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.9.0"
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/AmazonTransferExtension.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/AmazonTransferExtension.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon;
+
+import com.google.common.base.Preconditions;
+import org.datatransferproject.api.launcher.ExtensionContext;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.AppCredentialStore;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.extension.TransferExtension;
+import org.datatransferproject.spi.transfer.provider.Exporter;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.transfer.amazon.photos.AmazonPhotosImporter;
+import org.datatransferproject.types.common.models.DataVertical;
+import org.datatransferproject.types.transfer.auth.AppCredentials;
+
+import java.io.IOException;
+
+public class AmazonTransferExtension implements TransferExtension {
+
+  private static final String SERVICE_ID = "Amazon";
+
+  private AmazonPhotosImporter importer;
+  private volatile boolean initialized = false;
+
+  @Override
+  public String getServiceId() {
+    return SERVICE_ID;
+  }
+
+  @Override
+  public Exporter<?, ?> getExporter(DataVertical transferDataType) {
+    // TODO: Implement exporter
+    return null;
+  }
+
+  @Override
+  public Importer<?, ?> getImporter(DataVertical transferDataType) {
+    Preconditions.checkArgument(initialized, "Extension not initialized");
+    Preconditions.checkArgument(transferDataType == DataVertical.PHOTOS);
+    return importer;
+  }
+
+  @Override
+  public synchronized void initialize(ExtensionContext context) {
+    if (initialized) return;
+
+    Monitor monitor = context.getMonitor();
+
+    AppCredentials appCredentials;
+    try {
+      appCredentials = context.getService(AppCredentialStore.class)
+          .getAppCredentials("AMAZON_KEY", "AMAZON_SECRET");
+    } catch (IOException e) {
+      monitor.severe(() -> "Unable to retrieve Amazon AppCredentials.", e);
+      return;
+    }
+
+    importer = new AmazonPhotosImporter(
+        monitor, appCredentials.getKey(), appCredentials.getSecret(),
+        context.getService(TemporaryPerJobDataStore.class));
+
+    initialized = true;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosClient.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosClient.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.FormBody;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
+import org.datatransferproject.transfer.amazon.photos.model.CreateNodeRequest;
+import org.datatransferproject.transfer.amazon.photos.model.EndpointResponse;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * HTTP client for Amazon Photos APIs.
+ *
+ * <p>Handles endpoint resolution, token refresh on 401, simple and multipart uploads,
+ * node creation, listing, downloading, and parent-child relationships.
+ */
+public class AmazonPhotosClient implements AmazonPhotosInterface {
+
+  private static final String ENDPOINT_URL =
+      "https://drive.amazonaws.com/drive/v1/account/endpoint";
+  private static final String TOKEN_URL = "https://api.amazon.com/auth/o2/token";
+  private static final String RESOURCE_VERSION = "V2";
+  private static final String AUTH_HEADER = "x-amz-access-token";
+  private static final String MD5_HEADER = "x-amzn-file-md5";
+  private static final String SLASH = "/";
+  private static final String NODES_PATH = "nodes";
+  private static final String UPLOAD_PATH = "v2/upload/multiform-upload";
+  private static final String PARAM_RESOURCE_VERSION = "resourceVersion";
+  private static final String PARAM_CONFLICT_RESOLUTION = "conflictResolution";
+  private static final String PARAM_NAME = "name";
+  private static final String PARAM_KIND = "kind";
+  private static final String PARAM_FILE_SIZE = "fileSize";
+  private static final String PARAM_PARENT_NODE_ID = "visualCollectionParentNodeId";
+  private static final String PARAM_CONTENT_DATE = "fallbackContentDate";
+  private static final String PARAM_FAVORITE = "isFavorite";
+  private static final String KIND_FILE = "FILE";
+  private static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json");
+
+  private final OkHttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final String clientId;
+  private final String clientSecret;
+  private final String refreshToken;
+
+  private volatile String accessToken;
+  private volatile String metadataUrl;
+  private volatile String uploadServiceUrl;
+  private volatile String contentUrl;
+
+  @FunctionalInterface
+  interface AuthenticatedCall<T> {
+    T execute(String token) throws IOException;
+  }
+
+  public AmazonPhotosClient(OkHttpClient httpClient, String accessToken, String refreshToken,
+                            String clientId, String clientSecret) {
+    this.httpClient = httpClient;
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.objectMapper = new ObjectMapper();
+  }
+
+  /**
+   * Resolves regional API endpoints via the getEndpoint API.
+   * Must be called before any other API method.
+   */
+  @Override
+  public void resolveEndpoints() throws IOException {
+    executeWithTokenRefresh(token -> {
+      Request request = new Request.Builder()
+          .url(ENDPOINT_URL)
+          .addHeader(AUTH_HEADER, token)
+          .get()
+          .build();
+
+      try (Response response = httpClient.newCall(request).execute()) {
+        validateResponse(response);
+        EndpointResponse endpoints = objectMapper.readValue(
+            response.body().string(), EndpointResponse.class);
+        if (endpoints.getMetadataUrl() == null || endpoints.getContentUrl() == null) {
+          throw new IOException("Endpoint resolution returned incomplete response");
+        }
+        contentUrl = normalizeUrl(endpoints.getContentUrl());
+        uploadServiceUrl = endpoints.getUploadServiceUrl() != null
+            ? normalizeUrl(endpoints.getUploadServiceUrl())
+            : contentUrl;
+        metadataUrl = normalizeUrl(endpoints.getMetadataUrl());
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Creates an album in Amazon Photos.
+   */
+  @Override
+  public AmazonPhotosNode createAlbum(String name) throws IOException {
+    ensureEndpointsResolved();
+    return executeWithTokenRefresh(token -> {
+      CreateNodeRequest nodeRequest = new CreateNodeRequest(name, "VISUAL_COLLECTION");
+
+      HttpUrl url = HttpUrl.parse(metadataUrl + NODES_PATH).newBuilder()
+          .addQueryParameter(PARAM_RESOURCE_VERSION, RESOURCE_VERSION)
+          .build();
+
+      Request request = new Request.Builder()
+          .url(url)
+          .addHeader(AUTH_HEADER, token)
+          .post(RequestBody.create(
+              objectMapper.writeValueAsString(nodeRequest), JSON_MEDIA_TYPE))
+          .build();
+
+      try (Response response = httpClient.newCall(request).execute()) {
+        validateResponse(response);
+        return objectMapper.readValue(response.body().string(), AmazonPhotosNode.class);
+      }
+    });
+  }
+
+  /**
+   * Uploads a photo to Amazon Photos.
+   *
+   * TODO: Add multipart upload support for files > 5GB during video importer integration.
+   *
+   * @throws IOException on API errors including 409 duplicate conflict
+   */
+  @Override
+  public AmazonPhotosNode uploadPhoto(String fileName, File fileContent,
+                                      String md5Hex, long fileSize, String contentDate,
+                                      boolean isFavorite,
+                                      String albumId) throws IOException {
+    ensureEndpointsResolved();
+    return executeWithTokenRefresh(token -> {
+      HttpUrl url = buildUploadUrl(fileName, fileSize, contentDate, isFavorite, albumId);
+
+      String metadataJson = objectMapper.writeValueAsString(
+          new CreateNodeRequest(fileName, KIND_FILE));
+
+      RequestBody multipartBody = new okhttp3.MultipartBody.Builder()
+          .setType(okhttp3.MultipartBody.FORM)
+          .addFormDataPart("metadata", null,
+              RequestBody.create(metadataJson, JSON_MEDIA_TYPE))
+          .addFormDataPart("file", fileName,
+              RequestBody.create(fileContent, MediaType.parse("application/octet-stream")))
+          .build();
+
+      Request request = new Request.Builder()
+          .url(url)
+          .addHeader(AUTH_HEADER, token)
+          .addHeader(MD5_HEADER, md5Hex)
+          .post(multipartBody)
+          .build();
+
+      try (Response response = httpClient.newCall(request).execute()) {
+        validateResponse(response);
+        return objectMapper.readValue(response.body().string(), AmazonPhotosNode.class);
+      }
+    });
+  }
+
+  private <T> T executeWithTokenRefresh(AuthenticatedCall<T> call) throws IOException {
+    try {
+      return call.execute(accessToken);
+    } catch (TokenExpiredException e) {
+      refreshAccessToken();
+      return call.execute(accessToken);
+    }
+  }
+
+  private synchronized void refreshAccessToken() throws IOException {
+    RequestBody body = new FormBody.Builder()
+        .add("grant_type", "refresh_token")
+        .add("refresh_token", refreshToken)
+        .add("client_id", clientId)
+        .add("client_secret", clientSecret)
+        .build();
+
+    Request request = new Request.Builder().url(TOKEN_URL).post(body).build();
+    try (Response response = httpClient.newCall(request).execute()) {
+      if (!response.isSuccessful()) {
+        throw new IOException("Token refresh failed with status " + response.code());
+      }
+      JsonNode json = objectMapper.readTree(response.body().string());
+      this.accessToken = json.get("access_token").asText();
+    }
+  }
+
+  private void validateResponse(Response response) throws IOException {
+    if (response.code() == 401) {
+      throw new TokenExpiredException();
+    }
+    if (!response.isSuccessful()) {
+      String errorBody = response.body() != null ? response.body().string() : "";
+      throw new IOException("API error " + response.code() + ": " + errorBody);
+    }
+  }
+
+  private HttpUrl buildUploadUrl(String fileName, long fileSize, String contentDate,
+                                 boolean isFavorite, String albumId) {
+    HttpUrl.Builder builder = HttpUrl.parse(uploadServiceUrl + UPLOAD_PATH).newBuilder()
+        .addQueryParameter(PARAM_NAME, fileName)
+        .addQueryParameter(PARAM_KIND, KIND_FILE)
+        .addQueryParameter(PARAM_FILE_SIZE, String.valueOf(fileSize))
+        .addQueryParameter(PARAM_CONFLICT_RESOLUTION, "RENAME");
+
+    if (albumId != null) {
+      builder.addQueryParameter(PARAM_PARENT_NODE_ID, albumId);
+    }
+    if (contentDate != null) {
+      builder.addQueryParameter(PARAM_CONTENT_DATE, contentDate);
+    }
+    if (isFavorite) {
+      builder.addQueryParameter(PARAM_FAVORITE, "true");
+    }
+    return builder.build();
+  }
+
+  private static String normalizeUrl(String url) {
+    return url.endsWith(SLASH) ? url : url + SLASH;
+  }
+
+  private void ensureEndpointsResolved() throws IOException {
+    if (metadataUrl == null) {
+      synchronized (this) {
+        if (metadataUrl == null) {
+          resolveEndpoints();
+        }
+      }
+    }
+  }
+
+  private static class TokenExpiredException extends IOException {
+    TokenExpiredException() { super("Access token expired"); }
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporter.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporter.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.connection.ConnectionProvider;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.spi.transfer.provider.Importer;
+import org.datatransferproject.spi.transfer.types.DestinationMemoryFullException;
+import org.datatransferproject.transfer.JobMetadata;
+import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
+import org.datatransferproject.types.common.models.FavoriteInfo;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Imports photos into Amazon Photos from other DTP-supported services.
+ *
+ * <p>For each photo: downloads to a temp file (computing MD5 in a single pass via
+ * DigestInputStream), then uploads via the Upload Service. Duplicate detection and
+ * fallback album placement are handled server-side.
+ */
+public class AmazonPhotosImporter
+    implements Importer<TokensAndUrlAuthData, PhotosContainerResource> {
+
+  private static final String IMPORTED_SUFFIX = " - Imported from ";
+
+  private final Monitor monitor;
+  private final String clientId;
+  private final String clientSecret;
+  private final TemporaryPerJobDataStore dataStore;
+  private final ConnectionProvider connectionProvider;
+  private final AmazonPhotosTransmogrificationConfig transmogrificationConfig =
+      new AmazonPhotosTransmogrificationConfig();
+
+  private AmazonPhotosInterface client;
+
+  public AmazonPhotosImporter(Monitor monitor, String clientId, String clientSecret,
+                              TemporaryPerJobDataStore dataStore) {
+    this.monitor = monitor;
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.dataStore = dataStore;
+    this.connectionProvider = new ConnectionProvider(dataStore);
+  }
+
+  AmazonPhotosImporter(Monitor monitor, TemporaryPerJobDataStore dataStore,
+                       AmazonPhotosInterface client) {
+    this.monitor = monitor;
+    this.clientId = null;
+    this.clientSecret = null;
+    this.dataStore = dataStore;
+    this.connectionProvider = new ConnectionProvider(dataStore);
+    this.client = client;
+  }
+
+  @Override
+  public ImportResult importItem(UUID jobId, IdempotentImportExecutor executor,
+                                 TokensAndUrlAuthData authData,
+                                 PhotosContainerResource data) throws Exception {
+    initializeClient(authData);
+    data.transmogrify(transmogrificationConfig);
+
+    for (PhotoAlbum album : data.getAlbums()) {
+      executor.executeAndSwallowIOExceptions(
+          album.getId(), album.getName(), () -> createAlbum(album));
+    }
+
+    for (PhotoModel photo : data.getPhotos()) {
+      executor.executeAndSwallowIOExceptions(
+          photo.getIdempotentId(), photo.getTitle(),
+          () -> uploadPhoto(jobId, photo, executor));
+    }
+
+    return ImportResult.OK;
+  }
+
+  private String createAlbum(PhotoAlbum album) throws IOException {
+    String albumName = album.getName() + IMPORTED_SUFFIX + JobMetadata.getExportService();
+    AmazonPhotosNode node = client.createAlbum(albumName);
+    monitor.info(() -> "Created album: " + album.getName() + " -> " + node.getId());
+    return node.getId();
+  }
+
+  private String uploadPhoto(UUID jobId, PhotoModel photo,
+                             IdempotentImportExecutor executor) throws Exception {
+    String targetAlbumId = resolveTargetAlbumId(photo, executor);
+    MessageDigest md5 = newMd5Digest();
+    File tempFile = downloadToTempFile(jobId, photo, md5);
+
+    try {
+      String md5Hex = toHexString(md5.digest());
+      long fileSize = tempFile.length();
+      String contentDate = Optional.ofNullable(photo.getUploadedTime())
+          .map(d -> d.toInstant().toString())
+          .orElse(Instant.now().toString());
+      boolean isFavorite = Optional.ofNullable(photo.getFavoriteInfo())
+          .map(FavoriteInfo::getFavorited)
+          .orElse(false);
+
+      AmazonPhotosNode uploadedNode = client.uploadPhoto(
+          photo.getTitle(), tempFile, md5Hex,
+          fileSize, contentDate, isFavorite, targetAlbumId);
+
+      return uploadedNode.getId();
+
+    } catch (IOException e) {
+      if (e.getMessage() != null && e.getMessage().contains("DuplicatesConflictError")) {
+        monitor.info(() -> "Duplicate photo skipped: " + photo.getTitle());
+        return photo.getDataId();
+      }
+      if (isStorageQuotaExceeded(e)) {
+        throw new DestinationMemoryFullException("Amazon Photos storage full", e);
+      }
+      throw e;
+    } finally {
+      tempFile.delete();
+      if (photo.isInTempStore()) {
+        dataStore.removeData(jobId, photo.getFetchableUrl());
+      }
+    }
+  }
+
+  private String resolveTargetAlbumId(PhotoModel photo, IdempotentImportExecutor executor)
+      throws Exception {
+    if (photo.getAlbumId() != null && executor.isKeyCached(photo.getAlbumId())) {
+      return executor.getCachedValue(photo.getAlbumId());
+    }
+    return null;
+  }
+
+  private void initializeClient(TokensAndUrlAuthData authData) throws IOException {
+    if (client == null) {
+      client = new AmazonPhotosClient(
+          new okhttp3.OkHttpClient.Builder().build(),
+          authData.getAccessToken(), authData.getRefreshToken(), clientId, clientSecret);
+      client.resolveEndpoints();
+    }
+  }
+
+  private File downloadToTempFile(UUID jobId, PhotoModel photo, MessageDigest md5)
+      throws IOException {
+    String prefix = photo.getDataId().replaceAll("[/\\\\]", "_");
+    try (InputStream raw = connectionProvider.getInputStreamForItem(jobId, photo).getStream();
+         DigestInputStream dis = new DigestInputStream(raw, md5)) {
+      return dataStore.getTempFileFromInputStream(dis, prefix, ".tmp");
+    }
+  }
+
+  private static MessageDigest newMd5Digest() {
+    try {
+      return MessageDigest.getInstance("MD5");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("MD5 algorithm not available", e);
+    }
+  }
+
+  private static String toHexString(byte[] bytes) {
+    StringBuilder hex = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      hex.append(String.format("%02x", b));
+    }
+    return hex.toString();
+  }
+
+  private static boolean isStorageQuotaExceeded(IOException e) {
+    String message = e.getMessage();
+    return message != null && message.contains("InsufficientStorage");
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosInterface.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosInterface.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
+
+import java.io.File;
+import java.io.IOException;
+
+/** Interface for Amazon Photos API operations used during data transfer. */
+public interface AmazonPhotosInterface {
+
+  /**
+   * Resolves regional API endpoints. Must be called before any other method.
+   *
+   * @throws IOException if the endpoint API is unreachable or returns an error
+   */
+  void resolveEndpoints() throws IOException;
+
+  /**
+   * Creates an album in Amazon Photos.
+   *
+   * @param name album name
+   * @return the created node with id and name
+   * @throws IOException on API errors (4xx/5xx)
+   */
+  AmazonPhotosNode createAlbum(String name) throws IOException;
+
+  /**
+   * Uploads a photo to Amazon Photos using the multiform upload API.
+   * If albumId is provided, the photo is linked to the album atomically.
+   *
+   * @param fileName the photo filename
+   * @param fileContent raw file bytes
+   * @param md5Hex hex-encoded MD5 of the file content
+   * @param fileSize size in bytes
+   * @param contentDate fallback content date (ISO 8601) if EXIF is unavailable
+   * @param isFavorite whether to mark the photo as favorite
+   * @param albumId album to link the photo to, or null for no album
+   * @return the created node with id and name
+   * @throws IOException on API errors (4xx/5xx)
+   */
+  AmazonPhotosNode uploadPhoto(String fileName, File fileContent,
+                               String md5Hex, long fileSize, String contentDate,
+                               boolean isFavorite, String albumId) throws IOException;
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosTransmogrificationConfig.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosTransmogrificationConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import org.datatransferproject.types.common.models.TransmogrificationConfig;
+
+/** Transmogrification config for Amazon Photos imports. */
+public class AmazonPhotosTransmogrificationConfig extends TransmogrificationConfig {
+
+  private static final int MAX_ALBUM_NAME_LENGTH = 200;
+  private static final int MAX_PHOTO_TITLE_LENGTH = 200;
+
+  @Override
+  public int getAlbumNameMaxLength() {
+    return MAX_ALBUM_NAME_LENGTH;
+  }
+
+  @Override
+  public int getPhotoTitleMaxLength() {
+    return MAX_PHOTO_TITLE_LENGTH;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/AmazonPhotosNode.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/AmazonPhotosNode.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Represents an entity in Amazon Photos (e.g., Image, Video, Album). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AmazonPhotosNode {
+
+  @JsonProperty("id")
+  private String id;
+
+  @JsonProperty("name")
+  private String name;
+
+  public String getId() { return id; }
+  public String getName() { return name; }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/CreateNodeRequest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/CreateNodeRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Request body for node creation API (POST /nodes). */
+public class CreateNodeRequest {
+
+  @JsonProperty("name")
+  private final String name;
+
+  @JsonProperty("kind")
+  private final String kind;
+
+  public CreateNodeRequest(String name, String kind) {
+    this.name = name;
+    this.kind = kind;
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/EndpointResponse.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/java/org/datatransferproject/transfer/amazon/photos/model/EndpointResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Response model for GET /account/endpoint. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EndpointResponse {
+
+  @JsonProperty("metadataUrl")
+  private String metadataUrl;
+
+  @JsonProperty("contentUrl")
+  private String contentUrl;
+
+  @JsonProperty("uploadServiceUrl")
+  private String uploadServiceUrl;
+
+  public String getMetadataUrl() { return metadataUrl; }
+  public String getContentUrl() { return contentUrl; }
+  public String getUploadServiceUrl() { return uploadServiceUrl; }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/main/resources/META-INF/services/org.datatransferproject.spi.transfer.extension.TransferExtension
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/main/resources/META-INF/services/org.datatransferproject.spi.transfer.extension.TransferExtension
@@ -1,0 +1,1 @@
+org.datatransferproject.transfer.amazon.AmazonTransferExtension

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosClientTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosClientTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class AmazonPhotosClientTest {
+
+  private MockWebServer server;
+  private AmazonPhotosClient client;
+  private File tempFile;
+
+  private static final String ACCESS_TOKEN = "test-access-token";
+  private static final String REFRESH_TOKEN = "test-refresh-token";
+  private static final String CLIENT_ID = "test-client-id";
+  private static final String CLIENT_SECRET = "test-client-secret";
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = new MockWebServer();
+    server.start();
+
+    // Interceptor routes all requests to MockWebServer regardless of original host
+    OkHttpClient httpClient = new OkHttpClient.Builder()
+        .addInterceptor(chain -> {
+          okhttp3.HttpUrl originalUrl = chain.request().url();
+          okhttp3.HttpUrl newUrl = originalUrl.newBuilder()
+              .scheme("http")
+              .host(server.getHostName())
+              .port(server.getPort())
+              .build();
+          return chain.proceed(chain.request().newBuilder().url(newUrl).build());
+        })
+        .build();
+
+    client = new AmazonPhotosClient(httpClient, ACCESS_TOKEN, REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET);
+
+    // resolveEndpoints call
+    enqueueEndpointResponse();
+    client.resolveEndpoints();
+
+    tempFile = File.createTempFile("test", ".jpg");
+    tempFile.deleteOnExit();
+    Files.write(tempFile.toPath(), new byte[]{1, 2, 3});
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    server.shutdown();
+  }
+
+  @Test
+  void resolveEndpoints_sendsAuthHeader() throws Exception {
+    RecordedRequest request = server.takeRequest();
+    assertEquals("GET", request.getMethod());
+    assertEquals(ACCESS_TOKEN, request.getHeader("x-amz-access-token"));
+    assertTrue(request.getPath().contains("/drive/v1/account/endpoint"));
+  }
+
+  @Test
+  void createAlbum_sendsCorrectRequest() throws Exception {
+    server.takeRequest(); // endpoint
+
+    server.enqueue(new MockResponse()
+        .setBody("{\"id\":\"node123\",\"name\":\"My Album\",\"kind\":\"VISUAL_COLLECTION\"}"));
+
+    AmazonPhotosNode node = client.createAlbum("My Album");
+
+    assertEquals("node123", node.getId());
+    assertEquals("My Album", node.getName());
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals("POST", request.getMethod());
+    assertTrue(request.getPath().contains("resourceVersion=V2"));
+    assertFalse(request.getPath().contains("//"));
+    String body = request.getBody().readUtf8();
+    assertTrue(body.contains("\"name\":\"My Album\""));
+    assertTrue(body.contains("\"kind\":\"VISUAL_COLLECTION\""));
+    assertFalse(body.contains("parents"));
+  }
+
+  @Test
+  void createAlbum_withDifferentName() throws Exception {
+    server.takeRequest();
+
+    server.enqueue(new MockResponse()
+        .setBody("{\"id\":\"album2\",\"name\":\"Vacation\",\"kind\":\"VISUAL_COLLECTION\"}"));
+
+    AmazonPhotosNode node = client.createAlbum("Vacation");
+
+    assertEquals("album2", node.getId());
+
+    RecordedRequest request = server.takeRequest();
+    String body = request.getBody().readUtf8();
+    assertTrue(body.contains("\"kind\":\"VISUAL_COLLECTION\""));
+    assertTrue(body.contains("\"name\":\"Vacation\""));
+    assertFalse(body.contains("parents"));
+  }
+
+  @Test
+  void uploadPhoto_sendsContentAndHeaders() throws Exception {
+    server.takeRequest();
+
+    server.enqueue(new MockResponse()
+        .setBody("{\"id\":\"photo1\",\"name\":\"test.jpg\",\"kind\":\"FILE\"}"));
+
+    AmazonPhotosNode node = client.uploadPhoto(
+        "test.jpg", tempFile, "md5hex", tempFile.length(),
+        "2024-01-15T10:00:00Z", false, null);
+
+    assertEquals("photo1", node.getId());
+
+    RecordedRequest request = server.takeRequest();
+    assertEquals("POST", request.getMethod());
+    assertTrue(request.getPath().contains("name=test.jpg"));
+    assertTrue(request.getPath().contains("kind=FILE"));
+    assertTrue(request.getPath().contains("conflictResolution=RENAME"));
+    assertFalse(request.getPath().contains("visualCollectionParentNodeId"));
+    assertEquals("md5hex", request.getHeader("x-amzn-file-md5"));
+  }
+
+  @Test
+  void uploadPhoto_includesParentNodeId() throws Exception {
+    server.takeRequest();
+
+    server.enqueue(new MockResponse()
+        .setBody("{\"id\":\"p1\",\"name\":\"pic.png\",\"kind\":\"FILE\"}"));
+
+    client.uploadPhoto("pic.png", tempFile, "md5", 1, null, false, "album1");
+
+    RecordedRequest request = server.takeRequest();
+    assertTrue(request.getPath().contains("visualCollectionParentNodeId=album1"));
+  }
+
+  @Test
+  void uploadPhoto_includesFavoriteSetting() throws Exception {
+    server.takeRequest();
+
+    server.enqueue(new MockResponse()
+        .setBody("{\"id\":\"f1\",\"name\":\"fav.jpg\",\"kind\":\"FILE\"}"));
+
+    client.uploadPhoto("fav.jpg", tempFile, "md5", 1, null, true, null);
+
+    RecordedRequest request = server.takeRequest();
+    assertTrue(request.getPath().contains("isFavorite=true"));
+  }
+
+  @Test
+  void tokenRefresh_retriesOnUnauthorized() throws Exception {
+    server.takeRequest(); // endpoint
+
+    server.enqueue(new MockResponse().setResponseCode(401));
+    server.enqueue(new MockResponse()
+        .setBody("{\"access_token\":\"new-token\",\"token_type\":\"bearer\"}"));
+    server.enqueue(new MockResponse().setBody("{\"id\":\"x\",\"name\":\"test\"}"));
+
+    client.createAlbum("test");
+
+    server.takeRequest(); // 401
+    server.takeRequest(); // token refresh
+    RecordedRequest retryRequest = server.takeRequest();
+    assertEquals("new-token", retryRequest.getHeader("x-amz-access-token"));
+  }
+
+  @Test
+  void serverError_throwsIOException() throws Exception {
+    server.takeRequest();
+
+    server.enqueue(new MockResponse().setResponseCode(500).setBody("{\"message\":\"ISE\"}"));
+
+    IOException ex = assertThrows(IOException.class,
+        () -> client.createAlbum("test"));
+
+    assertTrue(ex.getMessage().contains("500"));
+  }
+
+  @Test
+  void uploadPhoto_duplicateReturnsIOExceptionWith409() throws Exception {
+    server.takeRequest();
+
+    server.enqueue(new MockResponse().setResponseCode(409).setBody(
+        "{\"errorCode\":\"DuplicatesConflictError\",\"errorDetails\":{\"conflictNodeIds\":[\"existingId\"]}}"));
+
+    IOException ex = assertThrows(IOException.class,
+        () -> client.uploadPhoto("dup.jpg", tempFile, "md5", 1, null, false, "album1"));
+
+    assertTrue(ex.getMessage().contains("409"));
+    assertTrue(ex.getMessage().contains("DuplicatesConflictError"));
+  }
+
+  @Test
+  void resolveEndpoints_throwsOnFailure() throws Exception {
+    OkHttpClient httpClient = new OkHttpClient.Builder()
+        .addInterceptor(chain -> {
+          okhttp3.HttpUrl newUrl = chain.request().url().newBuilder()
+              .scheme("http").host(server.getHostName()).port(server.getPort()).build();
+          return chain.proceed(chain.request().newBuilder().url(newUrl).build());
+        })
+        .build();
+
+    AmazonPhotosClient freshClient = new AmazonPhotosClient(
+        httpClient, ACCESS_TOKEN, REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET);
+
+    server.takeRequest(); // consume the setUp endpoint request
+
+    server.enqueue(new MockResponse().setResponseCode(403).setBody("{\"message\":\"Not Registered\"}"));
+    server.enqueue(new MockResponse().setBody("{\"access_token\":\"t\"}"));
+    server.enqueue(new MockResponse().setResponseCode(403).setBody("{\"message\":\"Not Registered\"}"));
+
+    IOException ex = assertThrows(IOException.class, freshClient::resolveEndpoints);
+    assertTrue(ex.getMessage().contains("403"));
+  }
+
+  @Test
+  void tokenRefreshFailure_throwsIOException() throws Exception {
+    server.takeRequest();
+
+    server.enqueue(new MockResponse().setResponseCode(401));
+    server.enqueue(new MockResponse().setResponseCode(401).setBody("Unauthorized"));
+
+    IOException ex = assertThrows(IOException.class,
+        () -> client.createAlbum("test"));
+
+    assertTrue(ex.getMessage().contains("Token refresh failed"));
+  }
+
+  @Test
+  void clientError403_throwsIOException() throws Exception {
+    server.takeRequest();
+
+    server.enqueue(new MockResponse().setResponseCode(403).setBody("{\"message\":\"Forbidden\"}"));
+
+    IOException ex = assertThrows(IOException.class,
+        () -> client.createAlbum("test"));
+
+    assertTrue(ex.getMessage().contains("403"));
+  }
+
+  private void enqueueEndpointResponse() {
+    server.enqueue(new MockResponse().setBody(
+        "{\"metadataUrl\":\"https://meta.example.com/v1\","
+            + "\"contentUrl\":\"https://content.example.com\","
+            + "\"uploadServiceUrl\":\"https://upload.example.com/\"}"));
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporterTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/AmazonPhotosImporterTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import org.datatransferproject.api.launcher.Monitor;
+import org.datatransferproject.spi.cloud.storage.TemporaryPerJobDataStore;
+import org.datatransferproject.spi.transfer.idempotentexecutor.IdempotentImportExecutor;
+import org.datatransferproject.spi.transfer.provider.ImportResult;
+import org.datatransferproject.types.common.models.photos.PhotoAlbum;
+import org.datatransferproject.types.common.models.photos.PhotoModel;
+import org.datatransferproject.types.common.models.photos.PhotosContainerResource;
+import org.datatransferproject.types.transfer.auth.TokensAndUrlAuthData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+public class AmazonPhotosImporterTest {
+
+  @Mock private Monitor monitor;
+  @Mock private TemporaryPerJobDataStore dataStore;
+  @Mock private IdempotentImportExecutor executor;
+  @Mock private AmazonPhotosInterface client;
+
+  private TokensAndUrlAuthData authData;
+  private AmazonPhotosImporter importer;
+  private UUID jobId;
+
+  @BeforeEach
+  void setUp() {
+    authData = new TokensAndUrlAuthData("access", "refresh", "http://token-url");
+    importer = new AmazonPhotosImporter(monitor, dataStore, client);
+    jobId = UUID.randomUUID();
+  }
+
+  @Test
+  void importItem_createsAlbums() throws Exception {
+    PhotoAlbum album = new PhotoAlbum("a1", "Vacation", null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.singletonList(album), Collections.emptyList());
+
+    ImportResult result = importer.importItem(jobId, executor, authData, resource);
+
+    assertEquals(ImportResult.OK, result);
+    verify(executor).executeAndSwallowIOExceptions(eq("a1"), eq("Vacation"), any());
+  }
+
+  @Test
+  void importItem_registersPhotosWithExecutor() throws Exception {
+    PhotoAlbum album = new PhotoAlbum("a1", "Album", null);
+    PhotoModel photo1 = new PhotoModel("pic1.jpg", "http://example.com/1.jpg",
+        null, "image/jpeg", "p1", "a1", false);
+    PhotoModel photo2 = new PhotoModel("pic2.jpg", "http://example.com/2.jpg",
+        null, "image/jpeg", "p2", "a1", false);
+
+    PhotosContainerResource resource = new PhotosContainerResource(
+        ImmutableList.of(album), ImmutableList.of(photo1, photo2));
+
+    ImportResult result = importer.importItem(jobId, executor, authData, resource);
+
+    assertEquals(ImportResult.OK, result);
+    // Verify album + 2 photos registered with executor
+    verify(executor, times(3)).executeAndSwallowIOExceptions(any(), any(), any());
+  }
+
+  @Test
+  void importItem_emptyResource() throws Exception {
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.emptyList());
+
+    ImportResult result = importer.importItem(jobId, executor, authData, resource);
+
+    assertEquals(ImportResult.OK, result);
+    verify(executor, never()).executeAndSwallowIOExceptions(any(), any(), any());
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void importItem_usesAlbumIdAsExecutorKey() throws Exception {
+    PhotoAlbum album = new PhotoAlbum("google-album-id", "My Album", null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.singletonList(album), Collections.emptyList());
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    verify(executor).executeAndSwallowIOExceptions(eq("google-album-id"), eq("My Album"), any());
+  }
+
+  @Test
+  void importItem_usesIdempotentIdForPhotos() throws Exception {
+    PhotoModel photo = new PhotoModel("pic.jpg", "http://example.com/pic.jpg",
+        null, "image/jpeg", "photo-data-id", "a1", false);
+
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    verify(executor).executeAndSwallowIOExceptions(
+        eq(photo.getIdempotentId()), eq("pic.jpg"), any());
+  }
+
+  // Verifies that path separators in photo titles do not affect filesystem operations.
+  // The importer uses dataId (not title) as the temp-file prefix, so hostile titles
+  // cannot cause path traversal. This test confirms the title is passed as-is to the
+  // executor while the safe dataId is used for file operations.
+  @Test
+  void importItem_hostileTitleUsesDataIdForFileSystem() throws Exception {
+    PhotoModel photo = new PhotoModel("../../etc/passwd", "tempkey",
+        null, "image/jpeg", "safe-data-id", "a1", true, (Date) null);
+
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    InputStream fakeStream = new java.io.ByteArrayInputStream(new byte[]{1, 2, 3});
+    when(dataStore.getStream(any(), eq("tempkey")))
+        .thenReturn(new TemporaryPerJobDataStore.InputStreamWrapper(fakeStream));
+    File tempFile = File.createTempFile("test", ".tmp");
+    tempFile.deleteOnExit();
+    when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(tempFile);
+    when(executor.executeAndSwallowIOExceptions(any(), any(), any()))
+        .thenAnswer(invocation -> {
+          java.util.concurrent.Callable<?> callable = invocation.getArgument(2);
+          return callable.call();
+        });
+    when(executor.isKeyCached(any())).thenReturn(false);
+    when(client.uploadPhoto(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenReturn(new org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode());
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    // Title with path separators is passed verbatim to executor (not a filesystem sink)
+    verify(executor).executeAndSwallowIOExceptions(
+        eq(photo.getIdempotentId()), eq("../../etc/passwd"), any());
+
+    // But the temp-file prefix uses dataId, not the title
+    org.mockito.ArgumentCaptor<String> prefixCaptor =
+        org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(dataStore).getTempFileFromInputStream(any(), prefixCaptor.capture(), eq(".tmp"));
+    assertEquals("safe-data-id", prefixCaptor.getValue());
+  }
+
+  @Test
+  void importItem_filenameLongerThan255Chars_registersWithExecutor() throws Exception {
+    String longName = "a".repeat(300) + ".jpg";
+    PhotoModel photo = new PhotoModel(longName, "http://example.com/long.jpg",
+        null, "image/jpeg", "long-id", "a1", false);
+
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    // Title gets truncated to 200 chars by transmogrification
+    String expectedTitle = "a".repeat(200);
+    verify(executor).executeAndSwallowIOExceptions(
+        eq(photo.getIdempotentId()), eq(expectedTitle), any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Path traversal protection tests for dataId.
+  //
+  // The importer builds temp-file prefixes from photo.getDataId() via
+  //   prefix = dataId.replaceAll("[/\\\\]", "_")
+  // These tests inject hostile path values into dataId and assert:
+  //   1. The prefix contains no path separators after sanitization.
+  //   2. Files.createTempFile keeps the file inside java.io.tmpdir.
+  // ---------------------------------------------------------------------------
+
+  private String captureTempPrefixForDataId(String dataId) throws Exception {
+    PhotoModel photo = new PhotoModel("title.jpg", "tempkey",
+        null, "image/jpeg", dataId, "a1", true, (Date) null);
+    PhotosContainerResource resource = new PhotosContainerResource(
+        Collections.emptyList(), Collections.singletonList(photo));
+
+    InputStream fakeStream = new java.io.ByteArrayInputStream(new byte[]{1, 2, 3});
+    when(dataStore.getStream(any(), eq("tempkey")))
+        .thenReturn(new TemporaryPerJobDataStore.InputStreamWrapper(fakeStream));
+    File tempFile = File.createTempFile("test", ".tmp");
+    tempFile.deleteOnExit();
+    when(dataStore.getTempFileFromInputStream(any(), any(), any())).thenReturn(tempFile);
+    when(executor.executeAndSwallowIOExceptions(any(), any(), any()))
+        .thenAnswer(invocation -> {
+          java.util.concurrent.Callable<?> callable = invocation.getArgument(2);
+          return callable.call();
+        });
+    when(executor.isKeyCached(any())).thenReturn(false);
+    when(client.uploadPhoto(any(), any(), any(), any(Long.class), any(), any(Boolean.class), any()))
+        .thenReturn(new org.datatransferproject.transfer.amazon.photos.model.AmazonPhotosNode());
+
+    importer.importItem(jobId, executor, authData, resource);
+
+    org.mockito.ArgumentCaptor<String> prefixCaptor =
+        org.mockito.ArgumentCaptor.forClass(String.class);
+    verify(dataStore).getTempFileFromInputStream(any(), prefixCaptor.capture(), eq(".tmp"));
+    return prefixCaptor.getValue();
+  }
+
+  /** The sanitized prefix must never re-introduce a path separator and must stay in tmpdir. */
+  private void assertPrefixIsContained(String prefix) throws Exception {
+    assertFalse(prefix.contains("/"), "Prefix should not contain forward slash: " + prefix);
+    assertFalse(prefix.contains("\\"), "Prefix should not contain backslash: " + prefix);
+    // Containment: the real JDK sink must accept the prefix AND keep the file
+    // inside java.io.tmpdir. createTempFile prepends the prefix to a random name,
+    // so the created file's parent must be exactly the temp directory.
+    File created = File.createTempFile(prefix, ".tmp");
+    created.deleteOnExit();
+    File tmpDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
+    assertEquals(tmpDir, created.getCanonicalFile().getParentFile(),
+        "Temp file escaped the temp directory: " + created.getCanonicalPath());
+  }
+
+  @Test
+  void downloadToTempFile_forwardSlashTraversalInDataId_isContained() throws Exception {
+    assertPrefixIsContained(captureTempPrefixForDataId("../../../../etc/passwd"));
+  }
+
+  @Test
+  void downloadToTempFile_backslashTraversalInDataId_isContained() throws Exception {
+    assertPrefixIsContained(captureTempPrefixForDataId("..\\..\\..\\windows\\system32"));
+  }
+
+  @Test
+  void downloadToTempFile_absolutePathInDataId_isContained() throws Exception {
+    assertPrefixIsContained(captureTempPrefixForDataId("/etc/cron.d/evil"));
+  }
+
+  @Test
+  void downloadToTempFile_mixedSeparatorTraversalInDataId_isContained() throws Exception {
+    assertPrefixIsContained(captureTempPrefixForDataId("..\\/..\\/secret"));
+  }
+
+  @Test
+  void downloadToTempFile_urlEncodedSeparatorInDataId_isContained() throws Exception {
+    // The regex strips literal separators only; %2F is NOT decoded by the JDK sink,
+    // so it is harmless here -- this test documents/locks that behavior.
+    assertPrefixIsContained(captureTempPrefixForDataId("..%2F..%2Fetc%2Fpasswd"));
+  }
+
+  @Test
+  void downloadToTempFile_dotSegmentsWithoutSeparatorInDataId_isContained() throws Exception {
+    assertPrefixIsContained(captureTempPrefixForDataId("....etc....passwd"));
+  }
+}

--- a/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/model/ModelDeserializationTest.java
+++ b/extensions/data-transfer/portability-data-transfer-amazon/src/test/java/org/datatransferproject/transfer/amazon/photos/model/ModelDeserializationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Data Transfer Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.datatransferproject.transfer.amazon.photos.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ModelDeserializationTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  void amazonPhotosNode_deserializesIdAndName() throws Exception {
+    String json = "{\"id\":\"nodeId1\",\"name\":\"photo.jpg\",\"kind\":\"FILE\","
+        + "\"description\":\"A photo\"}";
+
+    AmazonPhotosNode node = objectMapper.readValue(json, AmazonPhotosNode.class);
+
+    assertEquals("nodeId1", node.getId());
+    assertEquals("photo.jpg", node.getName());
+  }
+
+  @Test
+  void amazonPhotosNode_ignoresUnknownFields() throws Exception {
+    String json = "{\"id\":\"n1\",\"name\":\"test\",\"kind\":\"FOLDER\","
+        + "\"unknownField\":\"value\",\"anotherUnknown\":123}";
+
+    AmazonPhotosNode node = objectMapper.readValue(json, AmazonPhotosNode.class);
+
+    assertEquals("n1", node.getId());
+    assertEquals("test", node.getName());
+  }
+
+  @Test
+  void endpointResponse_deserializesAllFields() throws Exception {
+    String json = "{\"metadataUrl\":\"https://meta.example.com/v1/\","
+        + "\"contentUrl\":\"https://content.example.com/\","
+        + "\"uploadServiceUrl\":\"https://upload.example.com/\"}";
+
+    EndpointResponse response = objectMapper.readValue(json, EndpointResponse.class);
+
+    assertEquals("https://meta.example.com/v1/", response.getMetadataUrl());
+    assertEquals("https://content.example.com/", response.getContentUrl());
+    assertEquals("https://upload.example.com/", response.getUploadServiceUrl());
+  }
+
+  @Test
+  void endpointResponse_handlesNullUploadServiceUrl() throws Exception {
+    String json = "{\"metadataUrl\":\"https://meta.example.com/\","
+        + "\"contentUrl\":\"https://content.example.com/\"}";
+
+    EndpointResponse response = objectMapper.readValue(json, EndpointResponse.class);
+
+    assertNull(response.getUploadServiceUrl());
+  }
+
+  @Test
+  void createNodeRequest_serializesCorrectly() throws Exception {
+    CreateNodeRequest request = new CreateNodeRequest("My Album", "VISUAL_COLLECTION");
+
+    String json = objectMapper.writeValueAsString(request);
+
+    assertTrue(json.contains("\"name\":\"My Album\""));
+    assertTrue(json.contains("\"kind\":\"VISUAL_COLLECTION\""));
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,9 @@ include ':extensions:security:portability-security-cleartext', ':extensions:secu
 include ':extensions:copier:portability-stack-copier'
 
 // Service Integrations - Auth and Transfer Extensions
+// Amazon
+include ':extensions:auth:portability-auth-amazon'
+include ':extensions:data-transfer:portability-data-transfer-amazon'
 // Apple
 include ':extensions:auth:portability-auth-apple'
 include ':extensions:data-transfer:portability-data-transfer-apple'


### PR DESCRIPTION
Add support for transferring photos into Amazon Photos.

This PR includes:
- Amazon Photos auth extension (OAuth2 via Login with Amazon)
- Amazon Photos importer (albums and photos)
- Amazon Photos API client with token refresh and endpoint resolution
- Unit tests for client, importer, and models