### PR TITLE
feat(amazon-photos): Update OAuth scopes to amazonphotos namespace

### DIFF
--- a/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonOAuthConfig.java
+++ b/extensions/auth/portability-auth-amazon/src/main/java/org/datatransferproject/auth/amazon/AmazonOAuthConfig.java
@@ -33,23 +33,19 @@ public class AmazonOAuthConfig implements OAuth2Config {
 
   @Override
   public Map<DataVertical, Set<String>> getImportScopes() {
-    return ImmutableMap.<DataVertical, Set<String>>builder()
-        .put(PHOTOS, ImmutableSet.of(
-            "photos::images:create",
-            "photos::albums:create",
-            "photos::albums:update"))
-        .put(VIDEOS, ImmutableSet.of(
-            "photos::videos:create",
-            "photos::albums:create",
-            "photos::albums:update"))
-        .build();
+    return ImmutableMap.of(
+        PHOTOS, ImmutableSet.of(
+            "amazonphotos::images:create",
+            "amazonphotos::albums:create",
+            "amazonphotos::albums:update"),
+        VIDEOS, ImmutableSet.of(
+            "amazonphotos::videos:create",
+            "amazonphotos::albums:create",
+            "amazonphotos::albums:update"));
   }
 
   @Override
   public Map<DataVertical, Set<String>> getExportScopes() {
-    return ImmutableMap.<DataVertical, Set<String>>builder()
-        .put(PHOTOS, ImmutableSet.of("photos::images:read", "photos::albums:read"))
-        .put(VIDEOS, ImmutableSet.of("photos::videos:read", "photos::albums:read"))
-        .build();
+    return ImmutableMap.of();
   }
 }

--- a/extensions/auth/portability-auth-amazon/src/test/java/org/datatransferproject/auth/amazon/AmazonOAuthConfigTest.java
+++ b/extensions/auth/portability-auth-amazon/src/test/java/org/datatransferproject/auth/amazon/AmazonOAuthConfigTest.java
@@ -35,29 +35,22 @@ class AmazonOAuthConfigTest {
   void importScopesForPhotos() {
     assertThat(config.getImportScopes().get(PHOTOS))
         .containsExactly(
-            "photos::images:create",
-            "photos::albums:create",
-            "photos::albums:update");
+            "amazonphotos::images:create",
+            "amazonphotos::albums:create",
+            "amazonphotos::albums:update");
   }
 
   @Test
   void importScopesForVideos() {
     assertThat(config.getImportScopes().get(VIDEOS))
         .containsExactly(
-            "photos::videos:create",
-            "photos::albums:create",
-            "photos::albums:update");
+            "amazonphotos::videos:create",
+            "amazonphotos::albums:create",
+            "amazonphotos::albums:update");
   }
 
   @Test
-  void exportScopesForPhotos() {
-    assertThat(config.getExportScopes().get(PHOTOS))
-        .containsExactly("photos::images:read", "photos::albums:read");
-  }
-
-  @Test
-  void exportScopesForVideos() {
-    assertThat(config.getExportScopes().get(VIDEOS))
-        .containsExactly("photos::videos:read", "photos::albums:read");
+  void exportScopesEmpty() {
+    assertThat(config.getExportScopes()).isEmpty();
   }
 }


### PR DESCRIPTION
Summary
  
Updates the Amazon Photos auth extension (AmazonOAuthConfig) to use the correct amazonphotos:: OAuth scope namespace and removes export scopes, which are not used by this import only integration.
  
Changes
  
- Migrate all import scopes from the photos:: prefix to the amazonphotos:: prefix (images, videos, albums).
- Return an empty map from getExportScopes() — Amazon Photos supports import only, so no export scopes are requested.
- Update AmazonOAuthConfigTest to match: assert the new amazonphotos:: import scopes and replace the two export-scope tests with a single exportScopesEmpty test.