### PR TITLE
chore: shrink datatransferproject/dev image and fix bundled Gradle mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,29 @@
 # Runs the Java/Gradle build and test suite with no local JDK install.
 #
 # Source is bind-mounted at `docker run` time -- this image is not rebuilt
-# per code change. Gradle 6.9.2 (pulled by the wrapper regardless of this
-# image's bundled Gradle version) can't parse Java 17 bytecode when
-# compiling build.gradle/settings.gradle, so the JDK here is pinned to 11.
+# per code change. build.gradle uses the legacy `maven` plugin, removed in
+# Gradle 7+, so the build only works under the wrapper-pinned Gradle 6.9.2
+# (see gradle/wrapper/gradle-wrapper.properties) -- not whatever `gradle`
+# version a base image happens to bundle. The JDK here is pinned to 11
+# because that 6.9.2/Groovy-DSL combo can't parse newer bytecode when
+# compiling build.gradle/settings.gradle.
 #
-# The gradle:* image's default GRADLE_USER_HOME is /home/gradle/.gradle --
-# mount a named volume there to cache resolved dependencies across runs:
+# The wrapper distribution is resolved and cached into an image layer at
+# build time (`./gradlew --version` below) rather than left to download on
+# first `docker run` -- same version pin, but the image is self-contained
+# and works offline. GRADLE_USER_HOME matches the default the gradle:*
+# image used, so existing gradle-cache volumes from that image still work.
 #
 #   docker build -t datatransferproject/dev .
 #   docker run --rm -v "$PWD":/workspace -v gradle-cache:/home/gradle/.gradle datatransferproject/dev
-FROM gradle:8.10.2-jdk11
+FROM eclipse-temurin:11-jdk-jammy
 
+ENV GRADLE_USER_HOME=/home/gradle/.gradle
 WORKDIR /workspace
+
+COPY gradlew gradlew
+COPY gradle/wrapper gradle/wrapper
+RUN ./gradlew --version --no-daemon
 
 ENTRYPOINT ["./gradlew"]
 CMD ["--no-daemon", "check"]


### PR DESCRIPTION
## Summary
- The `datatransferproject/dev` image bundled Gradle 8.10.2, which is never invoked (the entrypoint is `./gradlew`, wrapper-pinned to 6.9.2) and can't even build this project -- `build.gradle` uses the legacy `maven` plugin, removed in Gradle 7+.
- Base image swapped to `eclipse-temurin:11-jdk-jammy`, with the wrapper-pinned Gradle 6.9.2 resolved and cached into an image layer at `docker build` time, rather than downloaded on first `docker run`.
- **708MB -> 631MB (11% smaller)**, while fixing a latent version mismatch and remaining fully offline-capable after build.

## Notable decisions / tradeoffs

- **Why temurin and not just a smaller `gradle:*` tag:** the project's build only works under Gradle 6.9.2 (wrapper-pinned). No official `gradle:6.9.2-*` variant is smaller than the current image anyway (727MB) -- baking the *correct* wrapper distribution onto a bare JDK base beats bundling a whole (and in this case wrong) Gradle install.
- **Why `eclipse-temurin` is not a new trust surface:** confirmed via matching `JAVA_HOME`, layer signatures, and entrypoint script fingerprint that `gradle:8.10.2-jdk11` was already built on Temurin -- this just removes a layer of indirection around the same JDK.
- **Prewarming vs. leaving the wrapper to download at `docker run`:** resolving at build time keeps the image self-contained/offline-capable and still respects `gradle-wrapper.properties` as the single source of truth -- no version hardcoded a second time, so Docker's build cache naturally invalidates and re-fetches if the wrapper version changes.
- **`GRADLE_USER_HOME`/volume path unchanged:** still `/home/gradle/.gradle`, so `docker-compose.yml` and any already-warmed `gradle-cache` volumes keep working untouched.

## Test plan
- [x] `docker build` succeeds
- [x] `./gradlew --version` resolves offline (`--network none`) against a fresh named volume
- [x] `./gradlew tasks` succeeds end-to-end with network available
- [x] Image size confirmed via `docker images`: 708MB -> 631MB